### PR TITLE
unportable usage of strerror_r without configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-#                                               -*- Autoconf -*-
+# #                                              -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])


### PR DESCRIPTION
when compiling against musl libc:
```
event-parse.c: In function 'pevent_strerror':
event-parse.c:5124:7: warning: assignment makes pointer from integer without a cast
```
only GNU libc defines strerror_r as returning char*:
https://www.gnu.org/software/autoconf/manual/autoconf-2.64/html_node/Function-Portability.html

> strerror_r
>    Posix specifies that strerror_r returns an int, but many systems (e.g., GNU C Library version 2.2.4) provide a different version returning a char *. AC_FUNC_STRERROR_R can detect which is in use (see Particular Functions).

sorry that i use this method to notify you of the issue, but i don't want to subscribe to a ML.