### PR TITLE
Reintroduced -d, --dump option, reports are by default written to STDOUT

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -97,6 +97,8 @@ powertop_SOURCES = \
 	report/report-formatter-base.h \
 	report/report-formatter-csv.cpp \
 	report/report-formatter-csv.h \
+	report/report-formatter-plain.cpp \
+	report/report-formatter-plain.h \
 	report/report-formatter-html.cpp \
 	report/report-formatter-html.h \
 	report/report-formatter.h \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,6 +84,7 @@ static const struct option long_options[] =
 	{"auto-tune",	no_argument,		NULL,		 OPT_AUTO_TUNE},
 	{"calibrate",	no_argument,		NULL,		 'c'},
 	{"csv",		optional_argument,	NULL,		 'C'},
+	{"dump",	optional_argument,	NULL,		 'd'},
 	{"debug",	no_argument,		&debug_learning, OPT_DEBUG},
 	{"extech",	optional_argument,	NULL,		 OPT_EXTECH},
 	{"html",	optional_argument,	NULL,		 'r'},
@@ -121,6 +122,7 @@ static void print_usage()
 	printf("     --auto-tune\t %s\n", _("sets all tunable options to their GOOD setting"));
 	printf(" -c, --calibrate\t %s\n", _("runs powertop in calibration mode"));
 	printf(" -C, --csv%s\t %s\n", _("[=filename]"), _("generate a csv report"));
+	printf(" -d, --dump %s\n", _("generate plain text report"));
 	printf("     --debug\t\t %s\n", _("run in \"debug\" mode"));
 	printf("     --extech%s\t %s\n", _("[=devnode]"), _("uses an Extech Power Analyzer for measurements"));
 	printf(" -r, --html%s\t %s\n", _("[=filename]"), _("generate a html report"));
