### PR TITLE
Add the ability to specify greater or equal constraints on sysfs tunable

### DIFF
--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -59,7 +59,7 @@ static void init_tuning(void)
 	add_sysfs_tunable(_("Enable Audio codec power management"), "/sys/module/snd_hda_intel/parameters/power_save", "1");
 	add_sysfs_tunable(_("NMI watchdog should be turned off"), "/proc/sys/kernel/nmi_watchdog", "0");
 	add_sysfs_tunable(_("Power Aware CPU scheduler"), "/sys/devices/system/cpu/sched_mc_power_savings", "1");
-	add_sysfs_tunable(_("VM writeback timeout"), "/proc/sys/vm/dirty_writeback_centisecs", "1500");
+	add_sysfs_tunable(_("VM writeback timeout"), "/proc/sys/vm/dirty_writeback_centisecs", ">=1500");
 	add_sata_tunables();
 	add_usb_tunables();
 	add_runtime_tunables("pci");

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -65,7 +65,19 @@ int sysfs_tunable::good_bad(void)
 	if (c)
 		*c = 0;
 
-	if (strcmp(current_value, target_value) == 0)
+	if (strncmp(">=", target_value, 2) == 0) {
+		char *endptr;
+		int expected, current;
+
+		expected = strtol(target_value + 2, &endptr, 10);
+		if (*endptr != '\0')
+			return TUNE_NEUTRAL;
+		current = strtol(current_value, &endptr, 10);
+		if (*endptr != '\0')
+			return TUNE_NEUTRAL;
+		if (current >= expected)
+			return TUNE_GOOD;
+	} else if (strcmp(current_value, target_value) == 0)
 		return TUNE_GOOD;
 
 	strcpy(bad_value, current_value);

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -95,7 +95,11 @@ void sysfs_tunable::toggle(void)
 		return;
 	}
 
-	write_sysfs(sysfs_path, target_value);
+	if (strncmp(target_value, ">=", 2) == 0) {
+		write_sysfs(sysfs_path, target_value + 2);
+	} else {
+		write_sysfs(sysfs_path, target_value);
+	}
 }
 
 const char *sysfs_tunable::toggle_script(void) {


### PR DESCRIPTION
Set the vm_dirtyback to GOOD if it's greater or equal to 1500 instead of just equal to 1500.

The only constraint accepted is >=, but it could be extended easily to do other operators.