### PR TITLE
configure.ac: use ax_cxx_compile_stdcxx instead

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_PROG_CC
 AC_PROG_INSTALL
 AM_PROG_CC_C_O
 AX_ADD_FORTIFY_SOURCE
-AX_CXX_COMPILE_STDCXX_11([noext], [mandatory])
+AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 
 # Checks for libraries.
 AX_PTHREAD([


### PR DESCRIPTION
Before, we used autotools's ax_cxx_compile_stdcxx_11, which was a
convenience macro. However, it caused an autoconf error, requiring
end-users to re-run autoreconf (or autogen.sh) at least twice to
generate the configure script.

By using ax_cxx_compile_stdcxx instead, we no longer cause autoreconf
(or autogen.sh) to error out due to too many loops.

Signed-off-by: Joe Konno <joe.konno@intel.com>