### PR TITLE
Fix to link to lnl-genl-3 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 
 ifeq ($(NL3FOUND),Y)
 CFLAGS += -DCONFIG_LIBNL20
-LIBS += -lnl-genl
+LIBS += -lnl-genl-3
 NLLIBNAME = libnl-3.0
 endif
 


### PR DESCRIPTION
Powertop fails to compile on my 3.2.6-2-ARCH kernel -- a recent update to libnl changed the library name to lnl-genl-3.  This pull request fixes the bug, though it's probably not correctly backwards compatible.

Works for me :)

https://aur.archlinux.org/packages.php?ID=48935
