### PR TITLE
Add --auto-tune-dump option to manpage

### DIFF
--- a/doc/powertop.8
+++ b/doc/powertop.8
@@ -15,6 +15,11 @@ powertop without arguments powertop starts in interactive mode.
 .B \-\-auto\-tune
 Set all tunable options to their good setting without interaction.
 .TP
+.B \-\-auto\-tune\-dump
+Print
+.I auto\-tune
+commands to STDOUT instead of executing them.
+.TP
 .BR \-c ", " \-\-calibrate
 Runs powertop in calibration mode.  When running on battery, powertop can
 track power consumption as well as system activity.  When there are


### PR DESCRIPTION
This PR adds the `--auto-tune-dump` option to the manpages as that was missing from the original PR (#116).