### PR TITLE
Fix typo: SATA link power 'Managmenet' to 'Management'

### DIFF
--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -443,7 +443,7 @@ msgstr "ইউএসবি ডিভাইস %s[%s] এর জন্য Autosus
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr ""
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/da_DK.po
+++ b/po/da_DK.po
@@ -442,7 +442,7 @@ msgstr ""
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr ""
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/es_CO.po
+++ b/po/es_CO.po
@@ -442,7 +442,7 @@ msgstr ""
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr ""
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/fy.po
+++ b/po/fy.po
@@ -443,7 +443,7 @@ msgstr "Autosliepstân foar USB apparaat %s [%s]"
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr "Skeakelje SATA link krêft behear yn foar %s"
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/hi.po
+++ b/po/hi.po
@@ -443,7 +443,7 @@ msgstr "यूएसबी उपकरण के लिए स्वतःस�
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr ""
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -442,7 +442,7 @@ msgstr ""
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr ""
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/ko.po
+++ b/po/ko.po
@@ -443,7 +443,7 @@ msgstr ""
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr ""
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/lt.po
+++ b/po/lt.po
@@ -443,7 +443,7 @@ msgstr "Automatinis USB įrenginio %s [%s] užmigdymas"
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr "Įjungti SATA sąsajos energijos valdymą %s"
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -446,7 +446,7 @@ msgstr ""
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr ""
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -444,7 +444,7 @@ msgstr "Suspensão automática para dispositivo USB %s [%s]"
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr "Habilitar gerenciamento de energia da conexão SATA para %s"
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -444,7 +444,7 @@ msgstr "Autosuspend для USB-устройства %s [%s]"
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr "Активировать управление питанием линка SATA для %s"
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/tr_TR.po
+++ b/po/tr_TR.po
@@ -443,7 +443,7 @@ msgstr ""
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr ""
 
 #: src/calibrate/calibrate.cpp:236

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -443,7 +443,7 @@ msgstr "自动挂起 USB 设备 %s [%s]"
 
 #: src/tuning/tuningsysfs.cpp:139
 #, c-format
-msgid "Enable SATA link power Managmenet for %s"
+msgid "Enable SATA link power Management for %s"
 msgstr ""
 
 #: src/calibrate/calibrate.cpp:236


### PR DESCRIPTION
Hello, I've fixed a minor typo in user-facing output. 

I see the repo description says to post patches to the mailing list instead of using GitHub pull requests: I'd be happy to do so, but I've never used a mailing list so I was hoping someone could advise on which mailing list and how to post a patch there (or just link some relevant instructions). I would have put this in an issue, but it looks like GitHub issues are disabled for this repo as well. 

Thanks!