### PR TITLE
i915: Fix possible memory leak of rapl_dev variable

### DIFF
--- a/src/devices/i915-gpu.cpp
+++ b/src/devices/i915-gpu.cpp
@@ -94,6 +94,8 @@ void create_i915_gpu(void)
 	rapl_dev = new class gpu_rapl_device(gpu);
 	if (rapl_dev->device_present())
 		all_devices.push_back(rapl_dev);
+	else
+		delete rapl_dev;
 }
 
 


### PR DESCRIPTION
If the rapl_dev variable in i915-gpu.cpp is not added to all_devices, it will cause a memory leak.