### PR TITLE
Fix undefined references when using libnl-3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,7 @@ PKG_CHECK_MODULES([LIBZ], [zlib],[],[
 
 has_libnl_ver=0
 PKG_CHECK_MODULES([LIBNL], [libnl-1], [has_libnl_ver=1], [
-	AC_SEARCH_LIBS([nl_socket_alloc], [nl], [has_libnl_ver=2], [
+	AC_SEARCH_LIBS([nl_socket_alloc], [libnl-2.0], [has_libnl_ver=2], [
 		     PKG_CHECK_MODULES([LIBNL], [libnl-3.0 libnl-genl-3.0], [has_libnl_ver=3],
 				       [AC_SEARCH_LIBS([nl_socket_alloc], [nl-3 nl-genl-3], [has_libnl_ver=3], [], [])])
 	], [])


### PR DESCRIPTION
When using libnl-3.0 we need to link with libnl-genl also, if not, we
get a lot of undefined symbols.

It was because the AC_CHECK_LIB was finding nl_socket_alloc on libnl, but the genl_\* functions can only be found on libnl-genl.

BTW, great job.
