### PR TITLE
Implement --auto-tune-dump

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,7 @@ void (*ui_notify_user) (const char *frmt, ...);
 
 enum {
 	OPT_AUTO_TUNE = CHAR_MAX + 1,
+	OPT_AUTO_TUNE_DUMP,
 	OPT_EXTECH,
 	OPT_DEBUG
 };
@@ -84,6 +85,7 @@ static const struct option long_options[] =
 {
 	/* These options set a flag. */
 	{"auto-tune",	no_argument,		NULL,		 OPT_AUTO_TUNE},
+	{"auto-tune-dump",	no_argument,	NULL,		 OPT_AUTO_TUNE_DUMP},
 	{"calibrate",	no_argument,		NULL,		 'c'},
 	{"csv",		optional_argument,	NULL,		 'C'},
 	{"debug",	no_argument,		&debug_learning, OPT_DEBUG},
@@ -122,6 +124,7 @@ static void print_usage()
 {
 	printf("%s\n\n", _("Usage: powertop [OPTIONS]"));
 	printf("     --auto-tune\t %s\n", _("sets all tunable options to their GOOD setting"));
+	printf("     --auto-tune-dump\t %s\n", _("print auto-tune commands to STDOUT *instead* of executing them"));
 	printf(" -c, --calibrate\t %s\n", _("runs powertop in calibration mode"));
 	printf(" -C, --csv%s\t %s\n", _("[=filename]"), _("generate a csv report"));
 	printf("     --debug\t\t %s\n", _("run in \"debug\" mode"));
@@ -434,6 +437,7 @@ int main(int argc, char **argv)
 	char filename[PATH_MAX];
 	char workload[PATH_MAX] = {0};
 	int  iterations = 1, auto_tune = 0, sample_interval = 5;
+	bool auto_tune_dump = false;
 
 	set_new_handler(out_of_memory);
 
@@ -450,6 +454,8 @@ int main(int argc, char **argv)
 		if (c == -1)
 			break;
 		switch (c) {
+		case OPT_AUTO_TUNE_DUMP:
+			auto_tune_dump = true; // do NOT `break;` here!
 		case OPT_AUTO_TUNE:
 			auto_tune = 1;
 			leave_powertop = 1;
@@ -546,7 +552,7 @@ int main(int argc, char **argv)
 		tuning_update_display();
 		show_tab(0);
 	} else {
-		auto_toggle_tuning();
+		auto_toggle_tuning(auto_tune_dump);
 	}
 
 	while (!leave_powertop) {

--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -51,6 +51,11 @@ public:
 
 	tunable(void);
 	tunable(const char *str, double _score, const char *good = "", const char *bad = "", const char *neutral ="");
+
+	void dump_cmd_good(FILE *fp) {
+		(void) fprintf(fp, "\n### %s\n# %s\n", desc, toggle_good);
+	}
+
 	virtual ~tunable() {};
 
 	virtual int good_bad(void) { return TUNE_NEUTRAL; }

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -323,10 +323,17 @@ void clear_tuning()
 	all_untunables.clear();
 }
 
-void auto_toggle_tuning()
+void auto_toggle_tuning(bool dump_only)
 {
+	if (dump_only) fprintf(stdout, "### auto-tune-dump commands BEGIN\n\n");
 	for (unsigned int i = 0; i < all_tunables.size(); i++) {
-		if (all_tunables[i]->good_bad() == TUNE_BAD)
-			all_tunables[i]->toggle();
+		if (all_tunables[i]->good_bad() == TUNE_BAD) {
+			if (dump_only) {
+				all_tunables[i]->dump_cmd_good(stdout);
+			} else {
+				all_tunables[i]->toggle();
+			}
+		}
 	}
+	if (dump_only) fprintf(stdout, "\n### auto-tune-dump commands END\n\n");
 }

--- a/src/tuning/tuning.h
+++ b/src/tuning/tuning.h
@@ -29,5 +29,5 @@ extern void initialize_tuning(void);
 extern void tuning_update_display(void);
 extern void report_show_tunables(void);
 extern void clear_tuning(void);
-extern void auto_toggle_tuning(void);
+extern void auto_toggle_tuning(bool dump_only);
 #endif


### PR DESCRIPTION
This switch, specified either alone or in addition to --auto-tune, will cause powertop to emit Bourne-shell compatible tuning commands to STDOUT instead of executing them unconditionally.

With --auto-tune-dump, suggested commands/tuning recommendations can be post-processed by shell pipelines involving grep(1) and other stream processors to selectively omit or apply them.