@@ -403,7 +405,7 @@ int main(int argc, char **argv)
 #endif
 	ui_notify_user = ui_notify_user_ncurses;
 	while (1) { /* parse commandline options */
-		c = getopt_long(argc, argv, "cC:r:i:qt:w:Vh", long_options, &option_index);
+		c = getopt_long(argc, argv, "cC::d::r::i:qt:w:Vh", long_options, &option_index);
 		/* Detect the end of the options. */
 		if (c == -1)
 			break;
@@ -419,12 +421,11 @@ int main(int argc, char **argv)
 			break;
 		case 'C':		/* csv report */
 			reporttype = REPORT_CSV;
-			snprintf(filename, sizeof(filename), "%s", optarg ? optarg : "powertop.csv");
-			if (!strlen(filename))
-			{
-				fprintf(stderr, _("Invalid CSV filename\n"));
-				exit(1);
-			}
+			snprintf(filename, sizeof(filename), "%s", optarg ? optarg : "");
+			break;
+		case 'd':		/* plain text report (dump) */
+			reporttype = REPORT_PLAIN;
+			snprintf(filename, sizeof(filename), "%s", optarg ? optarg : "");
 			break;
 		case OPT_DEBUG:
 			/* implemented using getopt_long(3) flag */
@@ -435,12 +436,7 @@ int main(int argc, char **argv)
 			break;
 		case 'r':		/* html report */
 			reporttype = REPORT_HTML;
-			snprintf(filename, sizeof(filename), "%s", optarg ? optarg : "powertop.html");
-			if (!strlen(filename))
-			{
-				fprintf(stderr, _("Invalid HTML filename\n"));
-				exit(1);
-			}
+			snprintf(filename, sizeof(filename), "%s", optarg ? optarg : "");
 			break;
 		case 'i':
 			iterations = (optarg ? atoi(optarg) : 1);

--- a/src/report/report-formatter-plain.cpp
+++ b/src/report/report-formatter-plain.cpp
@@ -1,0 +1,137 @@
+/* Copyright (c) 2016 Jaroslav Škarvada <jskarvad@redhat.com>
+ * Based on CSV formatter code by Igor Zhbanov <i.zhbanov@samsung.com>
+ *
+ * This file is part of PowerTOP
+ *
+ * This program file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in a file named COPYING; if not, write to the
+ * Free Software Foundation, Inc,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ * or just google for it.
+ */
+
+/* Uncomment to disable asserts */
+/*#define NDEBUG*/
+
+#include <stdio.h>
+#include <assert.h>
+#include <stdarg.h>
+
+#include "report-formatter-plain.h"
+#include "report-data-html.h"
+
+
+/* ************************************************************************ */
+report_formatter_plain::report_formatter_plain()
+{
+	/* Do nothing special  */
+}
+
+/* ************************************************************************ */
+void
+report_formatter_plain::finish_report()
+{
+	/* Do nothing special */
+}
+
+string
+report_formatter_plain::escape_string(const char *str)
+{
+	return string(str);
+}
+
+
+/* Report Style */
+void
+report_formatter_plain::add_header()
+{
+	add_exact("\n");
+}
+
+void
+report_formatter_plain::end_header()
+{
+	/* Do nothing */
+}
+
+void
+report_formatter_plain::add_logo()
+{
+	add_exact("= PowerTOP =\n");
+}
+
+
+void
+report_formatter_plain::add_div(struct tag_attr * div_attr)
+{
+	add_exact("\n");
+}
+
+void
+report_formatter_plain::end_div()
+{
+	/*Do nothing*/
+}
+
+void
+report_formatter_plain::add_title(struct tag_attr *title_att, const char *title)
+{
+	add_exact("\n");
+	addf_exact("- %s -\n", title);
+}
+
+void
+report_formatter_plain::add_navigation()
+{
+	/* No nav in plain - thinking on table of contents */
+}
+
+void
+report_formatter_plain::add_summary_list(string *list, int size)
+{
+	int i;
+	add_exact("\n");
+	for (i=0; i < size; i += 2){
+		addf_exact("%s %s", list[i].c_str(), list[i + 1].c_str());
+		if(i < (size - 1))
+			add_exact("\n");
+	}
+	add_exact("\n");
+}
+
+void
+report_formatter_plain::add_table(string *system_data, struct table_attributes* tb_attr)
+{
+	int i, j;
+	int offset=0;
+	string tmp_str="";
+	int empty_row=0;
+	add_exact("\n");
+	for (i=0; i < tb_attr->rows; i++){
+		for (j=0; j < tb_attr->cols; j++){
+			offset = i * (tb_attr->cols) + j;
+			tmp_str=system_data[offset];
+
+			if(tmp_str == "&nbsp;")
+				empty_row+=1;
+			else{
+				addf_exact("%s", system_data[offset].c_str());
+				if(j < (tb_attr->cols - 1))
+					add_exact(" ");
+			}
+		}
+		if(empty_row < tb_attr->cols)
+		add_exact("\n");
+		empty_row=0;
+	}
+}

--- a/src/report/report-formatter-plain.h
+++ b/src/report/report-formatter-plain.h
@@ -1,0 +1,53 @@
+/* Copyright (c) 2016 Jaroslav Škarvada <jskarvad@redhat.com>
+ * Based on CSV formatter code by Igor Zhbanov <i.zhbanov@samsung.com>
+ *
+ * This file is part of PowerTOP
+ *
+ * This program file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in a file named COPYING; if not, write to the
+ * Free Software Foundation, Inc,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ * or just google for it.
+ */
+
+#ifndef _REPORT_FORMATTER_PLAIN_H_
+#define _REPORT_FORMATTER_PLAIN_H_
+
+#include <string>
+
+#include "report-formatter-base.h"
+
+using namespace std;
+
+class report_formatter_plain: public report_formatter_string_base
+{
+public:
+	report_formatter_plain();
+	void finish_report();
+
+	/* Report Style */
+	void add_logo();
+	void add_header();
+	void end_header();
+	void add_div(struct tag_attr *div_attr);
+	void end_div();
+	void add_title(struct tag_attr *title_att, const char *title);
+	void add_navigation();
+	void add_summary_list(string *list, int size);
+	void add_table(string *system_data, struct table_attributes *tb_attr);
+
+private:
+	string escape_string(const char *str);
+};
+
+#endif /* _REPORT_FORMATTER_PLAIN_H_ */

--- a/src/report/report-maker.cpp
+++ b/src/report/report-maker.cpp
@@ -32,6 +32,7 @@
 #include "report-maker.h"
 #include "report-formatter-csv.h"
 #include "report-formatter-html.h"
+#include "report-formatter-plain.h"
 
 /* ************************************************************************ */
 
@@ -103,6 +104,8 @@ report_maker::setup_report_formatter()
 		formatter = new report_formatter_html();
 	else if (type == REPORT_CSV)
 		formatter = new report_formatter_csv();
+	else if (type == REPORT_PLAIN)
+		formatter = new report_formatter_plain();
 	else if (type == REPORT_OFF)
 		formatter = new report_formatter();
 	else

--- a/src/report/report-maker.h
+++ b/src/report/report-maker.h
@@ -65,7 +65,7 @@ using namespace std;
 /* Conditional gettext. We need original strings for CSV. */
 #ifdef ENABLE_NLS
 #define __(STRING) \
-	((report.get_type() == REPORT_CSV) ? (STRING) : gettext(STRING))
+	((report.get_type() == REPORT_CSV || report.get_type() == REPORT_PLAIN) ? (STRING) : gettext(STRING))
 #else
 #define __(STRING) (STRING)
 #endif
@@ -79,7 +79,8 @@ using namespace std;
 enum report_type {
 	REPORT_OFF,
 	REPORT_HTML,
-	REPORT_CSV
+	REPORT_CSV,
+	REPORT_PLAIN
 };
 
 /* ************************************************************************ */


### PR DESCRIPTION
The -d, --dump outputs plain text report, similarly how to old -d option
did. It takes one optional argument, the FILENAME. If there is no argument
it outputs to STDOUT.

Similarly the CSV and HTML reporters now by default outputs to STDOUT,
which allows easy filtering of output through pipes. Previously their
FILENAME argument was mandatory, now it is optional.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>