### PR TITLE
Fix configure to support ncurses w/ tinfo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,10 +116,13 @@ AC_CHECK_FUNCS([ \
 
 AC_SEARCH_LIBS([clock_gettime], [rt])
 
-PKG_CHECK_MODULES([NCURSES], [ncursesw ncurses], [LIBS="$LIBS $ncurses_LIBS"], [
-	AC_SEARCH_LIBS([delwin], [ncursesw ncurses], [], [
-		AC_MSG_ERROR([ncurses is required but was not found])
-	], [])
+PKG_CHECK_MODULES([ncursesw], [ncursesw],
+	[NCURSES_CFLAGS="$ncursesw_CFLAGS"; NCURSES_LIBS="$ncursesw_LIBS"], [
+	PKG_CHECK_MODULES([NCURSES], [ncurses], [], [
+		AC_SEARCH_LIBS([delwin], [ncursesw ncurses], [], [
+			AC_MSG_ERROR([ncurses is required but was not found])
+		])
+	])
 ])
 
 has_libpci=0


### PR DESCRIPTION
- The existing code checked for both ncursesw and ncurses and if both were not found, NCURSES_LIBS was not set correctly.
- Removed redundant concatenation to $LIBS since the makefile.am already maps NCURSES_LIBS into LIBS.
- Patch sent upstream to powertop mailing list [1]

[1] - https://lists.01.org/pipermail/powertop/2018-June/002021.html