### PR TITLE
Add more descriptive column headers for Idle Stats Tab

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -68,11 +68,15 @@ static class abstract_cpu * new_package(int package, int cpu, char * vendor, int
 	char packagename[128];
 	if (strcmp(vendor, "GenuineIntel") == 0)
 		if (family == 6)
-			if (is_supported_intel_cpu(model))
+			if (is_supported_intel_cpu(model)) {
 				ret = new class nhm_package(model);
+				ret->set_intel_MSR(true);
+			}
 
-	if (!ret)
+	if (!ret) {
 		ret = new class cpu_package;
+		ret->set_intel_MSR(false);
+	}
 
 	ret->set_number(package, cpu);
 	ret->set_type("Package");
@@ -105,11 +109,16 @@ static class abstract_cpu * new_core(int core, int cpu, char * vendor, int famil
 
 	if (strcmp(vendor, "GenuineIntel") == 0)
 		if (family == 6)
-			if (is_supported_intel_cpu(model))
+			if (is_supported_intel_cpu(model)) {
 				ret = new class nhm_core(model);
+				ret->set_intel_MSR(true);
+			}
 
-	if (!ret)
+	if (!ret) {
 		ret = new class cpu_core;
+		ret->set_intel_MSR(false);
+	}
+
 	ret->set_number(core, cpu);
 	ret->childcount = 0;
 	ret->set_type("Core");
@@ -134,11 +143,15 @@ static class abstract_cpu * new_cpu(int number, char * vendor, int family, int m
 
 	if (strcmp(vendor, "GenuineIntel") == 0)
 		if (family == 6)
-			if (is_supported_intel_cpu(model))
+			if (is_supported_intel_cpu(model)) {
 				ret = new class nhm_cpu;
+				ret->set_intel_MSR(true);
+			}
 
-	if (!ret)
+	if (!ret) {
 		ret = new class cpu_linux;
+		ret->set_intel_MSR(false);
+	}
 	ret->set_number(number, number);
 	ret->set_type("CPU");
 	ret->childcount = 0;

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -93,7 +93,7 @@ public:
 	int	number;
 	int	childcount;
 	const char*    name;
-	bool	idle, old_idle;
+	bool	idle, old_idle, has_intel_MSR;
 	uint64_t	current_frequency;
 	uint64_t	effective_frequency;
 
@@ -108,6 +108,7 @@ public:
 
 	int	get_first_cpu() { return first_cpu; }
 	void	set_number(int _number, int cpu) {this->number = _number; this->first_cpu = cpu;};
+	void	set_intel_MSR(bool _bool_value) {this->has_intel_MSR =  _bool_value;};
 	void	set_type(const char* _name) {this->name = _name;};
 	int	get_number(void) { return number; };
 	const char* get_type(void) { return name; };

--- a/src/cpu/cpu_core.cpp
+++ b/src/cpu/cpu_core.cpp
@@ -34,7 +34,7 @@ char * cpu_core::fill_cstate_line(int line_nr, char *buffer, const char *separat
 	buffer[0] = 0;
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_("  Core"));
+		sprintf(buffer, this->has_intel_MSR ? _(" Core(HW)"): _(" Core(OS)"));
 		return buffer;
 	}
 

--- a/src/cpu/cpu_linux.cpp
+++ b/src/cpu/cpu_linux.cpp
@@ -239,7 +239,7 @@ char * cpu_linux::fill_cstate_line(int line_nr, char *buffer, const char *separa
 	buffer[0] = 0;
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_(" CPU %i"), number);
+		sprintf(buffer,_(" CPU(OS) %i"), number);
 		return buffer;
 	}
 

--- a/src/cpu/cpu_package.cpp
+++ b/src/cpu/cpu_package.cpp
@@ -44,7 +44,7 @@ char * cpu_package::fill_cstate_line(int line_nr, char *buffer, const char *sepa
 	buffer[0] = 0;
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_("Package"));
+		sprintf(buffer, this->has_intel_MSR ? _(" Pkg(HW)"): _(" Cores(OS)"));
 		return buffer;
 	}
 


### PR DESCRIPTION
This patch introduces a more descriptive column headers to show where
Powertop gets these values from (OS versus model specific registers when 
a platform isn't supported).

Signed-off-by: Michael Cheng <michael.cheng@intel.com>