### PR TITLE
Fix typo in generated HTML report

### DIFF
--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -248,7 +248,7 @@ msgid "SATA disk: %s"
 msgstr "SATA ডিস্ক: %s"
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/ca.po
+++ b/po/ca.po
@@ -225,7 +225,7 @@ msgid "SATA disk: %s"
 msgstr "Disc SATA: %s"
 
 #: src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: src/devices/ahci.cpp:389

--- a/po/cs_CZ.po
+++ b/po/cs_CZ.po
@@ -227,7 +227,7 @@ msgid "SATA disk: %s"
 msgstr "SATA disk: %s"
 
 #: src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: src/devices/ahci.cpp:389

--- a/po/da_DK.po
+++ b/po/da_DK.po
@@ -222,7 +222,7 @@ msgid "SATA disk: %s"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -226,7 +226,7 @@ msgid "SATA disk: %s"
 msgstr "SATA-Festplatte: %s"
 
 #: src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: src/devices/ahci.cpp:389

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -224,7 +224,7 @@ msgid "SATA disk: %s"
 msgstr ""
 
 #: src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: src/devices/ahci.cpp:389

--- a/po/en_US.po
+++ b/po/en_US.po
@@ -223,7 +223,7 @@ msgid "SATA disk: %s"
 msgstr "SATA disk: %s"
 
 #: src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: src/devices/ahci.cpp:389

--- a/po/es_CO.po
+++ b/po/es_CO.po
@@ -222,7 +222,7 @@ msgid "SATA disk: %s"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -225,7 +225,7 @@ msgid "SATA disk: %s"
 msgstr "Disco SATA: %s"
 
 #: src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: src/devices/ahci.cpp:389

--- a/po/fy.po
+++ b/po/fy.po
@@ -224,7 +224,7 @@ msgid "SATA disk: %s"
 msgstr "SATA skiif: %s"
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/hi.po
+++ b/po/hi.po
@@ -224,7 +224,7 @@ msgid "SATA disk: %s"
 msgstr "SATA डिस्क: %s"
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/hu_HU.po
+++ b/po/hu_HU.po
@@ -227,7 +227,7 @@ msgid "SATA disk: %s"
 msgstr "SATA lemez: %s"
 
 #: src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: src/devices/ahci.cpp:389

--- a/po/id_ID.po
+++ b/po/id_ID.po
@@ -224,7 +224,7 @@ msgid "SATA disk: %s"
 msgstr "Disk SATA: %s"
 
 #: src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: src/devices/ahci.cpp:389

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -224,7 +224,7 @@ msgid "SATA disk: %s"
 msgstr "Disco SATA: %s"
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -222,7 +222,7 @@ msgid "SATA disk: %s"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/ko.po
+++ b/po/ko.po
@@ -223,7 +223,7 @@ msgid "SATA disk: %s"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/lt.po
+++ b/po/lt.po
@@ -225,7 +225,7 @@ msgid "SATA disk: %s"
 msgstr "SATA diskas: %s"
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/nl_NL.po
+++ b/po/nl_NL.po
@@ -224,7 +224,7 @@ msgid "SATA disk: %s"
 msgstr ""
 
 #: src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: src/devices/ahci.cpp:389

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -228,7 +228,7 @@ msgid "SATA disk: %s"
 msgstr "Dysk SATA: %s"
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -225,7 +225,7 @@ msgid "SATA disk: %s"
 msgstr "Disco SATA: %s"
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -226,7 +226,7 @@ msgid "SATA disk: %s"
 msgstr "Диск SATA: %s"
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/tr_TR.po
+++ b/po/tr_TR.po
@@ -224,7 +224,7 @@ msgid "SATA disk: %s"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -224,7 +224,7 @@ msgid "SATA disk: %s"
 msgstr "SATA 磁盘: %s"
 
 #: ../src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: ../src/devices/ahci.cpp:389

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -224,7 +224,7 @@ msgid "SATA disk: %s"
 msgstr "SATA 磁碟: %s"
 
 #: src/devices/ahci.cpp:374
-msgid "AHCI ALPM Residency Statistics - Not supported on this macine"
+msgid "AHCI ALPM Residency Statistics - Not supported on this machine"
 msgstr ""
 
 #: src/devices/ahci.cpp:389

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -371,7 +371,7 @@ void ahci_create_device_stats_table(void)
 	report.add_div(&div_attr);
 
 	if (links.size() == 0) {
-		report.add_title(&title_attr, __("AHCI ALPM Residency Statistics - Not supported on this macine"));
+		report.add_title(&title_attr, __("AHCI ALPM Residency Statistics - Not supported on this machine"));
 		report.end_div();
 		return;
 	}


### PR DESCRIPTION
# This PR addresses a typo found within the HTML report

## Changes made

Fixed the typo from "macine" to "machine" in the HTML report in the 'AHCI' and 'ALL' categories. I found this typo to be in multiple `.po` files as well as in a `.cpp` file.

"AHCI ALPM Residency Statistics - Not supported on this macine"
to
"AHCI ALPM Residency Statistics - Not supported on this machine"

## Testing performed

Built and executed the program, the typo is fixed in the generated HTML report.