### PR TITLE
Fix root privileges check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -327,7 +327,7 @@ void make_report(int time, char *workload, int iterations, int sample_interval, 
 
 static void checkroot() {
 	int uid;
-	uid = getuid();
+	uid = geteuid();
 
 	if (uid != 0) {
 		printf(_("PowerTOP " PACKAGE_VERSION " must be run with root privileges.\n"));


### PR DESCRIPTION
PowerTOP must be run with root privileges, but `getuid()` checks the user that the program is running as, and *not* whether the program is running with root privileges. This is a subtle distinction but meant that it was not possible to make the `powertop` binary setuid root.

Using `geteuid()` checks the *effective* user ID instead, which fixes this bug.

Fixes #178.