### PR TITLE
tuning: do not auto-tune USB ports with connected mouse or keyboard

### DIFF
--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -45,6 +45,7 @@ class tunable {
 protected:
 	char toggle_good[4096];
 	char toggle_bad[4096];
+	bool safe = true;
 public:
 	char desc[4096];
 	double score;
@@ -78,6 +79,8 @@ public:
 	virtual void toggle(void) { };
 
 	virtual const char *toggle_script(void) { return NULL; }
+
+	virtual bool is_safe(void) { return safe; }
 };
 
 extern vector<class tunable *> all_tunables;

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -331,7 +331,9 @@ void auto_toggle_tuning(bool dump_only)
 			if (dump_only) {
 				all_tunables[i]->dump_cmd_good(stdout);
 			} else {
-				all_tunables[i]->toggle();
+				if (all_tunables[i]->is_safe()) {
+					all_tunables[i]->toggle();
+				}
 			}
 		}
 	}

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -28,6 +28,7 @@
 #include "unistd.h"
 #include "tuningusb.h"
 #include <string.h>
+#include <algorithm>
 #include <dirent.h>
 #include <utility>
 #include <iostream>
@@ -73,6 +74,10 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 		snprintf(desc, sizeof(desc), _("Autosuspend for USB device %s [%s]"), product, name);
 	else if (strlen(vendor))
 		snprintf(desc, sizeof(desc), _("Autosuspend for USB device %s [%s]"), vendor, name);
+
+	str1 = product;
+	transform(str1.begin(), str1.end(), str1.begin(), ::tolower);
+	safe = str1.find("mouse") == string::npos && str1.find("keyboard") == string::npos;
 
 	snprintf(toggle_good, sizeof(toggle_good), "echo 'auto' > '%s';", usb_path);
 	snprintf(toggle_bad, sizeof(toggle_bad), "echo 'on' > '%s';", usb_path);


### PR DESCRIPTION
Enabling auto suspend on USB ports with connected mouse or keyboard can lead to problems with some implementations as e.g. reported in:
https://bugzilla.redhat.com/show_bug.cgi?id=2300988

I could also add parameter allowing auto-tuning even of unsafe devices, but IMHO it's probably what most of the users will not use.
