### PR TITLE
Indicate that the <tab> key is to use to navigate in the application

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -127,7 +127,7 @@ void show_tab(unsigned int tab)
 	if (c && strlen(c) > 0)
 		mvwprintw(bottom_line, 0,0, c);
 	else
-		mvwprintw(bottom_line, 0,0,"<ESC> %s | ",_("Exit"));
+		mvwprintw(bottom_line, 0,0, _("<ESC> Exit | <TAB> Navigate |"));
 
 
 	current_tab = tab;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -127,7 +127,9 @@ void show_tab(unsigned int tab)
 	if (c && strlen(c) > 0)
 		mvwprintw(bottom_line, 0,0, c);
 	else
-		mvwprintw(bottom_line, 0,0, _("<ESC> Exit | <TAB> / <Shift + TAB> Navigate |"));
+		mvwprintw(bottom_line, 0,0,
+                  "<ESC> %s | <TAB> / <Shift + TAB> %s |",
+                  _("Exit"), _("Navigate")));
 
 
 	current_tab = tab;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -127,7 +127,7 @@ void show_tab(unsigned int tab)
 	if (c && strlen(c) > 0)
 		mvwprintw(bottom_line, 0,0, c);
 	else
-		mvwprintw(bottom_line, 0,0, _("<ESC> Exit | <TAB> Navigate |"));
+		mvwprintw(bottom_line, 0,0, _("<ESC> Exit | <TAB> / <Shift + TAB> Navigate |"));
 
 
 	current_tab = tab;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -129,7 +129,7 @@ void show_tab(unsigned int tab)
 	else
 		mvwprintw(bottom_line, 0,0,
                   "<ESC> %s | <TAB> / <Shift + TAB> %s |",
-                  _("Exit"), _("Navigate")));
+                  _("Exit"), _("Navigate"));
 
 
 	current_tab = tab;


### PR DESCRIPTION
This makes is explicit how to leave or navigate in the program from the front
page. It changes one string for the translators.

Fixes https://bugzilla.redhat.com/1191112