### PR TITLE
intel_cpus: Fix SKY-X definition

### DIFF
--- a/src/cpu/intel_cpus.cpp
+++ b/src/cpu/intel_cpus.cpp
@@ -417,7 +417,6 @@ nhm_package::nhm_package(int model)
 		case 0x3D:	/* BDW */
 		case 0x45:	/* HSW */
 		case 0x4E:	/* SKY */
-		case 0x55:	/* SKY-X */
 		case 0x5C:	/* BXT-P */
 		case 0x5E:	/* SKY */
 		case 0x5F:	/* DNV */


### PR DESCRIPTION
Much like #51, SKY-X was incorrectly defined, so let's fix it.

Fixes: b637c171c362 ("intel_cpus: Enable Sky Lake server support in PowerTop")
Signed-off-by: Joe Konno <joe.konno@intel.com>