### PR TITLE
main: add missing space in --version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,7 @@ static const struct option long_options[] =
 
 static void print_version()
 {
-	printf(_("PowerTOP version" POWERTOP_VERSION ", compiled on " __DATE__ "\n"));
+	printf(_("PowerTOP version " POWERTOP_VERSION ", compiled on " __DATE__ "\n"));
 }
 
 static bool set_refresh_timeout()


### PR DESCRIPTION
Previously --version output looked like this:
```
PowerTOP versionv2.6.1, compiled on Aug 15 2014
               ^^^ missing space
```
