### PR TITLE
Add missing line breaks after error messages

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -362,10 +362,10 @@ static void powertop_init(int auto_tune)
 	setrlimit (RLIMIT_NOFILE, &rlmt);
 
 	if (system("/sbin/modprobe cpufreq_stats > /dev/null 2>&1"))
-		fprintf(stderr, _("modprobe cpufreq_stats failed"));
+		fprintf(stderr, _("modprobe cpufreq_stats failed\n"));
 #if defined(__i386__) || defined(__x86_64__)
 	if (system("/sbin/modprobe msr > /dev/null 2>&1"))
-		fprintf(stderr, _("modprobe msr failed"));
+		fprintf(stderr, _("modprobe msr failed\n"));
 #endif
 	statfs("/sys/kernel/debug", &st_fs);
 


### PR DESCRIPTION
Before:
```
modprobe cpufreq_stats failedLoaded 0 prior measurements
```

After:
```
modprobe cpufreq_stats failed
Loaded 0 prior measurements
```

Since these strings aren't currently translated in any language, I didn't update the *.po files.