### PR TITLE
intel_cpus: Fix ICX definition

### DIFF
--- a/src/cpu/intel_cpus.cpp
+++ b/src/cpu/intel_cpus.cpp
@@ -422,7 +422,6 @@ nhm_package::nhm_package(int model)
 		case 0x5E:	/* SKY */
 		case 0x5F:	/* DNV */
 		case 0x66:	/* CNL-U/Y */
-		case 0x6A:	/* ICL_X*/
 		case 0x7A:	/* GLK */
 		case 0x7D:	/* ICL_DESKTOP */
 		case 0x7E:	/* ICL_MOBILE */


### PR DESCRIPTION
There was a mistake in how package C-states are defined for the ICX.
Let's fix that.

Signed-off-by: Joe Konno <joe.konno@intel.com>