### PR TITLE
Remove tailing backslash from LOCAL_SHARED_LIBRARIES in Android.mk

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -5,7 +5,7 @@ LOCAL_MODULE_TAGS := debug
 LOCAL_SHARED_LIBRARIES := libstlport \
 			  libnl \
 			  libpci \
-			  libtraceevnet \
+			  libtraceevnet
 LOCAL_MODULE := powertop  
 
 #LOCAL_CFLAGS += -Wall -O2 -g -fno-omit-frame-pointer -fstack-protector -Wshadow -Wformat -D_FORTIFY_SOURCE=2


### PR DESCRIPTION
tailing \ (backslash) caused LOCAL_MODULE... to be appended to LOCAL_SHARED_LIBRARIES which causes build errors