### PR TITLE
Ensure that auto-tune is executed on resume as well

### DIFF
--- a/powertop.service
+++ b/powertop.service
@@ -6,4 +6,4 @@ Type=oneshot
 ExecStart=/usr/sbin/powertop --auto-tune
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target sleep.target


### PR DESCRIPTION
When resuming from sleep/hibernate, the tuneables are reset to Bad. This
will ensure that auto tune is run even on a resume.