### PR TITLE
Add Rocket Lake support, clean up cout, printf lines and revert power estimate feature

### DIFF
--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -176,15 +176,11 @@ void abstract_cpu::measurement_end(void)
 	for (i = 0; i < cstates.size(); i++) {
 		struct idle_state *state = cstates[i];
 
-		if (state->after_count == 0) {
-			cout << "after count is 0 " << state->linux_name << "\n";
+		if (state->after_count == 0)
 			continue;
-		}
 
-		if (state->after_count != state->before_count) {
-			cout << "count mismatch " << state->after_count << " " << state->before_count << " on cpu " << number << "\n";
+		if (state->after_count != state->before_count)
 			continue;
-		}
 
 		state->usage_delta =    (state->usage_after    - state->usage_before)    / state->after_count;
 		state->duration_delta = (state->duration_after - state->duration_before) / state->after_count;

--- a/src/cpu/intel_cpus.cpp
+++ b/src/cpu/intel_cpus.cpp
@@ -299,15 +299,11 @@ void nhm_core::measurement_end(void)
 	for (i = 0; i < cstates.size(); i++) {
 		struct idle_state *state = cstates[i];
 
-		if (state->after_count == 0) {
-			cout << "after count is 0\n";
+		if (state->after_count == 0)
 			continue;
-		}
 
-		if (state->after_count != state->before_count) {
-			cout << "count mismatch\n";
+		if (state->after_count != state->before_count)
 			continue;
-		}
 
 		state->usage_delta =    ratio * (state->usage_after    - state->usage_before)    / state->after_count;
 		state->duration_delta = ratio * (state->duration_after - state->duration_before) / state->after_count;
@@ -572,15 +568,11 @@ void nhm_package::measurement_end(void)
 	for (i = 0; i < cstates.size(); i++) {
 		struct idle_state *state = cstates[i];
 
-		if (state->after_count == 0) {
-			cout << "after count is 0\n";
+		if (state->after_count == 0)
 			continue;
-		}
 
-		if (state->after_count != state->before_count) {
-			cout << "count mismatch\n";
+		if (state->after_count != state->before_count)
 			continue;
-		}
 
 		state->usage_delta =    ratio * (state->usage_after    - state->usage_before)    / state->after_count;
 		state->duration_delta = ratio * (state->duration_after - state->duration_before) / state->after_count;

--- a/src/cpu/intel_cpus.cpp
+++ b/src/cpu/intel_cpus.cpp
@@ -83,6 +83,7 @@ static int intel_cpu_models[] = {
 	0x9E,	/* KBL */
 	0xA5,   /* CML_DESKTOP */
 	0xA6,   /* CML_MOBILE */
+	0xA7,	/* RKL_DESKTOP */
 	0	/* last entry must be zero */
 };
 
@@ -196,6 +197,7 @@ nhm_core::nhm_core(int model)
 		case 0x9E:	/* KBL */
 		case 0xA5:      /* CML_DESKTOP */
 		case 0xA6:      /* CML_MOBILE */
+		case 0xA7:	/* RKL_DESKTOP */
 			has_c7_res = 1;
 	}
 
@@ -385,6 +387,7 @@ nhm_package::nhm_package(int model)
 		case 0x9E:	/* KBL */
 		case 0xA5:      /* CML_DESKTOP */
 		case 0xA6:      /* CML_MOBILE */
+		case 0xA7:	/* RKL_DESKTOP */
 			has_c2c6_res=1;
 			has_c7_res = 1;
 	}
@@ -428,6 +431,7 @@ nhm_package::nhm_package(int model)
 		case 0x9E:	/* KBL */
 		case 0xA5:      /* CML_DESKTOP */
 		case 0xA6:      /* CML_MOBILE */
+		case 0xA7:	/* RKL_DESKTOP */
 			has_c8c9c10_res = 1;
 			break;
 	}

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -428,7 +428,7 @@ int utilization_power_valid(int index)
 
 
 /* force power data to be valid to the rest of the system  */
-int global_power_override = 1;
+int global_power_override = 0;
 int global_run_times=0;
 /*
  * only report power numbers once we have 3* more measurements than

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -188,7 +188,6 @@ void add_runtime_tunables(const char *bus)
 				continue;
 
 			snprintf(port, sizeof(port), "sd%c", blk);
-			printf (" the port is %s\n", port);
 			snprintf(filename, sizeof(filename), "/sys/block/%s/device", port);
 			runtime_ahci_disk = new class runtime_tunable(filename, bus, entry->d_name, port);
 			if (!device_has_runtime_pm(filename))


### PR DESCRIPTION
This Pull request adds Rocket Lake support. It disables the previously enabled power estimate feature because of the inaccurate readings that are misleading. Also, clean up the cout and printf lines that result in spurious printing 