### PR TITLE
Dropped unused variable "entry" detected by Coverity

### DIFF
--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -229,7 +229,6 @@ static void devfreq_dev_callback(const char *d_name)
 
 void create_all_devfreq_devices(void)
 {
-	struct dirent *entry;
 	int num = 0;
 
 	std::string p = "/sys/class/devfreq/";
@@ -240,7 +239,7 @@ void create_all_devfreq_devices(void)
 		return;
 	}
 
-	while((entry = readdir(dir)) != NULL)
+	while(readdir(dir) != NULL)
 		num++;
 
 	if (num == 2) {


### PR DESCRIPTION
The following two issues which were introduced between 2.11 and 2.12
were fixed:
  - Fixed the issue when the closedir in the intel_cpus.cpp
    could be called with the NULL arg.
  - Dropped unused local variable "entry" in the devfreq.cpp.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>