### PR TITLE
Patch for compability with Ryzen processors (v2)

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -551,6 +551,12 @@ void report_display_cpu_cstates(void)
 				if (!_core->can_collapse()) {
 					buffer[0] = 0;
 					buffer2[0] = 0;
+					
+					/*
+						* Patch for compatibility with Ryzen processors
+						* See https://github.com/fenrus75/powertop/issues/64
+					*/
+					if(idx2 >= core_tbl_size.cols * core_tbl_size.rows) break;
 
 					if (line == LEVEL_HEADER) {
 						/* Here we need to check for which core type we
@@ -576,11 +582,7 @@ void report_display_cpu_cstates(void)
 							}
 						}
 					} else {
-						/*
-						 * Patch for compatibility with Ryzen processors
-						 * See https://github.com/fenrus75/powertop/issues/64
-						*/
-						if(idx2 >= core_tbl_size.cols * core_tbl_size.rows) break;
+
 						
 						tmp_str=string(_core->fill_cstate_name(line, buffer));
 						core_data[idx2]=(tmp_str=="" ? "&nbsp;" : tmp_str);


### PR DESCRIPTION
I had the same problem as issue #64 and have been struggling with it. I saw that the PR #91 tried to fix it so I cloned the repo and tried `powertop --html`, but it still produced a segmentation fault. I moved the check `idx2>=cols*rows` to the top of the for loop, since it seems that in my case it was entering the true branch of the if at `line 561` and producing a segmentation fault there. Moving the check to the top of the for loop fixed that for me. If you want some screenshots, tell me.

Greetings