### PR TITLE
Fixed RISCV T-Head 1520 CPU identification

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -174,6 +174,8 @@ static void handle_one_cpu(unsigned int number, char *vendor, int family, int mo
 	file.open(filename, ios::in);
 	if (file) {
 		file >> core_number;
+		if (core_number == (unsigned int) -1)
+			core_number = number;
 		file.close();
 	}
 
@@ -300,11 +302,13 @@ void enumerate_cpus(void)
 		}
 		/* on x86 and others 'bogomips' is last
 		 * on ARM it *can* be bogomips, or 'CPU revision'
-		 * on POWER, it's revision
+		 * on POWER, it's 'revision'
+		 * on RISCV64 it's 'isa'
 		 */
 		if (strncasecmp(line, "bogomips\t", 9) == 0
 		    || strncasecmp(line, "CPU revision\t", 13) == 0
-		    || strncmp(line, "revision", 8) == 0) {
+		    || strncmp(line, "revision", 8) == 0
+		    || strncmp(line, "isa\t", 4) == 0) {
 			if (number == -1) {
 				/* Not all /proc/cpuinfo include "processor\t". */
 				number = 0;


### PR DESCRIPTION
 T-Head 1520 is a RISCV CPU. I suggest using `isa` line to mark the end of processing.

```
sipeed@lpi4a:~$ cat /proc/cpuinfo 
processor	: 0
hart		: 0
isa		: rv64imafdcvsu
mmu		: sv39
cpu-freq	: 1.848Ghz
cpu-icache	: 64KB
cpu-dcache	: 64KB
cpu-l2cache	: 1MB
cpu-tlb		: 1024 4-ways
cpu-cacheline	: 64Bytes
cpu-vector	: 0.7.1

processor	: 1
hart		: 1
isa		: rv64imafdcvsu
mmu		: sv39
cpu-freq	: 1.848Ghz
cpu-icache	: 64KB
cpu-dcache	: 64KB
cpu-l2cache	: 1MB
cpu-tlb		: 1024 4-ways
cpu-cacheline	: 64Bytes
cpu-vector	: 0.7.1

processor	: 2
hart		: 2
isa		: rv64imafdcvsu
mmu		: sv39
cpu-freq	: 1.848Ghz
cpu-icache	: 64KB
cpu-dcache	: 64KB
cpu-l2cache	: 1MB
cpu-tlb		: 1024 4-ways
cpu-cacheline	: 64Bytes
cpu-vector	: 0.7.1

processor	: 3
hart		: 3
isa		: rv64imafdcvsu
mmu		: sv39
cpu-freq	: 1.848Ghz
cpu-icache	: 64KB
cpu-dcache	: 64KB
cpu-l2cache	: 1MB
cpu-tlb		: 1024 4-ways
cpu-cacheline	: 64Bytes
cpu-vector	: 0.7.1
```

Also, topology doesn't have information for `core_id`

```
$ cat /sys/devices/system/cpu/cpu*/topology/core_id
-1
-1
-1
-1
```