### PR TITLE
Fix battery runtime estimation with negative sysfs values

### DIFF
--- a/src/measurement/sysfs.cpp
+++ b/src/measurement/sysfs.cpp
@@ -75,8 +75,10 @@ bool sysfs_power_meter::set_rate_from_power()
 	if (!get_sysfs_attr("power_now", &power))
 		return false;
 
-	/* µW to W */
-	rate = power / 1000000.0;
+	/* µW to W
+	 * Some drivers (example: Qualcomm) exposes use a negative value when
+	 * discharging, positive value when charging, so use the absolute value. */
+	rate = std::abs(power) / 1000000.0;
 	return true;
 }
 
@@ -89,8 +91,10 @@ bool sysfs_power_meter::set_rate_from_current(double voltage)
 
 	/* current: µA
 	 * voltage: V
-	 * rate: W */
-	rate = (current / 1000000.0) * voltage;
+	 * rate: W
+	 * Documentation ABI allows a negative value when discharging, positive
+	 * value when charging, so use the absolute value. */
+	rate = (std::abs(current) / 1000000.0) * voltage;
 	return true;
 }
 


### PR DESCRIPTION
Some drivers (example: qualcomm-battmgr, present on Snapdragon X1 laptops) expose the current_now and power_now values in sysfs as negative int when the device is discharging, positive when charging.

This breaks the battery runtime estimation in Powertop, as it expects a uint for power_now.

Use the absolute values of power_now to fix the problem, and does the same for current_now to respect the ABI documentation.

I discussed about it with the maintainer of qualcomm-battmgr, and the conclusion has been that it's better to fix the userland tools to respect the ABI documentation for current_now (which specifies negative values when discharging), and allows for negative values for power_now: https://lore.kernel.org/linux-arm-msm/20250213-patch-qcomm-bat-uint-power-v1-1-16e7e2a77a02@mailbox.org/