### PR TITLE
use pkg-config to detect proper ncurses flags.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_FUNC_REALLOC
 AC_FUNC_STRTOD
 AC_CHECK_FUNCS([fdatasync getpagesize gettimeofday memmove memset mkdir munmap pow realpath regcomp select setlocale socket sqrt strcasecmp strchr strdup strerror strncasecmp strstr strtoul strtoull])
 
-AC_SEARCH_LIBS([delwin], [ncursesw ncurses], [], AC_MSG_ERROR([ncurses is required but was not found]), [])
+PKG_CHECK_MODULES(ncurses, ncurses, [LIBS="$LIBS $ncurses_LIBS"], AC_MSG_ERROR([ncurses is required but was not found]))
 
 has_libpci=0
 PKG_CHECK_MODULES([PCIUTILS], [libpci],[has_libpci=1],[


### PR DESCRIPTION
Full details at https://bugs.gentoo.org/show_bug.cgi?id=486124 and https://bugs.gentoo.org/show_bug.cgi?id=457530

In gentoo, tinfo is an optional part of ncurses and that causes an issue when pkg-config is not used to detect the proper flags to use ncurses support.  Patch written by Jeroen Roovers.