### PR TITLE
Patch for compatibility with Ryzen processors

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -576,6 +576,12 @@ void report_display_cpu_cstates(void)
 							}
 						}
 					} else {
+						/*
+						 * Patch for compatibility with Ryzen processors
+						 * See https://github.com/fenrus75/powertop/issues/64
+						*/
+						if(idx2 >= core_tbl_size.cols * core_tbl_size.rows) break;
+						
 						tmp_str=string(_core->fill_cstate_name(line, buffer));
 						core_data[idx2]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx2+=1;


### PR DESCRIPTION
Following the segmentation fault that occurs when using `--csv` or `--html` on Ryzen processors (see https://github.com/fenrus75/powertop/issues/64), the error occurs because of a miscalculation of CPU cores in the output.

As a quick patch, I add a simple `break` to stop when the CPU cores exceed the core threshold (due to the miscalculation), and now Ryzen processors no longer cause a segmentation fault.