### PR TITLE
Fix powertop build with libc++.

### DIFF
--- a/src/lib.h
+++ b/src/lib.h
@@ -54,7 +54,7 @@ extern const char *kernel_function(uint64_t address);
 
 
 
-
+#include <ctime>
 #include <string>
 using namespace std;
 


### PR DESCRIPTION
<ctime> header is not automatically included with libc++.
Add it explicitly to make powertop build with libc++.

This fixes the following errors:
devices/gpu_rapl_device.cpp:35:14: error: use of undeclared identifier
'time'; did you mean 'tie'?
last_time = time(NULL);
                ^~~~
devices/gpu_rapl_device.cpp:45:14: error:use of undeclared identifier
'time'; did you mean 'tie'?
last_time = time(NULL);
                ^~~~

parameters/learn.cpp:161:10: error: use of undeclared identifier
'time'; did you mean 'tie'?
start =	time(NULL);
            ^~~~