### PR TITLE
Add support for RISC-V architecture

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -301,10 +301,12 @@ void enumerate_cpus(void)
 		/* on x86 and others 'bogomips' is last
 		 * on ARM it *can* be bogomips, or 'CPU revision'
 		 * on POWER, it's revision
+		 * on RISCV, it is uarch
 		 */
 		if (strncasecmp(line, "bogomips\t", 9) == 0
 		    || strncasecmp(line, "CPU revision\t", 13) == 0
-		    || strncmp(line, "revision", 8) == 0) {
+		    || strncmp(line, "revision", 8) == 0
+		    || strncmp(line, "uarch", 5) == 0) {
 			if (number == -1) {
 				/* Not all /proc/cpuinfo include "processor\t". */
 				number = 0;


### PR DESCRIPTION
Tested on VisionFive 2 Board. The cpuinfo would look like this. Adding this will add support to RISC-V chips.

![image](https://github.com/fenrus75/powertop/assets/5170481/5dcea24a-bcdd-4ef5-aadb-c67cf6bd7d0a)
