### PR TITLE
refactor phase 1: replace char * with std::string in a lot of key places

### DIFF
--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,398 @@
+[
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devlist.cpp.o -MF powertop.p/src_devlist.cpp.o.d -o powertop.p/src_devlist.cpp.o -c ../src/devlist.cpp",
+    "file": "../src/devlist.cpp",
+    "output": "powertop.p/src_devlist.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_display.cpp.o -MF powertop.p/src_display.cpp.o.d -o powertop.p/src_display.cpp.o -c ../src/display.cpp",
+    "file": "../src/display.cpp",
+    "output": "powertop.p/src_display.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_lib.cpp.o -MF powertop.p/src_lib.cpp.o.d -o powertop.p/src_lib.cpp.o -c ../src/lib.cpp",
+    "file": "../src/lib.cpp",
+    "output": "powertop.p/src_lib.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_main.cpp.o -MF powertop.p/src_main.cpp.o.d -o powertop.p/src_main.cpp.o -c ../src/main.cpp",
+    "file": "../src/main.cpp",
+    "output": "powertop.p/src_main.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_calibrate_calibrate.cpp.o -MF powertop.p/src_calibrate_calibrate.cpp.o.d -o powertop.p/src_calibrate_calibrate.cpp.o -c ../src/calibrate/calibrate.cpp",
+    "file": "../src/calibrate/calibrate.cpp",
+    "output": "powertop.p/src_calibrate_calibrate.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_abstract_cpu.cpp.o -MF powertop.p/src_cpu_abstract_cpu.cpp.o.d -o powertop.p/src_cpu_abstract_cpu.cpp.o -c ../src/cpu/abstract_cpu.cpp",
+    "file": "../src/cpu/abstract_cpu.cpp",
+    "output": "powertop.p/src_cpu_abstract_cpu.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_cpu.cpp.o -MF powertop.p/src_cpu_cpu.cpp.o.d -o powertop.p/src_cpu_cpu.cpp.o -c ../src/cpu/cpu.cpp",
+    "file": "../src/cpu/cpu.cpp",
+    "output": "powertop.p/src_cpu_cpu.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_cpu_core.cpp.o -MF powertop.p/src_cpu_cpu_core.cpp.o.d -o powertop.p/src_cpu_cpu_core.cpp.o -c ../src/cpu/cpu_core.cpp",
+    "file": "../src/cpu/cpu_core.cpp",
+    "output": "powertop.p/src_cpu_cpu_core.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_cpu_linux.cpp.o -MF powertop.p/src_cpu_cpu_linux.cpp.o.d -o powertop.p/src_cpu_cpu_linux.cpp.o -c ../src/cpu/cpu_linux.cpp",
+    "file": "../src/cpu/cpu_linux.cpp",
+    "output": "powertop.p/src_cpu_cpu_linux.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_cpu_package.cpp.o -MF powertop.p/src_cpu_cpu_package.cpp.o.d -o powertop.p/src_cpu_cpu_package.cpp.o -c ../src/cpu/cpu_package.cpp",
+    "file": "../src/cpu/cpu_package.cpp",
+    "output": "powertop.p/src_cpu_cpu_package.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_cpu_rapl_device.cpp.o -MF powertop.p/src_cpu_cpu_rapl_device.cpp.o.d -o powertop.p/src_cpu_cpu_rapl_device.cpp.o -c ../src/cpu/cpu_rapl_device.cpp",
+    "file": "../src/cpu/cpu_rapl_device.cpp",
+    "output": "powertop.p/src_cpu_cpu_rapl_device.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_cpudevice.cpp.o -MF powertop.p/src_cpu_cpudevice.cpp.o.d -o powertop.p/src_cpu_cpudevice.cpp.o -c ../src/cpu/cpudevice.cpp",
+    "file": "../src/cpu/cpudevice.cpp",
+    "output": "powertop.p/src_cpu_cpudevice.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_dram_rapl_device.cpp.o -MF powertop.p/src_cpu_dram_rapl_device.cpp.o.d -o powertop.p/src_cpu_dram_rapl_device.cpp.o -c ../src/cpu/dram_rapl_device.cpp",
+    "file": "../src/cpu/dram_rapl_device.cpp",
+    "output": "powertop.p/src_cpu_dram_rapl_device.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_intel_cpus.cpp.o -MF powertop.p/src_cpu_intel_cpus.cpp.o.d -o powertop.p/src_cpu_intel_cpus.cpp.o -c ../src/cpu/intel_cpus.cpp",
+    "file": "../src/cpu/intel_cpus.cpp",
+    "output": "powertop.p/src_cpu_intel_cpus.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_intel_gpu.cpp.o -MF powertop.p/src_cpu_intel_gpu.cpp.o.d -o powertop.p/src_cpu_intel_gpu.cpp.o -c ../src/cpu/intel_gpu.cpp",
+    "file": "../src/cpu/intel_gpu.cpp",
+    "output": "powertop.p/src_cpu_intel_gpu.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_cpu_rapl_rapl_interface.cpp.o -MF powertop.p/src_cpu_rapl_rapl_interface.cpp.o.d -o powertop.p/src_cpu_rapl_rapl_interface.cpp.o -c ../src/cpu/rapl/rapl_interface.cpp",
+    "file": "../src/cpu/rapl/rapl_interface.cpp",
+    "output": "powertop.p/src_cpu_rapl_rapl_interface.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_ahci.cpp.o -MF powertop.p/src_devices_ahci.cpp.o.d -o powertop.p/src_devices_ahci.cpp.o -c ../src/devices/ahci.cpp",
+    "file": "../src/devices/ahci.cpp",
+    "output": "powertop.p/src_devices_ahci.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_alsa.cpp.o -MF powertop.p/src_devices_alsa.cpp.o.d -o powertop.p/src_devices_alsa.cpp.o -c ../src/devices/alsa.cpp",
+    "file": "../src/devices/alsa.cpp",
+    "output": "powertop.p/src_devices_alsa.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_backlight.cpp.o -MF powertop.p/src_devices_backlight.cpp.o.d -o powertop.p/src_devices_backlight.cpp.o -c ../src/devices/backlight.cpp",
+    "file": "../src/devices/backlight.cpp",
+    "output": "powertop.p/src_devices_backlight.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_devfreq.cpp.o -MF powertop.p/src_devices_devfreq.cpp.o.d -o powertop.p/src_devices_devfreq.cpp.o -c ../src/devices/devfreq.cpp",
+    "file": "../src/devices/devfreq.cpp",
+    "output": "powertop.p/src_devices_devfreq.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_device.cpp.o -MF powertop.p/src_devices_device.cpp.o.d -o powertop.p/src_devices_device.cpp.o -c ../src/devices/device.cpp",
+    "file": "../src/devices/device.cpp",
+    "output": "powertop.p/src_devices_device.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_gpu_rapl_device.cpp.o -MF powertop.p/src_devices_gpu_rapl_device.cpp.o.d -o powertop.p/src_devices_gpu_rapl_device.cpp.o -c ../src/devices/gpu_rapl_device.cpp",
+    "file": "../src/devices/gpu_rapl_device.cpp",
+    "output": "powertop.p/src_devices_gpu_rapl_device.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_i915-gpu.cpp.o -MF powertop.p/src_devices_i915-gpu.cpp.o.d -o powertop.p/src_devices_i915-gpu.cpp.o -c ../src/devices/i915-gpu.cpp",
+    "file": "../src/devices/i915-gpu.cpp",
+    "output": "powertop.p/src_devices_i915-gpu.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_network.cpp.o -MF powertop.p/src_devices_network.cpp.o.d -o powertop.p/src_devices_network.cpp.o -c ../src/devices/network.cpp",
+    "file": "../src/devices/network.cpp",
+    "output": "powertop.p/src_devices_network.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_rfkill.cpp.o -MF powertop.p/src_devices_rfkill.cpp.o.d -o powertop.p/src_devices_rfkill.cpp.o -c ../src/devices/rfkill.cpp",
+    "file": "../src/devices/rfkill.cpp",
+    "output": "powertop.p/src_devices_rfkill.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_runtime_pm.cpp.o -MF powertop.p/src_devices_runtime_pm.cpp.o.d -o powertop.p/src_devices_runtime_pm.cpp.o -c ../src/devices/runtime_pm.cpp",
+    "file": "../src/devices/runtime_pm.cpp",
+    "output": "powertop.p/src_devices_runtime_pm.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_thinkpad-fan.cpp.o -MF powertop.p/src_devices_thinkpad-fan.cpp.o.d -o powertop.p/src_devices_thinkpad-fan.cpp.o -c ../src/devices/thinkpad-fan.cpp",
+    "file": "../src/devices/thinkpad-fan.cpp",
+    "output": "powertop.p/src_devices_thinkpad-fan.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_thinkpad-light.cpp.o -MF powertop.p/src_devices_thinkpad-light.cpp.o.d -o powertop.p/src_devices_thinkpad-light.cpp.o -c ../src/devices/thinkpad-light.cpp",
+    "file": "../src/devices/thinkpad-light.cpp",
+    "output": "powertop.p/src_devices_thinkpad-light.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_devices_usb.cpp.o -MF powertop.p/src_devices_usb.cpp.o.d -o powertop.p/src_devices_usb.cpp.o -c ../src/devices/usb.cpp",
+    "file": "../src/devices/usb.cpp",
+    "output": "powertop.p/src_devices_usb.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_measurement_acpi.cpp.o -MF powertop.p/src_measurement_acpi.cpp.o.d -o powertop.p/src_measurement_acpi.cpp.o -c ../src/measurement/acpi.cpp",
+    "file": "../src/measurement/acpi.cpp",
+    "output": "powertop.p/src_measurement_acpi.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_measurement_extech.cpp.o -MF powertop.p/src_measurement_extech.cpp.o.d -o powertop.p/src_measurement_extech.cpp.o -c ../src/measurement/extech.cpp",
+    "file": "../src/measurement/extech.cpp",
+    "output": "powertop.p/src_measurement_extech.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_measurement_measurement.cpp.o -MF powertop.p/src_measurement_measurement.cpp.o.d -o powertop.p/src_measurement_measurement.cpp.o -c ../src/measurement/measurement.cpp",
+    "file": "../src/measurement/measurement.cpp",
+    "output": "powertop.p/src_measurement_measurement.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_measurement_sysfs.cpp.o -MF powertop.p/src_measurement_sysfs.cpp.o.d -o powertop.p/src_measurement_sysfs.cpp.o -c ../src/measurement/sysfs.cpp",
+    "file": "../src/measurement/sysfs.cpp",
+    "output": "powertop.p/src_measurement_sysfs.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_measurement_opal-sensors.cpp.o -MF powertop.p/src_measurement_opal-sensors.cpp.o.d -o powertop.p/src_measurement_opal-sensors.cpp.o -c ../src/measurement/opal-sensors.cpp",
+    "file": "../src/measurement/opal-sensors.cpp",
+    "output": "powertop.p/src_measurement_opal-sensors.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_parameters_learn.cpp.o -MF powertop.p/src_parameters_learn.cpp.o.d -o powertop.p/src_parameters_learn.cpp.o -c ../src/parameters/learn.cpp",
+    "file": "../src/parameters/learn.cpp",
+    "output": "powertop.p/src_parameters_learn.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_parameters_parameters.cpp.o -MF powertop.p/src_parameters_parameters.cpp.o.d -o powertop.p/src_parameters_parameters.cpp.o -c ../src/parameters/parameters.cpp",
+    "file": "../src/parameters/parameters.cpp",
+    "output": "powertop.p/src_parameters_parameters.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_parameters_persistent.cpp.o -MF powertop.p/src_parameters_persistent.cpp.o.d -o powertop.p/src_parameters_persistent.cpp.o -c ../src/parameters/persistent.cpp",
+    "file": "../src/parameters/persistent.cpp",
+    "output": "powertop.p/src_parameters_persistent.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_perf_perf.cpp.o -MF powertop.p/src_perf_perf.cpp.o.d -o powertop.p/src_perf_perf.cpp.o -c ../src/perf/perf.cpp",
+    "file": "../src/perf/perf.cpp",
+    "output": "powertop.p/src_perf_perf.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_perf_perf_bundle.cpp.o -MF powertop.p/src_perf_perf_bundle.cpp.o.d -o powertop.p/src_perf_perf_bundle.cpp.o -c ../src/perf/perf_bundle.cpp",
+    "file": "../src/perf/perf_bundle.cpp",
+    "output": "powertop.p/src_perf_perf_bundle.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_process_do_process.cpp.o -MF powertop.p/src_process_do_process.cpp.o.d -o powertop.p/src_process_do_process.cpp.o -c ../src/process/do_process.cpp",
+    "file": "../src/process/do_process.cpp",
+    "output": "powertop.p/src_process_do_process.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_process_interrupt.cpp.o -MF powertop.p/src_process_interrupt.cpp.o.d -o powertop.p/src_process_interrupt.cpp.o -c ../src/process/interrupt.cpp",
+    "file": "../src/process/interrupt.cpp",
+    "output": "powertop.p/src_process_interrupt.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_process_powerconsumer.cpp.o -MF powertop.p/src_process_powerconsumer.cpp.o.d -o powertop.p/src_process_powerconsumer.cpp.o -c ../src/process/powerconsumer.cpp",
+    "file": "../src/process/powerconsumer.cpp",
+    "output": "powertop.p/src_process_powerconsumer.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_process_process.cpp.o -MF powertop.p/src_process_process.cpp.o.d -o powertop.p/src_process_process.cpp.o -c ../src/process/process.cpp",
+    "file": "../src/process/process.cpp",
+    "output": "powertop.p/src_process_process.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_process_processdevice.cpp.o -MF powertop.p/src_process_processdevice.cpp.o.d -o powertop.p/src_process_processdevice.cpp.o -c ../src/process/processdevice.cpp",
+    "file": "../src/process/processdevice.cpp",
+    "output": "powertop.p/src_process_processdevice.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_process_timer.cpp.o -MF powertop.p/src_process_timer.cpp.o.d -o powertop.p/src_process_timer.cpp.o -c ../src/process/timer.cpp",
+    "file": "../src/process/timer.cpp",
+    "output": "powertop.p/src_process_timer.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_process_work.cpp.o -MF powertop.p/src_process_work.cpp.o.d -o powertop.p/src_process_work.cpp.o -c ../src/process/work.cpp",
+    "file": "../src/process/work.cpp",
+    "output": "powertop.p/src_process_work.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_report_report-data-html.cpp.o -MF powertop.p/src_report_report-data-html.cpp.o.d -o powertop.p/src_report_report-data-html.cpp.o -c ../src/report/report-data-html.cpp",
+    "file": "../src/report/report-data-html.cpp",
+    "output": "powertop.p/src_report_report-data-html.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_report_report-formatter-base.cpp.o -MF powertop.p/src_report_report-formatter-base.cpp.o.d -o powertop.p/src_report_report-formatter-base.cpp.o -c ../src/report/report-formatter-base.cpp",
+    "file": "../src/report/report-formatter-base.cpp",
+    "output": "powertop.p/src_report_report-formatter-base.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_report_report-formatter-csv.cpp.o -MF powertop.p/src_report_report-formatter-csv.cpp.o.d -o powertop.p/src_report_report-formatter-csv.cpp.o -c ../src/report/report-formatter-csv.cpp",
+    "file": "../src/report/report-formatter-csv.cpp",
+    "output": "powertop.p/src_report_report-formatter-csv.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_report_report-formatter-html.cpp.o -MF powertop.p/src_report_report-formatter-html.cpp.o.d -o powertop.p/src_report_report-formatter-html.cpp.o -c ../src/report/report-formatter-html.cpp",
+    "file": "../src/report/report-formatter-html.cpp",
+    "output": "powertop.p/src_report_report-formatter-html.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_report_report-maker.cpp.o -MF powertop.p/src_report_report-maker.cpp.o.d -o powertop.p/src_report_report-maker.cpp.o -c ../src/report/report-maker.cpp",
+    "file": "../src/report/report-maker.cpp",
+    "output": "powertop.p/src_report_report-maker.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_report_report.cpp.o -MF powertop.p/src_report_report.cpp.o.d -o powertop.p/src_report_report.cpp.o -c ../src/report/report.cpp",
+    "file": "../src/report/report.cpp",
+    "output": "powertop.p/src_report_report.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_tuning_bluetooth.cpp.o -MF powertop.p/src_tuning_bluetooth.cpp.o.d -o powertop.p/src_tuning_bluetooth.cpp.o -c ../src/tuning/bluetooth.cpp",
+    "file": "../src/tuning/bluetooth.cpp",
+    "output": "powertop.p/src_tuning_bluetooth.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_tuning_ethernet.cpp.o -MF powertop.p/src_tuning_ethernet.cpp.o.d -o powertop.p/src_tuning_ethernet.cpp.o -c ../src/tuning/ethernet.cpp",
+    "file": "../src/tuning/ethernet.cpp",
+    "output": "powertop.p/src_tuning_ethernet.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "cc -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -MD -MQ powertop.p/src_tuning_iw.c.o -MF powertop.p/src_tuning_iw.c.o.d -o powertop.p/src_tuning_iw.c.o -c ../src/tuning/iw.c",
+    "file": "../src/tuning/iw.c",
+    "output": "powertop.p/src_tuning_iw.c.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_tuning_runtime.cpp.o -MF powertop.p/src_tuning_runtime.cpp.o.d -o powertop.p/src_tuning_runtime.cpp.o -c ../src/tuning/runtime.cpp",
+    "file": "../src/tuning/runtime.cpp",
+    "output": "powertop.p/src_tuning_runtime.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_tuning_tunable.cpp.o -MF powertop.p/src_tuning_tunable.cpp.o.d -o powertop.p/src_tuning_tunable.cpp.o -c ../src/tuning/tunable.cpp",
+    "file": "../src/tuning/tunable.cpp",
+    "output": "powertop.p/src_tuning_tunable.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_tuning_tuning.cpp.o -MF powertop.p/src_tuning_tuning.cpp.o.d -o powertop.p/src_tuning_tuning.cpp.o -c ../src/tuning/tuning.cpp",
+    "file": "../src/tuning/tuning.cpp",
+    "output": "powertop.p/src_tuning_tuning.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_tuning_tuningsysfs.cpp.o -MF powertop.p/src_tuning_tuningsysfs.cpp.o.d -o powertop.p/src_tuning_tuningsysfs.cpp.o -c ../src/tuning/tuningsysfs.cpp",
+    "file": "../src/tuning/tuningsysfs.cpp",
+    "output": "powertop.p/src_tuning_tuningsysfs.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_tuning_tuningusb.cpp.o -MF powertop.p/src_tuning_tuningusb.cpp.o.d -o powertop.p/src_tuning_tuningusb.cpp.o -c ../src/tuning/tuningusb.cpp",
+    "file": "../src/tuning/tuningusb.cpp",
+    "output": "powertop.p/src_tuning_tuningusb.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_tuning_tuningi2c.cpp.o -MF powertop.p/src_tuning_tuningi2c.cpp.o.d -o powertop.p/src_tuning_tuningi2c.cpp.o -c ../src/tuning/tuningi2c.cpp",
+    "file": "../src/tuning/tuningi2c.cpp",
+    "output": "powertop.p/src_tuning_tuningi2c.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_tuning_wifi.cpp.o -MF powertop.p/src_tuning_wifi.cpp.o.d -o powertop.p/src_tuning_wifi.cpp.o -c ../src/tuning/wifi.cpp",
+    "file": "../src/tuning/wifi.cpp",
+    "output": "powertop.p/src_tuning_wifi.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_wakeup_wakeup.cpp.o -MF powertop.p/src_wakeup_wakeup.cpp.o.d -o powertop.p/src_wakeup_wakeup.cpp.o -c ../src/wakeup/wakeup.cpp",
+    "file": "../src/wakeup/wakeup.cpp",
+    "output": "powertop.p/src_wakeup_wakeup.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_wakeup_waketab.cpp.o -MF powertop.p/src_wakeup_waketab.cpp.o.d -o powertop.p/src_wakeup_waketab.cpp.o -c ../src/wakeup/waketab.cpp",
+    "file": "../src/wakeup/waketab.cpp",
+    "output": "powertop.p/src_wakeup_waketab.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_wakeup_wakeup_ethernet.cpp.o -MF powertop.p/src_wakeup_wakeup_ethernet.cpp.o.d -o powertop.p/src_wakeup_wakeup_ethernet.cpp.o -c ../src/wakeup/wakeup_ethernet.cpp",
+    "file": "../src/wakeup/wakeup_ethernet.cpp",
+    "output": "powertop.p/src_wakeup_wakeup_ethernet.cpp.o"
+  },
+  {
+    "directory": "/home/arjan/git/powertop/build",
+    "command": "c++ -Ipowertop.p -I. -I.. -I../src -I/usr/include/x86_64-linux-gnu -I/usr/include/tracefs -I/usr/include/traceevent -I/usr/include/libnl3 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O2 -g -DHAVE_CONFIG_H -pthread -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Wall -Wformat -Wshadow -fno-omit-frame-pointer -fstack-protector -fpermissive -MD -MQ powertop.p/src_wakeup_wakeup_usb.cpp.o -MF powertop.p/src_wakeup_wakeup_usb.cpp.o.d -o powertop.p/src_wakeup_wakeup_usb.cpp.o -c ../src/wakeup/wakeup_usb.cpp",
+    "file": "../src/wakeup/wakeup_usb.cpp",
+    "output": "powertop.p/src_wakeup_wakeup_usb.cpp.o"
+  }
+]

--- a/local.md
+++ b/local.md
@@ -1,0 +1,15 @@
+This repository is for PowerTOP, a linux tool to find the sources of power
+consumption in a system.
+
+The code review rules for this project are in `review/review.md` and this
+includes a style guide.
+
+The class hiearchy is documented in `review/class.md` and this document
+needs to be kept uptodate as changes to the class hierarchy are made.
+
+The process for working on this codebase always consists for 4 steps
+1. Make the change
+2. Build the project (with meson/ninja)
+3. Code review the change to make sure it strictly matches the narrow objective
+4. Git commit the change with a comprehensive git commit message
+

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/m4/ax_require_defined.m4
+++ b/m4/ax_require_defined.m4
@@ -1,0 +1,37 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
+  m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])
+])dnl AX_REQUIRE_DEFINED

--- a/m4/build-to-host.m4
+++ b/m4/build-to-host.m4
@@ -1,0 +1,274 @@
+# build-to-host.m4
+# serial 5
+dnl Copyright (C) 2023-2024 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+dnl This file is offered as-is, without any warranty.
+
+dnl Written by Bruno Haible.
+
+dnl When the build environment ($build_os) is different from the target runtime
+dnl environment ($host_os), file names may need to be converted from the build
+dnl environment syntax to the target runtime environment syntax. This is
+dnl because the Makefiles are executed (mostly) by build environment tools and
+dnl therefore expect file names in build environment syntax, whereas the runtime
+dnl expects file names in target runtime environment syntax.
+dnl
+dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
+dnl be converted from Cygwin syntax to native Windows syntax:
+dnl   /cygdrive/c/foo/bar -> C:\foo\bar
+dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
+dnl
+dnl gl_BUILD_TO_HOST([somedir])
+dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
+dnl already have its final value assigned, and produces two additional
+dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
+dnl same file name value, just in different syntax:
+dnl   - somedir_c       is the file name in target runtime environment syntax,
+dnl                     as a C string (starting and ending with a double-quote,
+dnl                     and with escaped backslashes and double-quotes in
+dnl                     between).
+dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
+
+AC_DEFUN([gl_BUILD_TO_HOST],
+[
+  AC_REQUIRE([AC_CANONICAL_BUILD])
+  AC_REQUIRE([AC_CANONICAL_HOST])
+  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
+
+  dnl Define somedir_c.
+  gl_final_[$1]="$[$1]"
+  dnl Translate it from build syntax to host syntax.
+  case "$build_os" in
+    cygwin*)
+      case "$host_os" in
+        mingw* | windows*)
+          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
+      esac
+      ;;
+  esac
+  dnl Convert it to C string syntax.
+  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
+  [$1]_c='"'"$[$1]_c"'"'
+  AC_SUBST([$1_c])
+
+  dnl Define somedir_c_make.
+  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
+  dnl Use the substituted somedir variable, when possible, so that the user
+  dnl may adjust somedir a posteriori when there are no special characters.
+  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
+    [$1]_c_make='\"$([$1])\"'
+  fi
+  AC_SUBST([$1_c_make])
+])
+
+dnl Some initializations for gl_BUILD_TO_HOST.
+AC_DEFUN([gl_BUILD_TO_HOST_INIT],
+[
+  gl_sed_double_backslashes='s/\\/\\\\/g'
+  gl_sed_escape_doublequotes='s/"/\\"/g'
+changequote(,)dnl
+  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
+changequote([,])dnl
+  gl_sed_escape_for_make_2='s,\$,\\$$,g'
+  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
+  dnl does not understand '\r'.
+  case `echo r | tr -d '\r'` in
+    '') gl_tr_cr='\015' ;;
+    *)  gl_tr_cr='\r' ;;
+  esac
+])
+
+
+dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
+dnl for some of the variables that are defined by Autoconf.
+dnl To do so for _all_ the possible variables, use the module 'configmake'.
+
+dnl Defines bindir_c and bindir_c_make.
+AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
+[
+  dnl Find the final value of bindir.
+  gl_saved_prefix="${prefix}"
+  gl_saved_exec_prefix="${exec_prefix}"
+  gl_saved_bindir="${bindir}"
+  dnl Unfortunately, prefix and exec_prefix get only finally determined
+  dnl at the end of configure.
+  if test "X$prefix" = "XNONE"; then
+    prefix="$ac_default_prefix"
+  fi
+  if test "X$exec_prefix" = "XNONE"; then
+    exec_prefix='${prefix}'
+  fi
+  eval exec_prefix="$exec_prefix"
+  eval bindir="$bindir"
+  gl_BUILD_TO_HOST([bindir])
+  bindir="${gl_saved_bindir}"
+  exec_prefix="${gl_saved_exec_prefix}"
+  prefix="${gl_saved_prefix}"
+])
+
+dnl Defines datadir_c and datadir_c_make,
+dnl where datadir = $(datarootdir)
+AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
+[
+  dnl Find the final value of datadir.
+  gl_saved_prefix="${prefix}"
+  gl_saved_datarootdir="${datarootdir}"
+  gl_saved_datadir="${datadir}"
+  dnl Unfortunately, prefix gets only finally determined at the end of
+  dnl configure.
+  if test "X$prefix" = "XNONE"; then
+    prefix="$ac_default_prefix"
+  fi
+  eval datarootdir="$datarootdir"
+  eval datadir="$datadir"
+  gl_BUILD_TO_HOST([datadir])
+  datadir="${gl_saved_datadir}"
+  datarootdir="${gl_saved_datarootdir}"
+  prefix="${gl_saved_prefix}"
+])
+
+dnl Defines libdir_c and libdir_c_make.
+AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
+[
+  dnl Find the final value of libdir.
+  gl_saved_prefix="${prefix}"
+  gl_saved_exec_prefix="${exec_prefix}"
+  gl_saved_libdir="${libdir}"
+  dnl Unfortunately, prefix and exec_prefix get only finally determined
+  dnl at the end of configure.
+  if test "X$prefix" = "XNONE"; then
+    prefix="$ac_default_prefix"
+  fi
+  if test "X$exec_prefix" = "XNONE"; then
+    exec_prefix='${prefix}'
+  fi
+  eval exec_prefix="$exec_prefix"
+  eval libdir="$libdir"
+  gl_BUILD_TO_HOST([libdir])
+  libdir="${gl_saved_libdir}"
+  exec_prefix="${gl_saved_exec_prefix}"
+  prefix="${gl_saved_prefix}"
+])
+
+dnl Defines libexecdir_c and libexecdir_c_make.
+AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
+[
+  dnl Find the final value of libexecdir.
+  gl_saved_prefix="${prefix}"
+  gl_saved_exec_prefix="${exec_prefix}"
+  gl_saved_libexecdir="${libexecdir}"
+  dnl Unfortunately, prefix and exec_prefix get only finally determined
+  dnl at the end of configure.
+  if test "X$prefix" = "XNONE"; then
+    prefix="$ac_default_prefix"
+  fi
+  if test "X$exec_prefix" = "XNONE"; then
+    exec_prefix='${prefix}'
+  fi
+  eval exec_prefix="$exec_prefix"
+  eval libexecdir="$libexecdir"
+  gl_BUILD_TO_HOST([libexecdir])
+  libexecdir="${gl_saved_libexecdir}"
+  exec_prefix="${gl_saved_exec_prefix}"
+  prefix="${gl_saved_prefix}"
+])
+
+dnl Defines localedir_c and localedir_c_make.
+AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
+[
+  dnl Find the final value of localedir.
+  gl_saved_prefix="${prefix}"
+  gl_saved_datarootdir="${datarootdir}"
+  gl_saved_localedir="${localedir}"
+  dnl Unfortunately, prefix gets only finally determined at the end of
+  dnl configure.
+  if test "X$prefix" = "XNONE"; then
+    prefix="$ac_default_prefix"
+  fi
+  eval datarootdir="$datarootdir"
+  eval localedir="$localedir"
+  gl_BUILD_TO_HOST([localedir])
+  localedir="${gl_saved_localedir}"
+  datarootdir="${gl_saved_datarootdir}"
+  prefix="${gl_saved_prefix}"
+])
+
+dnl Defines pkgdatadir_c and pkgdatadir_c_make,
+dnl where pkgdatadir = $(datadir)/$(PACKAGE)
+AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
+[
+  dnl Find the final value of pkgdatadir.
+  gl_saved_prefix="${prefix}"
+  gl_saved_datarootdir="${datarootdir}"
+  gl_saved_datadir="${datadir}"
+  gl_saved_pkgdatadir="${pkgdatadir}"
+  dnl Unfortunately, prefix gets only finally determined at the end of
+  dnl configure.
+  if test "X$prefix" = "XNONE"; then
+    prefix="$ac_default_prefix"
+  fi
+  eval datarootdir="$datarootdir"
+  eval datadir="$datadir"
+  eval pkgdatadir="$pkgdatadir"
+  gl_BUILD_TO_HOST([pkgdatadir])
+  pkgdatadir="${gl_saved_pkgdatadir}"
+  datadir="${gl_saved_datadir}"
+  datarootdir="${gl_saved_datarootdir}"
+  prefix="${gl_saved_prefix}"
+])
+
+dnl Defines pkglibdir_c and pkglibdir_c_make,
+dnl where pkglibdir = $(libdir)/$(PACKAGE)
+AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
+[
+  dnl Find the final value of pkglibdir.
+  gl_saved_prefix="${prefix}"
+  gl_saved_exec_prefix="${exec_prefix}"
+  gl_saved_libdir="${libdir}"
+  gl_saved_pkglibdir="${pkglibdir}"
+  dnl Unfortunately, prefix and exec_prefix get only finally determined
+  dnl at the end of configure.
+  if test "X$prefix" = "XNONE"; then
+    prefix="$ac_default_prefix"
+  fi
+  if test "X$exec_prefix" = "XNONE"; then
+    exec_prefix='${prefix}'
+  fi
+  eval exec_prefix="$exec_prefix"
+  eval libdir="$libdir"
+  eval pkglibdir="$pkglibdir"
+  gl_BUILD_TO_HOST([pkglibdir])
+  pkglibdir="${gl_saved_pkglibdir}"
+  libdir="${gl_saved_libdir}"
+  exec_prefix="${gl_saved_exec_prefix}"
+  prefix="${gl_saved_prefix}"
+])
+
+dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
+dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
+AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
+[
+  dnl Find the final value of pkglibexecdir.
+  gl_saved_prefix="${prefix}"
+  gl_saved_exec_prefix="${exec_prefix}"
+  gl_saved_libexecdir="${libexecdir}"
+  gl_saved_pkglibexecdir="${pkglibexecdir}"
+  dnl Unfortunately, prefix and exec_prefix get only finally determined
+  dnl at the end of configure.
+  if test "X$prefix" = "XNONE"; then
+    prefix="$ac_default_prefix"
+  fi
+  if test "X$exec_prefix" = "XNONE"; then
+    exec_prefix='${prefix}'
+  fi
+  eval exec_prefix="$exec_prefix"
+  eval libexecdir="$libexecdir"
+  eval pkglibexecdir="$pkglibexecdir"
+  gl_BUILD_TO_HOST([pkglibexecdir])
+  pkglibexecdir="${gl_saved_pkglibexecdir}"
+  libexecdir="${gl_saved_libexecdir}"
+  exec_prefix="${gl_saved_exec_prefix}"
+  prefix="${gl_saved_prefix}"
+])

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('powertop', 'cpp', 'c',
   version: '2.15',
   meson_version: '>= 0.56.0',
   default_options: [
-    'cpp_std=c++11',
+    'cpp_std=c++20',
     'warning_level=1',
     'buildtype=debugoptimized',
   ]

--- a/po/insert-header.sed
+++ b/po/insert-header.sed
@@ -1,0 +1,31 @@
+# Sed script that inserts the file called HEADER before the header entry.
+#
+# Copyright (C) 2001 Free Software Foundation, Inc.
+# This file is free software; the Free Software Foundation
+# gives unlimited permission to copy and/or distribute it,
+# with or without modifications, as long as this notice is preserved.
+# This file is offered as-is, without any warranty.
+#
+# Written by Bruno Haible <bruno@clisp.org>, 2001.
+#
+# At each occurrence of a line starting with "msgid ", we execute the following
+# commands. At the first occurrence, insert the file. At the following
+# occurrences, do nothing. The distinction between the first and the following
+# occurrences is achieved by looking at the hold space.
+/^msgid /{
+x
+# Test if the hold space is empty.
+s/m/m/
+ta
+# Yes it was empty. First occurrence. Read the file.
+r HEADER
+# Output the file's contents by reading the next line. But don't lose the
+# current line while doing this.
+g
+N
+bb
+:a
+# The hold space was nonempty. Following occurrences. Do nothing.
+x
+:b
+}

--- a/review/class.md
+++ b/review/class.md
@@ -99,8 +99,7 @@ Base class for power-saving settings that can be "tuned" (e.g., SATA link power 
 * `good_bad()`: Returns whether the current setting is optimal for power saving.
 * `toggle()`: Switches between "good" and "bad" settings.
 * `description()`: Returns a std::string description of the tunable setting.
-* `result_string()`: Returns a string representation of the current state (Good/Bad/Unknown).
-* `result_string_s()`: Returns a std::string representation of the current state.
+* `result_string()`: Returns a std::string representation of the current state (Good/Bad/Unknown).
 * `toggle_script()`: Returns a shell script command to toggle the setting.
 * `toggle_script_s()`: Returns a std::string shell script command to toggle the setting.
 

--- a/review/class.md
+++ b/review/class.md
@@ -39,8 +39,7 @@ Represents any entity (process, interrupt, etc.) that consumes power.
 * `Witts()`: Returns the power consumption in Watts.
 * `usage()`: Returns a numerical value for usage (e.g., CPU time).
 * `events()`: Returns the rate of events (wakeups, ops) per second.
-* `description()`: Returns a description of the consumer.
-* `description_s()`: Returns a std::string description of the consumer.
+* `description()`: Returns a std::string description of the consumer.
 
 ### Key public variables
 * `uint64_t accumulated_runtime`: Total time the consumer was active.
@@ -99,8 +98,7 @@ Base class for power-saving settings that can be "tuned" (e.g., SATA link power 
 ### Key public methods
 * `good_bad()`: Returns whether the current setting is optimal for power saving.
 * `toggle()`: Switches between "good" and "bad" settings.
-* `description()`: Returns a description of the tunable setting.
-* `description_s()`: Returns a std::string description of the tunable setting.
+* `description()`: Returns a std::string description of the tunable setting.
 * `result_string()`: Returns a string representation of the current state (Good/Bad/Unknown).
 * `result_string_s()`: Returns a std::string representation of the current state.
 * `toggle_script()`: Returns a shell script command to toggle the setting.
@@ -121,8 +119,7 @@ Base class for system entities that can wake the system from sleep or idle.
 ### Key public methods
 * `wakeup_value()`: Returns the current enable/disable state.
 * `wakeup_toggle()`: Toggles the wakeup capability.
-* `description()`: Returns a description of the wakeup source.
-* `description_s()`: Returns a std::string description of the wakeup source.
+* `description()`: Returns a std::string description of the wakeup source.
 
 ### Key public variables
 * `std::string desc`: Description text.

--- a/review/class.md
+++ b/review/class.md
@@ -9,6 +9,8 @@ Base class for all hardware components that PowerTOP monitors for power consumpt
 * `end_measurement()`: Finalizes measurement for the device.
 * `utilization()`: Returns the utilization percentage of the device.
 * `device_name()`: Returns a string representing the device name.
+* `device_name_s()`: Returns a std::string representing the device name.
+* `human_name_s()`: Returns a std::string representing the human readable name.
 * `power_usage(result_bundle, parameter_bundle)`: Calculates power usage based on measurement results and parameters.
 
 ### Key public variables
@@ -38,6 +40,7 @@ Represents any entity (process, interrupt, etc.) that consumes power.
 * `usage()`: Returns a numerical value for usage (e.g., CPU time).
 * `events()`: Returns the rate of events (wakeups, ops) per second.
 * `description()`: Returns a description of the consumer.
+* `description_s()`: Returns a std::string description of the consumer.
 
 ### Key public variables
 * `uint64_t accumulated_runtime`: Total time the consumer was active.
@@ -97,10 +100,11 @@ Base class for power-saving settings that can be "tuned" (e.g., SATA link power 
 * `good_bad()`: Returns whether the current setting is optimal for power saving.
 * `toggle()`: Switches between "good" and "bad" settings.
 * `description()`: Returns a description of the tunable setting.
+* `description_s()`: Returns a std::string description of the tunable setting.
 
 ### Key public variables
 * `double score`: The estimated power saving impact.
-* `char desc[4096]`: Description text.
+* `std::string desc`: Description text.
 
 ### Derived class usb_tunable, ethernet_tunable, wifi_tunable, bt_tunable, etc.
 Specific implementations for different subsystems that allow power-saving toggles.
@@ -114,9 +118,10 @@ Base class for system entities that can wake the system from sleep or idle.
 * `wakeup_value()`: Returns the current enable/disable state.
 * `wakeup_toggle()`: Toggles the wakeup capability.
 * `description()`: Returns a description of the wakeup source.
+* `description_s()`: Returns a std::string description of the wakeup source.
 
 ### Key public variables
-* `char desc[4096]`: Description text.
+* `std::string desc`: Description text.
 
 ### Derived class usb_wakeup, ethernet_wakeup
 Implementations for specific hardware wakeup sources.

--- a/review/class.md
+++ b/review/class.md
@@ -10,7 +10,7 @@ Base class for all hardware components that PowerTOP monitors for power consumpt
 * `utilization()`: Returns the utilization percentage of the device.
 * `device_name()`: Returns a string representing the device name.
 * `device_name_s()`: Returns a std::string representing the device name.
-* `human_name_s()`: Returns a std::string representing the human readable name.
+* `human_name()`: Returns a std::string representing the human readable name.
 * `power_usage(result_bundle, parameter_bundle)`: Calculates power usage based on measurement results and parameters.
 
 ### Key public variables

--- a/review/class.md
+++ b/review/class.md
@@ -15,8 +15,8 @@ Base class for all hardware components that PowerTOP monitors for power consumpt
 
 ### Key public variables
 * `bool hide`: If true, the device is hidden from the UI.
-* `char guilty[4096]`: Stores information about processes responsible for this device's activity.
-* `char real_path[PATH_MAX+1]`: The sysfs path to the device.
+* `std::string guilty`: Stores information about processes responsible for this device's activity.
+* `std::string real_path`: The sysfs path to the device.
 
 ### Derived class cpudevice
 Specialized for CPU devices; serves as a base for RAPL (Running Average Power Limit) devices.
@@ -101,6 +101,10 @@ Base class for power-saving settings that can be "tuned" (e.g., SATA link power 
 * `toggle()`: Switches between "good" and "bad" settings.
 * `description()`: Returns a description of the tunable setting.
 * `description_s()`: Returns a std::string description of the tunable setting.
+* `result_string()`: Returns a string representation of the current state (Good/Bad/Unknown).
+* `result_string_s()`: Returns a std::string representation of the current state.
+* `toggle_script()`: Returns a shell script command to toggle the setting.
+* `toggle_script_s()`: Returns a std::string shell script command to toggle the setting.
 
 ### Key public variables
 * `double score`: The estimated power saving impact.
@@ -134,7 +138,7 @@ Base class for different methods of measuring system-wide power consumption.
 ### Key public methods
 * `power()`: Returns the current power consumption in Watts.
 * `start_measurement()`: Starts a measurement interval.
-* `end_measurement()`: Ends a measurement interval.
+* `end_measurement()`: Finalizes a measurement interval.
 * `is_discharging()`: Returns true if the system is running on battery.
 
 ### Derived class acpi_power_meter

--- a/review/general-c++.md
+++ b/review/general-c++.md
@@ -26,3 +26,7 @@ PowerTOP uses the C++ 20 language standard
 
 - [ ] Use "std::<element>" instead of "<element>" even when code uses 
     "using namespace std".
+
+## General C++ coding rules
+
+- [ ] Use "const" when possible for method and function parameters

--- a/review/overflows.md
+++ b/review/overflows.md
@@ -1,0 +1,52 @@
+# Buffer Overflow Vulnerability Report for PowerTOP
+
+This report summarizes potential buffer overflow vulnerabilities identified in the `src/` directory, primarily due to the use of legacy C-style string functions without adequate bounds checking.
+
+## 1. Tunable and Wakeup Description Buffers
+
+Many classes derived from `tunable` and `wakeup` use `sprintf` to populate a `desc` buffer defined in the base class.
+
+*   **Vulnerability**: `sprintf(desc, ...)`
+*   **Buffer Size**: `desc` is 4096 bytes (defined in `src/tuning/tunable.h` and `src/wakeup/wakeup.h`).
+*   **Risk**: If the arguments passed to `sprintf` (such as interface names, paths, or device descriptions) are long, they can easily exceed the 4096-byte limit.
+*   **Examples**:
+    *   `src/tuning/wifi.cpp:48`: `sprintf(desc, _("Wireless Power Saving for interface %s"), iface);` where `iface` is also 4096 bytes.
+    *   `src/tuning/runtime.cpp`: Multiple `sprintf` calls to `desc` using `path`, `bus`, `dev`, and `pci_id_to_name` results.
+    *   `src/wakeup/wakeup_usb.cpp:51` and `src/wakeup/wakeup_ethernet.cpp:51`.
+
+**Recommendation**: Replace `sprintf` with `snprintf(desc, sizeof(desc), ...)` to ensure no overflow occurs.
+
+## 2. Path Buffer Overflows
+
+Several locations use `sprintf` to construct file paths.
+
+*   **Vulnerability**: `sprintf(runtime_path, "%s/power/control", path);`
+*   **File**: `src/tuning/runtime.cpp:45`
+*   **Buffer Size**: `runtime_path` is `PATH_MAX` (typically 4096 on Linux).
+*   **Risk**: If `path` is already close to `PATH_MAX`, adding `/power/control` will overflow the buffer.
+
+**Recommendation**: Use `snprintf` with `sizeof(runtime_path)`.
+
+## 3. String Concatenation in `devlist.cpp`
+
+The `guilty` buffer in the `device` class is used to accumulate process names.
+
+*   **Vulnerability**: `strcat(_dev->guilty, one[i]->comm);`
+*   **File**: `src/devlist.cpp:221, 233`
+*   **Buffer Size**: `_dev->guilty` is 4096 bytes.
+*   **Risk**: While there is a check `if (strlen(_dev->guilty) < 2000)`, it only checks if the *current* length is less than 2000. If `one[i]->comm` (or many small ones) eventually exceeds the remaining 2096 bytes, an overflow will occur.
+
+**Recommendation**: Use `strncat` or check `strlen(_dev->guilty) + strlen(one[i]->comm) + 1 < sizeof(_dev->guilty)`.
+
+## 4. General `sprintf` Usage on Fixed-Size Buffers
+
+There are numerous instances of `sprintf` into buffers that are assumed to be "large enough".
+
+*   `src/devices/network.cpp:147`: `sprintf(humanname, "nic:%s", _name);`
+*   `src/cpu/cpu_linux.cpp`, `src/cpu/cpu_core.cpp`, `src/cpu/cpu_package.cpp`: Frequent use of `sprintf(buffer, ...)` where `buffer` is passed as a `char *`.
+
+**Recommendation**: Update function signatures to include buffer size and use `snprintf`.
+
+## Summary of Risks
+
+The identified patterns represent a "classic" set of buffer overflow risks. While many may not be exploitable under normal conditions (as they depend on system-provided strings like interface names), they violate secure coding practices and could lead to crashes or undefined behavior if system paths or device names are unusually long.

--- a/review/style.md
+++ b/review/style.md
@@ -95,6 +95,10 @@ default:
 ### 4.3 Strings
 *   Prefer `std::string` over C-style strings (`char *`) or fixed-size buffers, unless interfacing with C-only libraries.
 *   Always use the fully qualified `std::string` type.
+*   **Formatting**: Use `std::format` for internal strings and `pt_format` for user-facing (translated) strings.
+    *   `pt_format(_("..."), args...)` is required for gettext-translated strings to ensure compatibility with runtime format strings in C++20.
+    *   Do not use `std::vformat` or `std::make_format_args` directly; use the `pt_format` helper instead.
+    *   Example: `humanname = pt_format(_("USB device: {}"), device_name);`
 
 ### 4.4 Includes
 *   Order: Standard library headers first, followed by project-specific headers.

--- a/src/calibrate/calibrate.cpp
+++ b/src/calibrate/calibrate.cpp
@@ -88,24 +88,25 @@ static void restore_all_sysfs(void)
 
 static void find_all_usb_callback(const char *d_name)
 {
-	char filename[PATH_MAX];
+	std::string filename;
 	ifstream file;
 
-	snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s/power/active_duration", d_name);
-	if (access(filename, R_OK) != 0)
+	filename = std::format("/sys/bus/usb/devices/{}/power/active_duration", d_name);
+	if (access(filename.c_str(), R_OK) != 0)
 		return;
 
-	snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s/power/idVendor", d_name);
-	file.open(filename, ios::in);
+	filename = std::format("/sys/bus/usb/devices/{}/power/idVendor", d_name);
+	file.open(filename.c_str(), ios::in);
 	if (file) {
-		file.getline(filename, sizeof(filename));
+		std::string vendor_id;
+		getline(file, vendor_id);
 		file.close();
-		if (strcmp(filename, "1d6b") == 0)
+		if (vendor_id == "1d6b")
 			return;
 	}
 
-	snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s/power/control", d_name);
-	save_sysfs(filename);
+	filename = std::format("/sys/bus/usb/devices/{}/power/control", d_name);
+	save_sysfs(filename.c_str());
 	usb_devices.push_back(filename);
 }
 
@@ -124,11 +125,11 @@ static void suspend_all_usb_devices(void)
 
 static void find_all_rfkill_callback(const char *d_name)
 {
-	char filename[PATH_MAX];
-	snprintf(filename, sizeof(filename), "/sys/class/rfkill/%s/soft", d_name);
-	if (access(filename, R_OK) != 0)
+	std::string filename;
+	filename = std::format("/sys/class/rfkill/{}/soft", d_name);
+	if (access(filename.c_str(), R_OK) != 0)
 		return;
-	save_sysfs(filename);
+	save_sysfs(filename.c_str());
 	rfkill_devices.push_back(filename);
 }
 
@@ -154,15 +155,15 @@ static void unrfkill_all_radios(void)
 
 static void find_backlight_callback(const char *d_name)
 {
-	char filename[PATH_MAX];
-	snprintf(filename, sizeof(filename), "/sys/class/backlight/%s/brightness", d_name);
-	if (access(filename, R_OK) != 0)
+	std::string filename;
+	filename = std::format("/sys/class/backlight/{}/brightness", d_name);
+	if (access(filename.c_str(), R_OK) != 0)
 		return;
 
-	save_sysfs(filename);
+	save_sysfs(filename.c_str());
 	backlight_devices.push_back(filename);
-	snprintf(filename, sizeof(filename), "/sys/class/backlight/%s/max_brightness", d_name);
-	blmax = read_sysfs(filename);
+	filename = std::format("/sys/class/backlight/{}/max_brightness", d_name);
+	blmax = read_sysfs(filename.c_str());
 }
 
 static void find_backlight(void)
@@ -180,12 +181,12 @@ static void lower_backlight(void)
 
 static void find_scsi_link_callback(const char *d_name)
 {
-	char filename[PATH_MAX];
-	snprintf(filename, sizeof(filename), "/sys/class/scsi_host/%s/link_power_management_policy", d_name);
-	if (access(filename, R_OK)!=0)
+	std::string filename;
+	filename = std::format("/sys/class/scsi_host/{}/link_power_management_policy", d_name);
+	if (access(filename.c_str(), R_OK)!=0)
 		return;
 
-	save_sysfs(filename);
+	save_sysfs(filename.c_str());
 	scsi_link_devices.push_back(filename);
 }
 
@@ -229,9 +230,8 @@ static void *burn_disk(void *dummy)
 {
 	int fd;
 	char buffer[64*1024];
-	char filename[256];
+	char filename[] = "/tmp/powertop.XXXXXX";
 
-	strcpy(filename ,"/tmp/powertop.XXXXXX");
 	fd = mkstemp(filename);
 
 	if (fd < 0) {
@@ -323,41 +323,34 @@ static void rfkill_calibration(void)
 	}
 	rfkill_all_radios();
 }
-
 static void backlight_calibration(void)
 {
 	unsigned int i;
 
 	printf(_("Calibrating backlight\n"));
 	for (i = 0; i < backlight_devices.size(); i++) {
-		char str[4096];
+		std::string str;
 		printf(_(".... device %s \n"), backlight_devices[i].c_str());
 		lower_backlight();
 		one_measurement(15, 15, NULL);
-		sprintf(str, "%i\n", blmax / 4);
+		str = std::format("{}\n", blmax / 4);
 		write_sysfs(backlight_devices[i], str);
 		one_measurement(15, 15, NULL);
 
-		sprintf(str, "%i\n", blmax / 2);
+		str = std::format("{}\n", blmax / 2);
 		write_sysfs(backlight_devices[i], str);
 		one_measurement(15, 15, NULL);
 
-		sprintf(str, "%i\n", 3 * blmax / 4 );
+		str = std::format("{}\n", 3 * blmax / 4 );
 		write_sysfs(backlight_devices[i], str);
 		one_measurement(15, 15, NULL);
 
-		sprintf(str, "%i\n", blmax);
+		str = std::format("{}\n", blmax);
 		write_sysfs(backlight_devices[i], str);
 		one_measurement(15, 15, NULL);
 		lower_backlight();
 		sleep(1);
 	}
-	printf(_("Calibrating idle\n"));
-	if(!system("DISPLAY=:0 /usr/bin/xset dpms force off"))
-		printf("System is not available\n");
-	one_measurement(15, 15, NULL);
-	if(!system("DISPLAY=:0 /usr/bin/xset dpms force on"))
-		printf("System is not available\n");
 }
 
 static void idle_calibration(void)

--- a/src/calibrate/calibrate.cpp
+++ b/src/calibrate/calibrate.cpp
@@ -351,6 +351,12 @@ static void backlight_calibration(void)
 		lower_backlight();
 		sleep(1);
 	}
+	printf(_("Calibrating idle\n"));
+	if(!system("DISPLAY=:0 /usr/bin/xset dpms force off"))
+		printf("System is not available\n");
+	one_measurement(15, 15, NULL);
+	if(!system("DISPLAY=:0 /usr/bin/xset dpms force on"))
+		printf("System is not available\n");
 }
 
 static void idle_calibration(void)

--- a/src/calibrate/calibrate.h
+++ b/src/calibrate/calibrate.h
@@ -25,7 +25,7 @@
 #ifndef __INCLUDE_GUARD_CALIBRATE_H
 #define __INCLUDE_GUARD_CALIBRATE_H
 
-extern void one_measurement(int seconds, int sample_interval, char *workload);
+extern void one_measurement(int seconds, int sample_interval, const char *workload);
 extern void calibrate(void);
 
 

--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -64,13 +64,6 @@ void abstract_cpu::account_freq(uint64_t freq, uint64_t duration)
 		if (!state)
 			return;
 
-		state->line_level = 0;
-		state->time_after = 0;
-		state->time_before = 0;
-		state->before_count = 0;
-		state->after_count = 0;
-		state->display_value = 0.0;
-
 		pstates.push_back(state);
 
 		state->freq = freq;
@@ -352,11 +345,6 @@ void abstract_cpu::insert_pstate(uint64_t freq, const char *human_name, uint64_t
 
 	if (!state)
 		return;
-
-	state->line_level = 0;
-	state->time_after = 0;
-	state->after_count = 0;
-	state->display_value = 0.0;
 
 	pstates.push_back(state);
 

--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -93,7 +93,7 @@ void abstract_cpu::measurement_start(void)
 {
 	unsigned int i;
 	ifstream file;
-	char filename[4096];
+	std::string filename;
 
 	last_stamp = 0;
 
@@ -110,8 +110,8 @@ void abstract_cpu::measurement_start(void)
 	old_idle = true;
 
 
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpufreq/scaling_available_frequencies", number);
-	file.open(filename, ios::in);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/scaling_available_frequencies", number);
+	file.open(filename.c_str(), ios::in);
 	if (file) {
 		file >> max_frequency;
 		file >> max_minus_one_frequency;
@@ -451,7 +451,7 @@ void abstract_cpu::change_effective_frequency(uint64_t time, uint64_t frequency)
 
 void abstract_cpu::wiggle(void)
 {
-	char filename[PATH_MAX];
+	std::string filename;
 	ifstream ifile;
 	ofstream ofile;
 	uint64_t minf,maxf;
@@ -459,40 +459,41 @@ void abstract_cpu::wiggle(void)
 
 	/* wiggle a CPU so that we have a record of it at the start and end of the perf trace */
 
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpufreq/scaling_max_freq", first_cpu);
-	ifile.open(filename, ios::in);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/scaling_max_freq", first_cpu);
+	ifile.open(filename.c_str(), ios::in);
 	ifile >> maxf;
 	ifile.close();
 
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpufreq/scaling_min_freq", first_cpu);
-	ifile.open(filename, ios::in);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/scaling_min_freq", first_cpu);
+	ifile.open(filename.c_str(), ios::in);
 	ifile >> minf;
 	ifile.close();
 
 	/* In case of the userspace governor, remember the old setspeed setting, it will be affected by wiggle */
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpufreq/scaling_setspeed", first_cpu);
-	ifile.open(filename, ios::in);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/scaling_setspeed", first_cpu);
+	ifile.open(filename.c_str(), ios::in);
 	/* Note that non-userspace governors report "<unsupported>". In that case ifile will fail and setspeed remains 0 */
 	ifile >> setspeed;
 	ifile.close();
 
-	ofile.open(filename, ios::out);
+	ofile.open(filename.c_str(), ios::out);
 	ofile << maxf;
 	ofile.close();
-	ofile.open(filename, ios::out);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/scaling_min_freq", first_cpu);
+	ofile.open(filename.c_str(), ios::out);
 	ofile << minf;
 	ofile.close();
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpufreq/scaling_max_freq", first_cpu);
-	ofile.open(filename, ios::out);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/scaling_max_freq", first_cpu);
+	ofile.open(filename.c_str(), ios::out);
 	ofile << minf;
 	ofile.close();
-	ofile.open(filename, ios::out);
+	ofile.open(filename.c_str(), ios::out);
 	ofile << maxf;
 	ofile.close();
 
 	if (setspeed != 0) {
-		snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpufreq/scaling_setspeed", first_cpu);
-		ofile.open(filename, ios::out);
+		filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/scaling_setspeed", first_cpu);
+		ofile.open(filename.c_str(), ios::out);
 		ofile << setspeed;
 		ofile.close();
 	}

--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -47,7 +47,7 @@ abstract_cpu::~abstract_cpu()
 
 void abstract_cpu::account_freq(uint64_t freq, uint64_t duration)
 {
-	struct frequency *state = NULL;
+	class frequency *state = NULL;
 	unsigned int i;
 
 	for (i = 0; i < pstates.size(); i++) {
@@ -59,21 +59,26 @@ void abstract_cpu::account_freq(uint64_t freq, uint64_t duration)
 
 
 	if (!state) {
-		state = new(std::nothrow) struct frequency;
+		state = new(std::nothrow) class frequency;
 
 		if (!state)
 			return;
 
-		memset(state, 0, sizeof(*state));
+		state->line_level = 0;
+		state->time_after = 0;
+		state->time_before = 0;
+		state->before_count = 0;
+		state->after_count = 0;
+		state->display_value = 0.0;
 
 		pstates.push_back(state);
 
 		state->freq = freq;
-		hz_to_human(freq, state->human_name);
+		state->human_name = hz_to_human(freq);
 		if (freq == 0)
-			pt_strcpy(state->human_name, _("Idle"));
+			state->human_name = _("Idle");
 		if (is_turbo(freq, max_frequency, max_minus_one_frequency))
-			pt_strcpy(state->human_name, _("Turbo Mode"));
+			state->human_name = _("Turbo Mode");
 
 		state->after_count = 1;
 	}
@@ -159,16 +164,16 @@ void abstract_cpu::measurement_end(void)
 				if (!state)
 					continue;
 
-				update_cstate( state->linux_name, state->human_name, state->usage_before, state->duration_before, state->before_count);
-				finalize_cstate(state->linux_name,                   state->usage_after,  state->duration_after,  state->after_count);
+				update_cstate( state->linux_name.c_str(), state->human_name.c_str(), state->usage_before, state->duration_before, state->before_count);
+				finalize_cstate(state->linux_name.c_str(),                   state->usage_after,  state->duration_after,  state->after_count);
 			}
 			for (j = 0; j < children[i]->pstates.size(); j++) {
-				struct frequency *state;
+				class frequency *state;
 				state = children[i]->pstates[j];
 				if (!state)
 					continue;
 
-				update_pstate(  state->freq, state->human_name, state->time_before, state->before_count);
+				update_pstate(  state->freq, state->human_name.c_str(), state->time_before, state->before_count);
 				finalize_pstate(state->freq,                    state->time_after,  state->after_count);
 			}
 		}
@@ -197,18 +202,25 @@ void abstract_cpu::insert_cstate(const char *linux_name, const char *human_name,
 	if (!state)
 		return;
 
-	memset(state, 0, sizeof(*state));
+	state->usage_before = 0;
+	state->usage_after = 0;
+	state->usage_delta = 0;
+	state->duration_before = 0;
+	state->duration_after = 0;
+	state->duration_delta = 0;
+	state->before_count = 0;
+	state->after_count = 0;
 
 	cstates.push_back(state);
 
-	pt_strcpy(state->linux_name, linux_name);
-	pt_strcpy(state->human_name, human_name);
+	state->linux_name = linux_name;
+	state->human_name = human_name;
 
 	state->line_level = -1;
 
 	c = human_name;
 	while (*c) {
-		if (strcmp(linux_name, "active")==0) {
+		if (state->linux_name == "active") {
 			state->line_level = LEVEL_C0;
 			break;
 		}
@@ -217,10 +229,12 @@ void abstract_cpu::insert_cstate(const char *linux_name, const char *human_name,
 			if(*(c+1) != '-'){
 				int greater_line_level = strtoull(c, NULL, 10);
 				for(unsigned int pos = 0; pos < cstates.size(); pos++){
-					if(*c == cstates[pos]->human_name[1]){
-						if(*(c+1) != cstates[pos]->human_name[2]){
-							greater_line_level = max(greater_line_level, cstates[pos]->line_level);
-							state->line_level = greater_line_level + 1;
+					if (cstates[pos]->human_name.length() > 2) {
+						if(*c == cstates[pos]->human_name[1]){
+							if(*(c+1) != cstates[pos]->human_name[2]){
+								greater_line_level = max(greater_line_level, cstates[pos]->line_level);
+								state->line_level = greater_line_level + 1;
+							}
 						}
 					}
 				}
@@ -254,7 +268,7 @@ void abstract_cpu::finalize_cstate(const char *linux_name, uint64_t usage, uint6
 	struct idle_state *state = NULL;
 
 	for (i = 0; i < cstates.size(); i++) {
-		if (strcmp(linux_name, cstates[i]->linux_name) == 0) {
+		if (cstates[i]->linux_name == linux_name) {
 			state = cstates[i];
 			break;
 		}
@@ -276,7 +290,7 @@ void abstract_cpu::update_cstate(const char *linux_name, const char *human_name,
 	struct idle_state *state = NULL;
 
 	for (i = 0; i < cstates.size(); i++) {
-		if (strcmp(linux_name, cstates[i]->linux_name) == 0) {
+		if (cstates[i]->linux_name == linux_name) {
 			state = cstates[i];
 			break;
 		}
@@ -332,19 +346,22 @@ int abstract_cpu::has_pstate_level(int level)
 
 void abstract_cpu::insert_pstate(uint64_t freq, const char *human_name, uint64_t duration, int count)
 {
-	struct frequency *state;
+	class frequency *state;
 
-	state = new(std::nothrow) struct frequency;
+	state = new(std::nothrow) class frequency;
 
 	if (!state)
 		return;
 
-	memset(state, 0, sizeof(*state));
+	state->line_level = 0;
+	state->time_after = 0;
+	state->after_count = 0;
+	state->display_value = 0.0;
 
 	pstates.push_back(state);
 
 	state->freq = freq;
-	pt_strcpy(state->human_name, human_name);
+	state->human_name = human_name;
 
 
 	state->time_before = duration;
@@ -354,7 +371,7 @@ void abstract_cpu::insert_pstate(uint64_t freq, const char *human_name, uint64_t
 void abstract_cpu::finalize_pstate(uint64_t freq, uint64_t duration, int count)
 {
 	unsigned int i;
-	struct frequency *state = NULL;
+	class frequency *state = NULL;
 
 	for (i = 0; i < pstates.size(); i++) {
 		if (freq == pstates[i]->freq) {
@@ -375,7 +392,7 @@ void abstract_cpu::finalize_pstate(uint64_t freq, uint64_t duration, int count)
 void abstract_cpu::update_pstate(uint64_t freq, const char *human_name, uint64_t duration, int count)
 {
 	unsigned int i;
-	struct frequency *state = NULL;
+	class frequency *state = NULL;
 
 	for (i = 0; i < pstates.size(); i++) {
 		if (freq == pstates[i]->freq) {

--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -157,8 +157,8 @@ void abstract_cpu::measurement_end(void)
 				if (!state)
 					continue;
 
-				update_cstate( state->linux_name.c_str(), state->human_name.c_str(), state->usage_before, state->duration_before, state->before_count);
-				finalize_cstate(state->linux_name.c_str(),                   state->usage_after,  state->duration_after,  state->after_count);
+				update_cstate( state->linux_name, state->human_name, state->usage_before, state->duration_before, state->before_count);
+				finalize_cstate(state->linux_name,                   state->usage_after,  state->duration_after,  state->after_count);
 			}
 			for (j = 0; j < children[i]->pstates.size(); j++) {
 				class frequency *state;
@@ -166,7 +166,7 @@ void abstract_cpu::measurement_end(void)
 				if (!state)
 					continue;
 
-				update_pstate(  state->freq, state->human_name.c_str(), state->time_before, state->before_count);
+				update_pstate(  state->freq, state->human_name, state->time_before, state->before_count);
 				finalize_pstate(state->freq,                    state->time_after,  state->after_count);
 			}
 		}
@@ -185,7 +185,7 @@ void abstract_cpu::measurement_end(void)
 	}
 }
 
-void abstract_cpu::insert_cstate(const char *linux_name, const char *human_name, uint64_t usage, uint64_t duration, int count, int level)
+void abstract_cpu::insert_cstate(const string &linux_name, const string &human_name, uint64_t usage, uint64_t duration, int count, int level)
 {
 	struct idle_state *state;
 	const char *c;
@@ -211,7 +211,7 @@ void abstract_cpu::insert_cstate(const char *linux_name, const char *human_name,
 
 	state->line_level = -1;
 
-	c = human_name;
+	c = human_name.c_str();
 	while (*c) {
 		if (state->linux_name == "active") {
 			state->line_level = LEVEL_C0;
@@ -238,7 +238,7 @@ void abstract_cpu::insert_cstate(const char *linux_name, const char *human_name,
 	}
 
 	/* some architectures (ARM) don't have good numbers in their human name.. fall back to the linux name for those */
-	c = linux_name;
+	c = linux_name.c_str();
 	while (*c && state->line_level < 0) {
 		if (*c >= '0' && *c <='9') {
 			state->line_level = strtoull(c, NULL, 10);
@@ -255,7 +255,7 @@ void abstract_cpu::insert_cstate(const char *linux_name, const char *human_name,
 	state->before_count = count;
 }
 
-void abstract_cpu::finalize_cstate(const char *linux_name, uint64_t usage, uint64_t duration, int count)
+void abstract_cpu::finalize_cstate(const string &linux_name, uint64_t usage, uint64_t duration, int count)
 {
 	unsigned int i;
 	struct idle_state *state = NULL;
@@ -277,7 +277,7 @@ void abstract_cpu::finalize_cstate(const char *linux_name, uint64_t usage, uint6
 	state->after_count += count;
 }
 
-void abstract_cpu::update_cstate(const char *linux_name, const char *human_name, uint64_t usage, uint64_t duration, int count, int level)
+void abstract_cpu::update_cstate(const string &linux_name, const string &human_name, uint64_t usage, uint64_t duration, int count, int level)
 {
 	unsigned int i;
 	struct idle_state *state = NULL;
@@ -297,7 +297,6 @@ void abstract_cpu::update_cstate(const char *linux_name, const char *human_name,
 	state->usage_before += usage;
 	state->duration_before += duration;
 	state->before_count += count;
-
 }
 
 int abstract_cpu::has_cstate_level(int level)
@@ -337,7 +336,7 @@ int abstract_cpu::has_pstate_level(int level)
 
 
 
-void abstract_cpu::insert_pstate(uint64_t freq, const char *human_name, uint64_t duration, int count)
+void abstract_cpu::insert_pstate(uint64_t freq, const string &human_name, uint64_t duration, int count)
 {
 	class frequency *state;
 
@@ -377,7 +376,7 @@ void abstract_cpu::finalize_pstate(uint64_t freq, uint64_t duration, int count)
 
 }
 
-void abstract_cpu::update_pstate(uint64_t freq, const char *human_name, uint64_t duration, int count)
+void abstract_cpu::update_pstate(uint64_t freq, const string &human_name, uint64_t duration, int count)
 {
 	unsigned int i;
 	class frequency *state = NULL;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -86,14 +86,14 @@ static class abstract_cpu * new_package(int package, int cpu, const std::string 
 	cpudev = new class cpudevice(_("cpu package"), packagename.c_str(), ret);
 	all_devices.push_back(cpudev);
 
-	packagename = std::format("package-{}", cpu);
+	packagename = pt_format(_("package-{}"), cpu);
 	cpu_rapl_dev = new class cpu_rapl_device(cpudev, _("cpu rapl package"), packagename.c_str(), ret);
 	if (cpu_rapl_dev->device_present())
 		all_devices.push_back(cpu_rapl_dev);
 	else
 		delete cpu_rapl_dev;
 
-	packagename = std::format("package-{}", cpu);
+	packagename = pt_format(_("package-{}"), cpu);
 	dram_rapl_dev = new class dram_rapl_device(cpudev, _("dram rapl package"), packagename.c_str(), ret);
 	if (dram_rapl_dev->device_present())
 		all_devices.push_back(dram_rapl_dev);

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -446,7 +446,6 @@ static int get_cstates_num(void)
 
 void report_display_cpu_cstates(void)
 {
-	char tmp_num[50];
 	unsigned int package, core, cpu;
 	int line, cstates_num, title=0, core_num=0;
 	class abstract_cpu *_package, *_core = NULL, * _cpu;
@@ -566,15 +565,13 @@ void report_display_cpu_cstates(void)
 							if (strcmp(core_type, "Core") == 0 ) {
 								core_data[idx2]="";
 								idx2+=1;
-								snprintf(tmp_num, sizeof(tmp_num), __("Core %d"), _core->get_number());
-								core_data[idx2]=string(tmp_num);
+								core_data[idx2]=pt_format(__("Core {}"), _core->get_number());
 								idx2+=1;
 								core_num+=1;
 							} else {
 								core_data[idx2]="";
 								idx2+=1;
-								snprintf(tmp_num, sizeof(tmp_num), __("GPU %d"), _core->get_number());
-								core_data[idx2]=string(tmp_num);
+								core_data[idx2]=pt_format(__("GPU {}"), _core->get_number());
 								idx2+=1;
 							}
 						}
@@ -652,7 +649,6 @@ void report_display_cpu_cstates(void)
 
 void report_display_cpu_pstates(void)
 {
-	char tmp_num[50];
 	unsigned int package, core, cpu;
 	int line, title=0;
 	class abstract_cpu *_package, *_core = NULL, * _cpu;
@@ -770,8 +766,7 @@ void report_display_cpu_pstates(void)
 					if (line == LEVEL_HEADER) {
 						core_data[idx2]="";
 						idx2+=1;
-						snprintf(tmp_num, sizeof(tmp_num), __("Core %d"), _core->get_number());
-						core_data[idx2]=string(tmp_num);
+						core_data[idx2]=pt_format(__("Core {}"), _core->get_number());
 						idx2+=1;
 					} else {
 						tmp_str=_core->fill_pstate_name(line);
@@ -790,8 +785,7 @@ void report_display_cpu_pstates(void)
 						continue;
 
 					if (line == LEVEL_HEADER) {
-						snprintf(tmp_num, sizeof(tmp_num), __("CPU %d"), _cpu->get_number());
-						cpu_data[idx3] = string(tmp_num);
+						cpu_data[idx3] = pt_format(__("CPU {}"), _cpu->get_number());
 						idx3+=1;
 						continue;
 					}

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -381,7 +381,7 @@ static std::string fill_state_name(class abstract_cpu *acpu, int state, int line
 }
 
 static std::string fill_state_line(class abstract_cpu *acpu, int state, int line,
-					const char *sep = "")
+					const string &sep = "")
 {
 	switch (state) {
 		case PSTATE:
@@ -449,7 +449,7 @@ void report_display_cpu_cstates(void)
 	unsigned int package, core, cpu;
 	int line, cstates_num, title=0, core_num=0;
 	class abstract_cpu *_package, *_core = NULL, * _cpu;
-	const char* core_type = NULL;
+	std::string core_type;
 
 	cstates_num = get_cstates_num();
 	/* div attr css_class and css_id */
@@ -500,8 +500,8 @@ void report_display_cpu_cstates(void)
 			if (!_core)
 				continue;
 			core_type = _core->get_type();
-			if (core_type != NULL)
-				if (strcmp(core_type, "Core") == 0 )
+			if (!core_type.empty())
+				if (core_type == "Core")
 					num_cores+=1;
 
 			for (cpu = 0; cpu < _core->children.size(); cpu++) {
@@ -561,13 +561,12 @@ void report_display_cpu_cstates(void)
 						* for translation decision making for the reports.
 						* */
 						core_type = _core->get_type();
-						if (core_type != NULL) {
-							if (strcmp(core_type, "Core") == 0 ) {
+						if (!core_type.empty()) {
+							if (core_type == "Core") {
 								core_data[idx2]="";
 								idx2+=1;
 								core_data[idx2]=pt_format(__("Core {}"), _core->get_number());
 								idx2+=1;
-								core_num+=1;
 							} else {
 								core_data[idx2]="";
 								idx2+=1;
@@ -653,7 +652,7 @@ void report_display_cpu_pstates(void)
 	int line, title=0;
 	class abstract_cpu *_package, *_core = NULL, * _cpu;
 	unsigned int i, pstates_num;
-	const char* core_type = NULL;
+	std::string core_type;
 
 	/* div attr css_class and css_id */
 	tag_attr div_attr;
@@ -712,8 +711,8 @@ void report_display_cpu_pstates(void)
 				continue;
 
 			core_type = _core->get_type();
-			if (core_type != NULL)
-				if (strcmp(core_type, "Core") == 0 )
+			if (!core_type.empty())
+				if (core_type == "Core")
 					num_cores+=1;
 
 			for (cpu = 0; cpu < _core->children.size(); cpu++) {

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -536,8 +536,7 @@ void report_display_cpu_cstates(void)
 					if (first_core) {
 						pkg_data[idx1]=__("Package");
 						idx1+=1;
-						sprintf(tmp_num,"%d",  _package->get_number());
-						pkg_data[idx1]= string(tmp_num);
+						pkg_data[idx1]=std::to_string(_package->get_number());
 						idx1+=1;
 					}
 				} else if (first_core) {
@@ -601,8 +600,7 @@ void report_display_cpu_cstates(void)
 					if (line == LEVEL_HEADER) {
 						cpu_data[idx3] = __("CPU");
 						idx3+=1;
-						sprintf(tmp_num,"%d",_cpu->get_number());
-						cpu_data[idx3]=string(tmp_num);
+						cpu_data[idx3]=std::to_string(_cpu->get_number());
 						idx3+=1;
 						continue;
 					}
@@ -757,8 +755,7 @@ void report_display_cpu_pstates(void)
 					if (line == LEVEL_HEADER) {
 						pkg_data[idx1]=__("Package");
 						idx1+=1;
-						sprintf(tmp_num,"%d",  _package->get_number());
-						pkg_data[idx1]= string(tmp_num);
+						pkg_data[idx1]=std::to_string(_package->get_number());
 						idx1+=1;
 					} else {
 						tmp_str=_package->fill_pstate_name(line);
@@ -779,10 +776,10 @@ void report_display_cpu_pstates(void)
 						core_data[idx2]=string(tmp_num);
 						idx2+=1;
 					} else {
-						tmp_str=string(_core->fill_pstate_name(line).c_str());
+						tmp_str=_core->fill_pstate_name(line);
 						core_data[idx2]= (tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx2+=1;
-						tmp_str=string(_core->fill_pstate_line(line).c_str());
+						tmp_str=_core->fill_pstate_line(line);
 						core_data[idx2]= (tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx2+=1;
 					}
@@ -802,13 +799,13 @@ void report_display_cpu_pstates(void)
 					}
 
 					if (first_cpu) {
-						tmp_str=string(_cpu->fill_pstate_name(line).c_str());
+						tmp_str=_cpu->fill_pstate_name(line);
 						cpu_data[idx3]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx3+=1;
 						first_cpu = false;
 					}
 
-					tmp_str=string(_cpu->fill_pstate_line(line).c_str());
+					tmp_str=_cpu->fill_pstate_line(line);
 					cpu_data[idx3]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 					idx3+=1;
 				}
@@ -839,7 +836,6 @@ void report_display_cpu_pstates(void)
 void impl_w_display_cpu_states(int state)
 {
 	WINDOW *win;
-	char buffer[128];
 	char linebuf[1024];
 	unsigned int package, core, cpu;
 	int line, loop, cstates_num, pstates_num;
@@ -891,7 +887,6 @@ void impl_w_display_cpu_states(int state)
 				if (!has_state_level(_package, state, line))
 					continue;
 
-				buffer[0] = 0;
 				if (first_pkg == 0) {
 					strcat(linebuf, fill_state_name(_package, state, line).c_str());
 					expand_string(linebuf, ctr + 10);
@@ -904,7 +899,6 @@ void impl_w_display_cpu_states(int state)
 				ctr += strlen("| ");
 
 				if (!_core->can_collapse()) {
-					buffer[0] = 0;
 					strcat(linebuf, fill_state_name(_core, state, line).c_str());
 					expand_string(linebuf, ctr + 10);
 					strcat(linebuf, fill_state_line(_core, state, line).c_str());
@@ -927,8 +921,7 @@ void impl_w_display_cpu_states(int state)
 						first = 0;
 						ctr += 12;
 					}
-					buffer[0] = 0;
-					strcat(linebuf, fill_state_line(_cpu, state, line, buffer).c_str());
+					strcat(linebuf, fill_state_line(_cpu, state, line).c_str());
 					ctr += 10;
 					expand_string(linebuf, ctr);
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -58,15 +58,15 @@ class perf_power_bundle: public perf_bundle
 };
 
 
-static class abstract_cpu * new_package(int package, int cpu, char * vendor, int family, int model)
+static class abstract_cpu * new_package(int package, int cpu, const std::string &vendor, int family, int model)
 {
 	class abstract_cpu *ret = NULL;
 	class cpudevice *cpudev;
 	class cpu_rapl_device *cpu_rapl_dev;
 	class dram_rapl_device *dram_rapl_dev;
 
-	char packagename[128];
-	if (strcmp(vendor, "GenuineIntel") == 0)
+	std::string packagename;
+	if (vendor == "GenuineIntel")
 		if (family == 6)
 			if (is_supported_intel_cpu(model, cpu)) {
 				ret = new class nhm_package(model);
@@ -82,19 +82,19 @@ static class abstract_cpu * new_package(int package, int cpu, char * vendor, int
 	ret->set_type("Package");
 	ret->childcount = 0;
 
-	snprintf(packagename, sizeof(packagename), _("cpu package %i"), cpu);
-	cpudev = new class cpudevice(_("cpu package"), packagename, ret);
+	packagename = pt_format(_("cpu package {}"), cpu);
+	cpudev = new class cpudevice(_("cpu package"), packagename.c_str(), ret);
 	all_devices.push_back(cpudev);
 
-	snprintf(packagename, sizeof(packagename), _("package-%i"), cpu);
-	cpu_rapl_dev = new class cpu_rapl_device(cpudev, _("cpu rapl package"), packagename, ret);
+	packagename = std::format("package-{}", cpu);
+	cpu_rapl_dev = new class cpu_rapl_device(cpudev, _("cpu rapl package"), packagename.c_str(), ret);
 	if (cpu_rapl_dev->device_present())
 		all_devices.push_back(cpu_rapl_dev);
 	else
 		delete cpu_rapl_dev;
 
-	snprintf(packagename, sizeof(packagename), _("package-%i"), cpu);
-	dram_rapl_dev = new class dram_rapl_device(cpudev, _("dram rapl package"), packagename, ret);
+	packagename = std::format("package-{}", cpu);
+	dram_rapl_dev = new class dram_rapl_device(cpudev, _("dram rapl package"), packagename.c_str(), ret);
 	if (dram_rapl_dev->device_present())
 		all_devices.push_back(dram_rapl_dev);
 	else
@@ -103,11 +103,11 @@ static class abstract_cpu * new_package(int package, int cpu, char * vendor, int
 	return ret;
 }
 
-static class abstract_cpu * new_core(int core, int cpu, char * vendor, int family, int model)
+static class abstract_cpu * new_core(int core, int cpu, const std::string &vendor, int family, int model)
 {
 	class abstract_cpu *ret = NULL;
 
-	if (strcmp(vendor, "GenuineIntel") == 0)
+	if (vendor == "GenuineIntel")
 		if (family == 6)
 			if (is_supported_intel_cpu(model, cpu)) {
 				ret = new class nhm_core(model);
@@ -137,11 +137,11 @@ static class abstract_cpu * new_i965_gpu(void)
 	return ret;
 }
 
-static class abstract_cpu * new_cpu(int number, char * vendor, int family, int model)
+static class abstract_cpu * new_cpu(int number, const std::string &vendor, int family, int model)
 {
 	class abstract_cpu * ret = NULL;
 
-	if (strcmp(vendor, "GenuineIntel") == 0)
+	if (vendor == "GenuineIntel")
 		if (family == 6)
 			if (is_supported_intel_cpu(model, number)) {
 				ret = new class nhm_cpu;
@@ -162,16 +162,14 @@ static class abstract_cpu * new_cpu(int number, char * vendor, int family, int m
 
 
 
-static void handle_one_cpu(unsigned int number, char *vendor, int family, int model)
+static void handle_one_cpu(unsigned int number, const std::string &vendor, int family, int model)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 	unsigned int package_number = 0;
 	unsigned int core_number = 0;
 	class abstract_cpu *package, *core, *cpu;
 
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/topology/core_id", number);
-	file.open(filename, ios::in);
+	file.open(std::format("/sys/devices/system/cpu/cpu{}/topology/core_id", number), ios::in);
 	if (file) {
 		file >> core_number;
 		if (core_number == (unsigned int) -1)
@@ -179,8 +177,7 @@ static void handle_one_cpu(unsigned int number, char *vendor, int family, int mo
 		file.close();
 	}
 
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/topology/physical_package_id", number);
-	file.open(filename, ios::in);
+	file.open(std::format("/sys/devices/system/cpu/cpu{}/topology/physical_package_id", number), ios::in);
 	if (file) {
 		file >> package_number;
 		if (package_number == (unsigned int) -1)
@@ -200,6 +197,7 @@ static void handle_one_cpu(unsigned int number, char *vendor, int family, int mo
 	package = system_level.children[package_number];
 	package->parent = &system_level;
 
+
 	if (package->children.size() <= core_number)
 		package->children.resize(core_number + 1, NULL);
 
@@ -213,6 +211,7 @@ static void handle_one_cpu(unsigned int number, char *vendor, int family, int mo
 
 	if (core->children.size() <= number)
 		core->children.resize(number + 1, NULL);
+
 	if (!core->children[number]) {
 		core->children[number] = new_cpu(number, vendor, family, model);
 		core->childcount++;
@@ -252,7 +251,7 @@ void enumerate_cpus(void)
 	char line[4096];
 
 	int number = -1;
-	char vendor[128];
+	std::string vendor;
 	int family = 0;
 	int model = 0;
 
@@ -261,7 +260,6 @@ void enumerate_cpus(void)
 	if (!file)
 		return;
 	/* Not all /proc/cpuinfo include "vendor_id\t". */
-	vendor[0] = '\0';
 
 	while (file) {
 
@@ -273,7 +271,7 @@ void enumerate_cpus(void)
 				c++;
 				if (*c == ' ')
 					c++;
-				pt_strcpy(vendor, c);
+				vendor = c;
 			}
 		}
 		if (strncmp(line, "processor\t",10) == 0) {

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -369,28 +369,28 @@ static int has_state_level(class abstract_cpu *acpu, int state, int line)
 	return 0;
 }
 
-static const char * fill_state_name(class abstract_cpu *acpu, int state, int line, char *buf)
+static std::string fill_state_name(class abstract_cpu *acpu, int state, int line)
 {
 	switch (state) {
 		case PSTATE:
-			return acpu->fill_pstate_name(line, buf);
+			return acpu->fill_pstate_name(line);
 			break;
 		case CSTATE:
-			return acpu->fill_cstate_name(line, buf);
+			return acpu->fill_cstate_name(line);
 			break;
 	}
 	return "-EINVAL";
 }
 
-static const char * fill_state_line(class abstract_cpu *acpu, int state, int line,
-					char *buf, const char *sep = "")
+static std::string fill_state_line(class abstract_cpu *acpu, int state, int line,
+					const char *sep = "")
 {
 	switch (state) {
 		case PSTATE:
-			return acpu->fill_pstate_line(line, buf);
+			return acpu->fill_pstate_line(line);
 			break;
 		case CSTATE:
-			return acpu->fill_cstate_line(line, buf, sep);
+			return acpu->fill_cstate_line(line, sep);
 			break;
 	}
 	return "-EINVAL";
@@ -448,7 +448,7 @@ static int get_cstates_num(void)
 
 void report_display_cpu_cstates(void)
 {
-	char buffer[512], buffer2[512], tmp_num[50];
+	char tmp_num[50];
 	unsigned int package, core, cpu;
 	int line, cstates_num, title=0, core_num=0;
 	class abstract_cpu *_package, *_core = NULL, * _cpu;
@@ -532,8 +532,6 @@ void report_display_cpu_cstates(void)
 				bool first_cpu = true;
 				if (!_package->has_cstate_level(line))
 				continue;
-				buffer[0] = 0;
-				buffer2[0] = 0;
 				if (line == LEVEL_HEADER) {
 					if (first_core) {
 						pkg_data[idx1]=__("Package");
@@ -543,18 +541,16 @@ void report_display_cpu_cstates(void)
 						idx1+=1;
 					}
 				} else if (first_core) {
-					tmp_str=string(_package->fill_cstate_name(line, buffer));
+					tmp_str=_package->fill_cstate_name(line);
 					pkg_data[idx1]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 					idx1+=1;
-					tmp_str=string(_package->fill_cstate_line(line, buffer2));
+					tmp_str=_package->fill_cstate_line(line);
 					pkg_data[idx1]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 					idx1+=1;
 				}
 
 				/* *** CORE STARTS *** */
 				if (!_core->can_collapse()) {
-					buffer[0] = 0;
-					buffer2[0] = 0;
 					
 					/*
 						* Patch for compatibility with Ryzen processors
@@ -588,10 +584,10 @@ void report_display_cpu_cstates(void)
 					} else {
 
 						
-						tmp_str=string(_core->fill_cstate_name(line, buffer));
+						tmp_str=_core->fill_cstate_name(line);
 						core_data[idx2]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx2+=1;
-						tmp_str=string(_core->fill_cstate_line(line, buffer2));
+						tmp_str=_core->fill_cstate_line(line);
 						core_data[idx2]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx2+=1;
 					}
@@ -613,18 +609,17 @@ void report_display_cpu_cstates(void)
 
 					if (first_cpu) {
 						title+=1;
-						cpu_data[idx3]=(string(_cpu->fill_cstate_name(line, buffer)));
+						cpu_data[idx3]=_cpu->fill_cstate_name(line);
 						idx3+=1;
 						first_cpu = false;
 					}
 
-					buffer[0] = 0;
-					tmp_str=string(_cpu->fill_cstate_percentage(line, buffer));
+					tmp_str=_cpu->fill_cstate_percentage(line);
 					cpu_data[idx3]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 					idx3+=1;
 
 					if (line != LEVEL_C0){
-						tmp_str=string(_cpu->fill_cstate_time(line, buffer));
+						tmp_str=_cpu->fill_cstate_time(line);
 						cpu_data[idx3]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx3+=1;
 					} else {
@@ -661,7 +656,7 @@ void report_display_cpu_cstates(void)
 
 void report_display_cpu_pstates(void)
 {
-	char buffer[512], buffer2[512], tmp_num[50];
+	char tmp_num[50];
 	unsigned int package, core, cpu;
 	int line, title=0;
 	class abstract_cpu *_package, *_core = NULL, * _cpu;
@@ -758,8 +753,6 @@ void report_display_cpu_pstates(void)
 				if (!_package->has_pstate_level(line))
 					continue;
 
-				buffer[0] = 0;
-				buffer2[0] = 0;
 				if (first_core) {
 					if (line == LEVEL_HEADER) {
 						pkg_data[idx1]=__("Package");
@@ -768,10 +761,10 @@ void report_display_cpu_pstates(void)
 						pkg_data[idx1]= string(tmp_num);
 						idx1+=1;
 					} else {
-						tmp_str=string(_package->fill_pstate_name(line, buffer));
+						tmp_str=_package->fill_pstate_name(line);
 						pkg_data[idx1]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx1+=1;
-						tmp_str=string(_package->fill_pstate_line(line, buffer2));
+						tmp_str=_package->fill_pstate_line(line);
 						pkg_data[idx1]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx1+=1;
 					}
@@ -779,8 +772,6 @@ void report_display_cpu_pstates(void)
 
 
 				if (!_core->can_collapse()) {
-					buffer[0] = 0;
-					buffer2[0] = 0;
 					if (line == LEVEL_HEADER) {
 						core_data[idx2]="";
 						idx2+=1;
@@ -788,10 +779,10 @@ void report_display_cpu_pstates(void)
 						core_data[idx2]=string(tmp_num);
 						idx2+=1;
 					} else {
-						tmp_str=string(_core->fill_pstate_name(line, buffer));
+						tmp_str=string(_core->fill_pstate_name(line).c_str());
 						core_data[idx2]= (tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx2+=1;
-						tmp_str=string(_core->fill_pstate_line(line, buffer2));
+						tmp_str=string(_core->fill_pstate_line(line).c_str());
 						core_data[idx2]= (tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx2+=1;
 					}
@@ -799,7 +790,6 @@ void report_display_cpu_pstates(void)
 
 				/* CPU */
 				for (cpu = 0; cpu < _core->children.size(); cpu++) {
-					buffer[0] = 0;
 					_cpu = _core->children[cpu];
 					if (!_cpu)
 						continue;
@@ -812,14 +802,13 @@ void report_display_cpu_pstates(void)
 					}
 
 					if (first_cpu) {
-						tmp_str=string(_cpu->fill_pstate_name(line, buffer));
+						tmp_str=string(_cpu->fill_pstate_name(line).c_str());
 						cpu_data[idx3]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 						idx3+=1;
 						first_cpu = false;
 					}
 
-					buffer[0] = 0;
-					tmp_str=string(_cpu->fill_pstate_line(line, buffer));
+					tmp_str=string(_cpu->fill_pstate_line(line).c_str());
 					cpu_data[idx3]=(tmp_str=="" ? "&nbsp;" : tmp_str);
 					idx3+=1;
 				}
@@ -904,9 +893,9 @@ void impl_w_display_cpu_states(int state)
 
 				buffer[0] = 0;
 				if (first_pkg == 0) {
-					strcat(linebuf, fill_state_name(_package, state, line, buffer));
+					strcat(linebuf, fill_state_name(_package, state, line).c_str());
 					expand_string(linebuf, ctr + 10);
-					strcat(linebuf, fill_state_line(_package, state, line, buffer));
+					strcat(linebuf, fill_state_line(_package, state, line).c_str());
 				}
 				ctr += 20;
 				expand_string(linebuf, ctr);
@@ -916,9 +905,9 @@ void impl_w_display_cpu_states(int state)
 
 				if (!_core->can_collapse()) {
 					buffer[0] = 0;
-					strcat(linebuf, fill_state_name(_core, state, line, buffer));
+					strcat(linebuf, fill_state_name(_core, state, line).c_str());
 					expand_string(linebuf, ctr + 10);
-					strcat(linebuf, fill_state_line(_core, state, line, buffer));
+					strcat(linebuf, fill_state_line(_core, state, line).c_str());
 					ctr += 20;
 					expand_string(linebuf, ctr);
 
@@ -932,13 +921,14 @@ void impl_w_display_cpu_states(int state)
 						continue;
 
 					if (first == 1) {
-						strcat(linebuf, fill_state_name(_cpu, state, line, buffer));
+						std::string str = fill_state_name(_cpu, state, line);
+						strcat(linebuf, str.c_str());
 						expand_string(linebuf, ctr + 10);
 						first = 0;
 						ctr += 12;
 					}
 					buffer[0] = 0;
-					strcat(linebuf, fill_state_line(_cpu, state, line, buffer));
+					strcat(linebuf, fill_state_line(_cpu, state, line, buffer).c_str());
 					ctr += 10;
 					expand_string(linebuf, ctr);
 
@@ -1076,4 +1066,8 @@ void clear_all_cpus(void)
 		delete all_cpus[i];
 	}
 	all_cpus.clear();
+}
+
+frequency::frequency()
+{
 }

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -94,7 +94,7 @@ public:
 	uint64_t	total_stamp;
 	int	number;
 	int	childcount;
-	const char*    name;
+	std::string    name;
 	bool	idle, old_idle, has_intel_MSR;
 	uint64_t	current_frequency;
 	uint64_t	effective_frequency;
@@ -111,9 +111,9 @@ public:
 	int	get_first_cpu() { return first_cpu; }
 	void	set_number(int _number, int cpu) {this->number = _number; this->first_cpu = cpu;};
 	void	set_intel_MSR(bool _bool_value) {this->has_intel_MSR =  _bool_value;};
-	void	set_type(const char* _name) {this->name = _name;};
+	void	set_type(const std::string& _name) {this->name = _name;};
 	int	get_number(void) { return number; };
-	const char* get_type(void) { return name; };
+	std::string get_type(void) { return name; };
 
 	virtual void	measurement_start(void);
 	virtual void	measurement_end(void);
@@ -123,21 +123,21 @@ public:
 
 	/* C state related methods */
 
-	void		insert_cstate(const char *linux_name, const char *human_name, uint64_t usage, uint64_t duration, int count, int level = -1);
-	void		update_cstate(const char *linux_name, const char *human_name, uint64_t usage, uint64_t duration, int count, int level = -1);
-	void		finalize_cstate(const char *linux_name, uint64_t usage, uint64_t duration, int count);
+	void		insert_cstate(const std::string &linux_name, const std::string &human_name, uint64_t usage, uint64_t duration, int count, int level = -1);
+	void		update_cstate(const std::string &linux_name, const std::string &human_name, uint64_t usage, uint64_t duration, int count, int level = -1);
+	void		finalize_cstate(const std::string &linux_name, uint64_t usage, uint64_t duration, int count);
 
 	virtual int	has_cstate_level(int level);
 
-	virtual std::string  fill_cstate_line(int line_nr, const char *separator="") { return "";};
+	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="") { return "";};
 	virtual std::string  fill_cstate_percentage(int line_nr) { return ""; };
 	virtual std::string  fill_cstate_time(int line_nr) { return ""; };
 	virtual std::string  fill_cstate_name(int line_nr) { return "";};
 
 
 	/* P state related methods */
-	void		insert_pstate(uint64_t freq, const char *human_name, uint64_t duration, int count);
-	void		update_pstate(uint64_t freq, const char *human_name, uint64_t duration, int count);
+	void		insert_pstate(uint64_t freq, const std::string &human_name, uint64_t duration, int count);
+	void		update_pstate(uint64_t freq, const std::string &human_name, uint64_t duration, int count);
 	void		finalize_pstate(uint64_t freq, uint64_t duration, int count);
 
 
@@ -175,7 +175,7 @@ public:
 	virtual void	measurement_start(void);
 	virtual void	measurement_end(void);
 
-	virtual std::string  fill_cstate_line(int line_nr, const char *separator="");
+	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="");
 	virtual std::string  fill_cstate_name(int line_nr);
 	virtual std::string  fill_cstate_percentage(int line_nr);
 	virtual std::string  fill_cstate_time(int line_nr);
@@ -187,7 +187,7 @@ public:
 class cpu_core: public abstract_cpu
 {
 public:
-	virtual std::string  fill_cstate_line(int line_nr, const char *separator="");
+	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="");
 	virtual std::string  fill_cstate_name(int line_nr);
 
 	virtual std::string  fill_pstate_line(int line_nr);
@@ -201,7 +201,7 @@ class cpu_package: public abstract_cpu
 protected:
 	virtual void	freq_updated(uint64_t time);
 public:
-	virtual std::string  fill_cstate_line(int line_nr, const char *separator="");
+	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="");
 	virtual std::string  fill_cstate_name(int line_nr);
 
 	virtual std::string  fill_pstate_line(int line_nr);
@@ -214,13 +214,6 @@ extern void enumerate_cpus(void);
 extern void report_display_cpu_pstates(void);
 extern void report_display_cpu_cstates(void);
 
-
-
-extern void display_cpu_cstates(const char *start= "",
-				const char *end = "",
-				const char *linestart = "",
-				const char *separator = "| ",
-				const char *lineend = "\n");
 
 extern void w_display_cpu_cstates(void);
 extern void w_display_cpu_pstates(void);

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -43,8 +43,8 @@ class abstract_cpu;
 #define CSTATE 2
 
 struct idle_state {
-	char linux_name[16]; /* state0 etc.. cpuidle name */
-	char human_name[32];
+	std::string linux_name; /* state0 etc.. cpuidle name */
+	std::string human_name;
 
 	uint64_t usage_before;
 	uint64_t usage_after;
@@ -60,19 +60,21 @@ struct idle_state {
 	int line_level;
 };
 
-struct frequency {
-	char human_name[32];
-	int line_level;
+class frequency {
+public:
+	frequency(void);
+	std::string human_name = "";
+	int line_level = 0;
 
-	uint64_t freq;
+	uint64_t freq = 0;
 
-	uint64_t time_after;
-	uint64_t time_before;
+	uint64_t time_after = 0;
+	uint64_t time_before = 0;
 
-	int before_count;
-	int after_count;
+	int before_count = 0;
+	int after_count = 0;
 
-	double   display_value;
+	double   display_value = 0.0;
 };
 
 class abstract_cpu
@@ -127,10 +129,10 @@ public:
 
 	virtual int	has_cstate_level(int level);
 
-	virtual char *  fill_cstate_line(int line_nr, char *buffer, const char *separator="") { return buffer;};
-	virtual char *  fill_cstate_percentage(int line_nr, char *buffer) { return buffer; };
-	virtual char *  fill_cstate_time(int line_nr, char *buffer) { return buffer; };
-	virtual char *  fill_cstate_name(int line_nr, char *buffer) { return buffer;};
+	virtual std::string  fill_cstate_line(int line_nr, const char *separator="") { return "";};
+	virtual std::string  fill_cstate_percentage(int line_nr) { return ""; };
+	virtual std::string  fill_cstate_time(int line_nr) { return ""; };
+	virtual std::string  fill_cstate_name(int line_nr) { return "";};
 
 
 	/* P state related methods */
@@ -139,8 +141,8 @@ public:
 	void		finalize_pstate(uint64_t freq, uint64_t duration, int count);
 
 
-	virtual char *  fill_pstate_line(int line_nr, char *buffer) { return buffer;};
-	virtual char *  fill_pstate_name(int line_nr, char *buffer) { return buffer;};
+	virtual std::string  fill_pstate_line(int line_nr) { return "";};
+	virtual std::string  fill_pstate_name(int line_nr) { return "";};
 	virtual int	has_pstate_level(int level);
 	virtual int	has_pstates(void) { return 1; };
 
@@ -173,23 +175,23 @@ public:
 	virtual void	measurement_start(void);
 	virtual void	measurement_end(void);
 
-	virtual char *  fill_cstate_line(int line_nr, char *buffer, const char *separator="");
-	virtual char *  fill_cstate_name(int line_nr, char *buffer);
-	virtual char *  fill_cstate_percentage(int line_nr, char *buffer);
-	virtual char *  fill_cstate_time(int line_nr, char *buffer);
+	virtual std::string  fill_cstate_line(int line_nr, const char *separator="");
+	virtual std::string  fill_cstate_name(int line_nr);
+	virtual std::string  fill_cstate_percentage(int line_nr);
+	virtual std::string  fill_cstate_time(int line_nr);
 
-	virtual char *  fill_pstate_line(int line_nr, char *buffer);
-	virtual char *  fill_pstate_name(int line_nr, char *buffer);
+	virtual std::string  fill_pstate_line(int line_nr);
+	virtual std::string  fill_pstate_name(int line_nr);
 };
 
 class cpu_core: public abstract_cpu
 {
 public:
-	virtual char *  fill_cstate_line(int line_nr, char *buffer, const char *separator="");
-	virtual char *  fill_cstate_name(int line_nr, char *buffer);
+	virtual std::string  fill_cstate_line(int line_nr, const char *separator="");
+	virtual std::string  fill_cstate_name(int line_nr);
 
-	virtual char *  fill_pstate_line(int line_nr, char *buffer);
-	virtual char *  fill_pstate_name(int line_nr, char *buffer);
+	virtual std::string  fill_pstate_line(int line_nr);
+	virtual std::string  fill_pstate_name(int line_nr);
 
 	virtual int     can_collapse(void) { return childcount == 1;};
 };
@@ -199,11 +201,11 @@ class cpu_package: public abstract_cpu
 protected:
 	virtual void	freq_updated(uint64_t time);
 public:
-	virtual char *  fill_cstate_line(int line_nr, char *buffer, const char *separator="");
-	virtual char *  fill_cstate_name(int line_nr, char *buffer);
+	virtual std::string  fill_cstate_line(int line_nr, const char *separator="");
+	virtual std::string  fill_cstate_name(int line_nr);
 
-	virtual char *  fill_pstate_line(int line_nr, char *buffer);
-	virtual char *  fill_pstate_name(int line_nr, char *buffer);
+	virtual std::string  fill_pstate_line(int line_nr);
+	virtual std::string  fill_pstate_name(int line_nr);
 	virtual int     can_collapse(void) { return childcount == 1;};
 };
 

--- a/src/cpu/cpu_core.cpp
+++ b/src/cpu/cpu_core.cpp
@@ -28,56 +28,51 @@
 
 #include "../parameters/parameters.h"
 
-char * cpu_core::fill_cstate_line(int line_nr, char *buffer, const char *separator)
+#include <format>
+
+std::string cpu_core::fill_cstate_line(int line_nr, const char *separator)
 {
 	unsigned int i;
-	buffer[0] = 0;
 
 	if (line_nr == LEVEL_HEADER)
-		sprintf(buffer, this->has_intel_MSR ? _(" Core(HW)"): _(" Core(OS)"));
+		return this->has_intel_MSR ? _(" Core(HW)"): _(" Core(OS)");
 
 	for (i = 0; i < cstates.size(); i++) {
 		if (cstates[i]->line_level != line_nr)
 			continue;
-		sprintf(buffer,"%5.1f%%", percentage(cstates[i]->duration_delta / time_factor));
+		return std::format("{:5.1f}%", percentage(cstates[i]->duration_delta / time_factor));
 	}
 
-	return buffer;
+	return "";
 }
 
 
-char * cpu_core::fill_cstate_name(int line_nr, char *buffer)
+std::string cpu_core::fill_cstate_name(int line_nr)
 {
 	unsigned int i;
-	buffer[0] = 0;
 
 	for (i = 0; i < cstates.size(); i++) {
 		if (cstates[i]->line_level != line_nr)
 			continue;
 
-		sprintf(buffer,"%s", cstates[i]->human_name);
+		return cstates[i]->human_name;
 	}
 
-	return buffer;
+	return "";
 }
 
 
 
-char * cpu_core::fill_pstate_name(int line_nr, char *buffer)
+std::string cpu_core::fill_pstate_name(int line_nr)
 {
-	buffer[0] = 0;
-
 	if (line_nr >= (int)pstates.size() || line_nr < 0)
-		return buffer;
+		return "";
 
-	sprintf(buffer,"%s", pstates[line_nr]->human_name);
-
-	return buffer;
+	return pstates[line_nr]->human_name;
 }
 
-char * cpu_core::fill_pstate_line(int line_nr, char *buffer)
+std::string cpu_core::fill_pstate_line(int line_nr)
 {
-	buffer[0] = 0;
 	unsigned int i;
 
 	if (total_stamp ==0) {
@@ -88,13 +83,11 @@ char * cpu_core::fill_pstate_line(int line_nr, char *buffer)
 	}
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_("  Core"));
-		return buffer;
+		return _("  Core");
 	}
 
 	if (line_nr >= (int)pstates.size() || line_nr < 0)
-		return buffer;
+		return "";
 
-	sprintf(buffer," %5.1f%% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
-	return buffer;
+	return std::format(" {:5.1f}% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
 }

--- a/src/cpu/cpu_core.cpp
+++ b/src/cpu/cpu_core.cpp
@@ -30,7 +30,7 @@
 
 #include <format>
 
-std::string cpu_core::fill_cstate_line(int line_nr, const char *separator)
+std::string cpu_core::fill_cstate_line(int line_nr, const string &separator)
 {
 	unsigned int i;
 

--- a/src/cpu/cpu_linux.cpp
+++ b/src/cpu/cpu_linux.cpp
@@ -101,7 +101,7 @@ void cpu_linux::parse_cstates_start(void)
 void cpu_linux::parse_pstates_start(void)
 {
 	ifstream file;
-	char filename[256];
+	std::string filename;
 	unsigned int i;
 
 	last_stamp = 0;
@@ -109,16 +109,16 @@ void cpu_linux::parse_pstates_start(void)
 		if (children[i])
 			children[i]->wiggle();
 
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpufreq/stats/time_in_state", first_cpu);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/stats/time_in_state", first_cpu);
 
-	file.open(filename, ios::in);
+	file.open(filename.c_str(), ios::in);
 
 	if (file) {
 		char line[1024];
 
 		while (file) {
 			uint64_t f;
-			file.getline(line, sizeof(line));
+			file.getline(line, 1024);
 			f = strtoull(line, NULL, 10);
 			account_freq(f, 0);
 		}
@@ -186,12 +186,12 @@ void cpu_linux::parse_cstates_end(void)
 
 void cpu_linux::parse_pstates_end(void)
 {
-	char filename[256];
+	std::string filename;
 	ifstream file;
 
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpufreq/stats/time_in_state", number);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/stats/time_in_state", number);
 
-	file.open(filename, ios::in);
+	file.open(filename.c_str(), ios::in);
 
 	if (file) {
 		char line[1024];

--- a/src/cpu/cpu_linux.cpp
+++ b/src/cpu/cpu_linux.cpp
@@ -37,26 +37,26 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <format>
 
 void cpu_linux::parse_cstates_start(void)
 {
 	ifstream file;
 	DIR *dir;
 	struct dirent *entry;
-	char filename[256];
-	int len;
+	std::string filename;
 
-	len = snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpuidle", number);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpuidle", number);
 
-	dir = opendir(filename);
+	dir = opendir(filename.c_str());
 	if (!dir)
 		return;
 
 	/* For each C-state, there is a stateX directory which
 	 * contains a 'usage' and a 'time' (duration) file */
 	while ((entry = readdir(dir))) {
-		char linux_name[64];
-		char human_name[64];
+		std::string linux_name;
+		std::string human_name;
 		uint64_t usage = 0;
 		uint64_t duration = 0;
 
@@ -64,38 +64,34 @@ void cpu_linux::parse_cstates_start(void)
 		if (strlen(entry->d_name) < 3)
 			continue;
 
-		pt_strcpy(linux_name, entry->d_name);
-		pt_strcpy(human_name, linux_name);
+		linux_name = entry->d_name;
+		human_name = linux_name;
 
-		snprintf(filename + len, sizeof(filename) - len, "/%s/name", entry->d_name);
-
-		file.open(filename, ios::in);
+		file.open(std::format("{}/{}/name", filename, entry->d_name), ios::in);
 		if (file) {
-			file.getline(human_name, sizeof(human_name));
+			getline(file, human_name);
 			file.close();
 		}
 
-		if (strcmp(human_name, "C0")==0)
-			pt_strcpy(human_name, _("C0 polling"));
+		if (human_name == "C0")
+			human_name = _("C0 polling");
 
-		snprintf(filename + len, sizeof(filename) - len, "/%s/usage", entry->d_name);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/{}/usage", filename, entry->d_name), ios::in);
 		if (file) {
 			file >> usage;
 			file.close();
 		} else
 			continue;
 
-		snprintf(filename + len, sizeof(filename) - len, "/%s/time", entry->d_name);
+		file.open(std::format("{}/{}/time", filename, entry->d_name), ios::in);
 
-		file.open(filename, ios::in);
 		if (file) {
 			file >> duration;
 			file.close();
 		}
 
 
-		update_cstate(linux_name, human_name, usage, duration, 1);
+		update_cstate(linux_name.c_str(), human_name.c_str(), usage, duration, 1);
 
 	}
 	closedir(dir);
@@ -140,23 +136,22 @@ void cpu_linux::measurement_start(void)
 
 void cpu_linux::parse_cstates_end(void)
 {
+	ifstream file;
 	DIR *dir;
 	struct dirent *entry;
-	char filename[256];
-	ifstream file;
-	int len;
+	std::string filename;
 
-	len = snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpuidle", number);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpuidle", number);
 
-	dir = opendir(filename);
+	dir = opendir(filename.c_str());
 	if (!dir)
 		return;
 
 	/* For each C-state, there is a stateX directory which
 	 * contains a 'usage' and a 'time' (duration) file */
 	while ((entry = readdir(dir))) {
-		char linux_name[64];
-		char human_name[64];
+		std::string linux_name;
+		std::string human_name;
 		uint64_t usage = 0;
 		uint64_t duration = 0;
 
@@ -164,28 +159,26 @@ void cpu_linux::parse_cstates_end(void)
 		if (strlen(entry->d_name) < 3)
 			continue;
 
-		pt_strcpy(linux_name, entry->d_name);
-		pt_strcpy(human_name, linux_name);
+		linux_name = entry->d_name;
+		human_name = linux_name;
 
 
-		snprintf(filename + len, sizeof(filename) - len, "/%s/usage", entry->d_name);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/{}/usage", filename, entry->d_name), ios::in);
 		if (file) {
 			file >> usage;
 			file.close();
 		} else
 			continue;
 
-		snprintf(filename + len, sizeof(filename) - len, "/%s/time", entry->d_name);
+		file.open(std::format("{}/{}/time", filename, entry->d_name), ios::in);
 
-		file.open(filename, ios::in);
 		if (file) {
 			file >> duration;
 			file.close();
 		}
 
 
-		finalize_cstate(linux_name, usage, duration, 1);
+		finalize_cstate(linux_name.c_str(), usage, duration, 1);
 
 	}
 	closedir(dir);
@@ -232,15 +225,14 @@ void cpu_linux::measurement_end(void)
 	parse_pstates_end();
 	abstract_cpu::measurement_end();
 }
+#include <format>
 
-char * cpu_linux::fill_cstate_line(int line_nr, char *buffer, const char *separator)
+std::string cpu_linux::fill_cstate_line(int line_nr, const char *separator)
 {
 	unsigned int i;
-	buffer[0] = 0;
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_(" CPU(OS) %i"), number);
-		return buffer;
+		return std::format(_(" CPU(OS) {}"), number);
 	}
 
 	for (i = 0; i < cstates.size(); i++) {
@@ -248,87 +240,76 @@ char * cpu_linux::fill_cstate_line(int line_nr, char *buffer, const char *separa
 			continue;
 
 		if (line_nr == LEVEL_C0)
-			sprintf(buffer,"%5.1f%%", percentage(cstates[i]->duration_delta / time_factor));
+			return std::format("{:5.1f}%", percentage(cstates[i]->duration_delta / time_factor));
 		else
-			sprintf(buffer,"%5.1f%%%s %6.1f ms",
+			return std::format("{:5.1f}%{} {:6.1f} ms",
 				percentage(cstates[i]->duration_delta / time_factor),
 				separator,
 				1.0 * cstates[i]->duration_delta / (1 + cstates[i]->usage_delta) / 1000);
 	}
 
-	return buffer;
+	return "";
 }
 
-char * cpu_linux::fill_cstate_percentage(int line_nr, char *buffer)
+std::string cpu_linux::fill_cstate_percentage(int line_nr)
 {
 	unsigned int i;
-	buffer[0] = 0;
 
 	for (i = 0; i < cstates.size(); i++) {
 		if (cstates[i]->line_level != line_nr)
 			continue;
 
-		sprintf(buffer,"%5.1f%%",
+		return std::format("{:5.1f}%",
 			percentage(cstates[i]->duration_delta / time_factor));
-		break;
 	}
 
-	return buffer;
+	return "";
 }
 
-char * cpu_linux::fill_cstate_time(int line_nr, char *buffer)
+std::string cpu_linux::fill_cstate_time(int line_nr)
 {
 	unsigned int i;
-	buffer[0] = 0;
 
 	if (line_nr == LEVEL_C0)
-		return buffer;
+		return "";
 
 	for (i = 0; i < cstates.size(); i++) {
 		if (cstates[i]->line_level != line_nr)
 			continue;
 
-		sprintf(buffer,"%6.1f ms",
+		return std::format("{:6.1f} ms",
 			1.0 * cstates[i]->duration_delta /
 			(1 + cstates[i]->usage_delta) / 1000);
-		break;
 	}
 
-	return buffer;
+	return "";
 }
 
-char * cpu_linux::fill_cstate_name(int line_nr, char *buffer)
+std::string cpu_linux::fill_cstate_name(int line_nr)
 {
 	unsigned int i;
-	buffer[0] = 0;
 
 	for (i = 0; i < cstates.size(); i++) {
 		if (cstates[i]->line_level != line_nr)
 			continue;
 
-		sprintf(buffer,"%s", cstates[i]->human_name);
+		return std::format("{}", cstates[i]->human_name);
 	}
 
-	return buffer;
+	return "";
 }
 
 
-char * cpu_linux::fill_pstate_name(int line_nr, char *buffer)
+std::string cpu_linux::fill_pstate_name(int line_nr)
 {
-	buffer[0] = 0;
-
 	if (line_nr >= (int)pstates.size() || line_nr < 0)
-		return buffer;
+		return "";
 
-	sprintf(buffer,"%s", pstates[line_nr]->human_name);
-
-	return buffer;
+	return std::format("{}", pstates[line_nr]->human_name);
 }
 
-char * cpu_linux::fill_pstate_line(int line_nr, char *buffer)
+std::string cpu_linux::fill_pstate_line(int line_nr)
 {
-	buffer[0] = 0;
-
 	if (total_stamp ==0) {
 		unsigned int i;
 		for (i = 0; i < pstates.size(); i++)
@@ -338,13 +319,11 @@ char * cpu_linux::fill_pstate_line(int line_nr, char *buffer)
 	}
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_(" CPU %i"), number);
-		return buffer;
+		return std::format(_(" CPU {}"), number);
 	}
 
 	if (line_nr >= (int)pstates.size() || line_nr < 0)
-		return buffer;
+		return "";
 
-	sprintf(buffer," %5.1f%% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
-	return buffer;
+	return std::format(" {:5.1f}% ", percentage(1.0 * (pstates[line_nr]->time_after) / total_stamp));
 }

--- a/src/cpu/cpu_linux.cpp
+++ b/src/cpu/cpu_linux.cpp
@@ -227,7 +227,7 @@ void cpu_linux::measurement_end(void)
 }
 #include <format>
 
-std::string cpu_linux::fill_cstate_line(int line_nr, const char *separator)
+std::string cpu_linux::fill_cstate_line(int line_nr, const string &separator)
 {
 	unsigned int i;
 
@@ -247,7 +247,6 @@ std::string cpu_linux::fill_cstate_line(int line_nr, const char *separator)
 				separator,
 				1.0 * cstates[i]->duration_delta / (1 + cstates[i]->usage_delta) / 1000);
 	}
-
 	return "";
 }
 

--- a/src/cpu/cpu_linux.cpp
+++ b/src/cpu/cpu_linux.cpp
@@ -232,7 +232,7 @@ std::string cpu_linux::fill_cstate_line(int line_nr, const char *separator)
 	unsigned int i;
 
 	if (line_nr == LEVEL_HEADER) {
-		return std::format(_(" CPU(OS) {}"), number);
+		return pt_format(_(" CPU(OS) {}"), number);
 	}
 
 	for (i = 0; i < cstates.size(); i++) {
@@ -319,7 +319,7 @@ std::string cpu_linux::fill_pstate_line(int line_nr)
 	}
 
 	if (line_nr == LEVEL_HEADER) {
-		return std::format(_(" CPU {}"), number);
+		return pt_format(_(" CPU {}"), number);
 	}
 
 	if (line_nr >= (int)pstates.size() || line_nr < 0)

--- a/src/cpu/cpu_package.cpp
+++ b/src/cpu/cpu_package.cpp
@@ -40,18 +40,16 @@ void cpu_package::freq_updated(uint64_t time)
 
 #include <format>
 
-std::string cpu_package::fill_cstate_line(int line_nr, const char *separator)
+std::string cpu_package::fill_cstate_line(int line_nr, const string &separator)
 {
 	unsigned int i;
 
-	if (line_nr == LEVEL_HEADER) {
-		return this->has_intel_MSR ? _(" Pkg(HW)"): _(" Pkg(OS)");
-	}
+	if (line_nr == LEVEL_HEADER)
+		return this->has_intel_MSR ? _(" Package(HW)"): _(" Package(OS)");
 
 	for (i = 0; i < cstates.size(); i++) {
 		if (cstates[i]->line_level != line_nr)
 			continue;
-
 		return std::format("{:5.1f}%", percentage(cstates[i]->duration_delta / time_factor));
 	}
 

--- a/src/cpu/cpu_package.cpp
+++ b/src/cpu/cpu_package.cpp
@@ -38,58 +38,53 @@ void cpu_package::freq_updated(uint64_t time)
 	old_idle = idle;
 }
 
-char * cpu_package::fill_cstate_line(int line_nr, char *buffer, const char *separator)
+#include <format>
+
+std::string cpu_package::fill_cstate_line(int line_nr, const char *separator)
 {
 	unsigned int i;
-	buffer[0] = 0;
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer, this->has_intel_MSR ? _(" Pkg(HW)"): _(" Pkg(OS)"));
+		return this->has_intel_MSR ? _(" Pkg(HW)"): _(" Pkg(OS)");
 	}
 
 	for (i = 0; i < cstates.size(); i++) {
 		if (cstates[i]->line_level != line_nr)
 			continue;
 
-		sprintf(buffer,"%5.1f%%", percentage(cstates[i]->duration_delta / time_factor));
+		return std::format("{:5.1f}%", percentage(cstates[i]->duration_delta / time_factor));
 	}
 
-	return buffer;
+	return "";
 }
 
 
-char * cpu_package::fill_cstate_name(int line_nr, char *buffer)
+std::string cpu_package::fill_cstate_name(int line_nr)
 {
 	unsigned int i;
-	buffer[0] = 0;
 
 	for (i = 0; i < cstates.size(); i++) {
 		if (cstates[i]->line_level != line_nr)
 			continue;
 
-		sprintf(buffer,"%s", cstates[i]->human_name);
+		return cstates[i]->human_name;
 	}
 
-	return buffer;
+	return "";
 }
 
 
 
-char * cpu_package::fill_pstate_name(int line_nr, char *buffer)
+std::string cpu_package::fill_pstate_name(int line_nr)
 {
-	buffer[0] = 0;
-
 	if (line_nr >= (int)pstates.size() || line_nr < 0)
-		return buffer;
+		return "";
 
-	sprintf(buffer,"%s", pstates[line_nr]->human_name);
-
-	return buffer;
+	return pstates[line_nr]->human_name;
 }
 
-char * cpu_package::fill_pstate_line(int line_nr, char *buffer)
+std::string cpu_package::fill_pstate_line(int line_nr)
 {
-	buffer[0] = 0;
 	unsigned int i;
 
 	if (total_stamp ==0) {
@@ -99,15 +94,12 @@ char * cpu_package::fill_pstate_line(int line_nr, char *buffer)
 			total_stamp = 1;
 	}
 
-
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_("  Package"));
-		return buffer;
+		return _("Package");
 	}
 
 	if (line_nr >= (int)pstates.size() || line_nr < 0)
-		return buffer;
+		return "";
 
-	sprintf(buffer," %5.1f%% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
-	return buffer;
+	return std::format(" {:5.1f}% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
 }

--- a/src/cpu/cpu_rapl_device.cpp
+++ b/src/cpu/cpu_rapl_device.cpp
@@ -28,7 +28,7 @@
 #include "../parameters/parameters.h"
 #include "cpu_rapl_device.h"
 
-cpu_rapl_device::cpu_rapl_device(cpudevice *parent, const char *classname, const char *dev_name, class abstract_cpu *_cpu)
+cpu_rapl_device::cpu_rapl_device(cpudevice *parent, const string &classname, const string &dev_name, class abstract_cpu *_cpu)
 	: cpudevice(classname, dev_name, _cpu),
 	  device_valid(false)
 {

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -47,7 +47,7 @@ public:
 	~cpu_rapl_device() { delete rapl; }
 	virtual const char * device_name(void) {return "CPU core";};
 	virtual std::string device_name_s(void) {return "CPU core";};
-	virtual std::string human_name_s(void) {return human_name();};
+	virtual std::string human_name_s(void) {return human_name_cstr();};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual void start_measurement(void);

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -43,7 +43,7 @@ class cpu_rapl_device: public cpudevice {
 	bool		device_valid;
 
 public:
-	cpu_rapl_device(cpudevice *parent, const char *classname = "cpu_core", const char *device_name = "cpu_core", class abstract_cpu *_cpu = NULL);
+	cpu_rapl_device(cpudevice *parent, const std::string &classname = "cpu_core", const std::string &device_name = "cpu_core", class abstract_cpu *_cpu = NULL);
 	~cpu_rapl_device() { delete rapl; }
 	virtual std::string device_name(void) {return "CPU core";};
 	virtual std::string human_name(void) {return "CPU core";};

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -46,6 +46,8 @@ public:
 	cpu_rapl_device(cpudevice *parent, const char *classname = "cpu_core", const char *device_name = "cpu_core", class abstract_cpu *_cpu = NULL);
 	~cpu_rapl_device() { delete rapl; }
 	virtual const char * device_name(void) {return "CPU core";};
+	virtual std::string device_name_s(void) {return "CPU core";};
+	virtual std::string human_name_s(void) {return human_name();};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual void start_measurement(void);

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -47,7 +47,7 @@ public:
 	~cpu_rapl_device() { delete rapl; }
 	virtual const char * device_name(void) {return "CPU core";};
 	virtual std::string device_name_s(void) {return "CPU core";};
-	virtual std::string human_name_s(void) {return human_name_cstr();};
+	virtual std::string human_name(void) {return "CPU core";};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual void start_measurement(void);

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -45,8 +45,7 @@ class cpu_rapl_device: public cpudevice {
 public:
 	cpu_rapl_device(cpudevice *parent, const char *classname = "cpu_core", const char *device_name = "cpu_core", class abstract_cpu *_cpu = NULL);
 	~cpu_rapl_device() { delete rapl; }
-	virtual const char * device_name(void) {return "CPU core";};
-	virtual std::string device_name_s(void) {return "CPU core";};
+	virtual std::string device_name(void) {return "CPU core";};
 	virtual std::string human_name(void) {return "CPU core";};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);

--- a/src/cpu/cpudevice.cpp
+++ b/src/cpu/cpudevice.cpp
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <format>
 #include "../lib.h"
 #include "../parameters/parameters.h"
 
@@ -39,6 +40,19 @@ cpudevice::cpudevice(const char *classname, const char *dev_name, class abstract
 	consumption_index = get_param_index("cpu-consumption");;
 	r_wake_index = get_result_index("cpu-wakeups");;
 	r_consumption_index = get_result_index("cpu-consumption");;
+}
+
+const char * cpudevice::device_name(void)
+{
+	return _cpuname.c_str();
+}
+
+std::string cpudevice::human_name_s(void)
+{
+	if (!guilty.empty())
+		return std::format("{} ({})", _cpuname, guilty);
+
+	return _cpuname;
 }
 
 double cpudevice::power_usage(struct result_bundle *result, struct parameter_bundle *bundle)

--- a/src/cpu/cpudevice.cpp
+++ b/src/cpu/cpudevice.cpp
@@ -31,7 +31,7 @@
 #include "../parameters/parameters.h"
 
 
-cpudevice::cpudevice(const char *classname, const char *dev_name, class abstract_cpu *_cpu)
+cpudevice::cpudevice(const std::string &classname, const std::string &dev_name, class abstract_cpu *_cpu)
 {
 	_class = classname;
 	_cpuname = dev_name;
@@ -42,9 +42,9 @@ cpudevice::cpudevice(const char *classname, const char *dev_name, class abstract
 	r_consumption_index = get_result_index("cpu-consumption");;
 }
 
-const char * cpudevice::device_name(void)
+std::string cpudevice::device_name(void)
 {
-	return _cpuname.c_str();
+	return _cpuname;
 }
 
 std::string cpudevice::human_name(void)

--- a/src/cpu/cpudevice.cpp
+++ b/src/cpu/cpudevice.cpp
@@ -47,7 +47,7 @@ const char * cpudevice::device_name(void)
 	return _cpuname.c_str();
 }
 
-std::string cpudevice::human_name_s(void)
+std::string cpudevice::human_name(void)
 {
 	if (!guilty.empty())
 		return std::format("{} ({})", _cpuname, guilty);

--- a/src/cpu/cpudevice.cpp
+++ b/src/cpu/cpudevice.cpp
@@ -32,21 +32,13 @@
 
 cpudevice::cpudevice(const char *classname, const char *dev_name, class abstract_cpu *_cpu)
 {
-	pt_strcpy(_class, classname);
-	pt_strcpy(_cpuname, dev_name);
+	_class = classname;
+	_cpuname = dev_name;
 	cpu = _cpu;
 	wake_index = get_param_index("cpu-wakeups");;
 	consumption_index = get_param_index("cpu-consumption");;
 	r_wake_index = get_result_index("cpu-wakeups");;
 	r_consumption_index = get_result_index("cpu-consumption");;
-}
-
-const char * cpudevice::device_name(void)
-{
-	if (child_devices.size())
-		return "CPU misc";
-	else
-		return "CPU use";
 }
 
 double cpudevice::power_usage(struct result_bundle *result, struct parameter_bundle *bundle)

--- a/src/cpu/cpudevice.h
+++ b/src/cpu/cpudevice.h
@@ -54,7 +54,7 @@ public:
 
 	virtual const char * device_name(void);
 	virtual std::string device_name_s(void) { return _cpuname; };
-	virtual std::string human_name_s(void) { return human_name(); };
+	virtual std::string human_name_s(void);
 
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual bool show_in_list(void) {return false;};

--- a/src/cpu/cpudevice.h
+++ b/src/cpu/cpudevice.h
@@ -35,23 +35,26 @@ using namespace std;
 
 class cpudevice: public device {
 protected:
-	char _class[128];
-	char _cpuname[128];
+	std::string _class;
+	std::string _cpuname;
 
-	vector<string> params;
+	std::vector<std::string> params;
 	class abstract_cpu *cpu;
 	int wake_index;
 	int consumption_index;
 	int r_wake_index;
 	int r_consumption_index;
 
-	vector<device *>child_devices;
+	std::vector<device *>child_devices;
 
 public:
 	cpudevice(const char *classname = "cpu", const char *device_name = "cpu0", class abstract_cpu *_cpu = NULL);
-	virtual const char * class_name(void) { return _class;};
+	virtual const char * class_name(void) { return _class.c_str(); };
+	virtual std::string class_name_s(void) { return _class; };
 
 	virtual const char * device_name(void);
+	virtual std::string device_name_s(void) { return _cpuname; };
+	virtual std::string human_name_s(void) { return human_name(); };
 
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual bool show_in_list(void) {return false;};

--- a/src/cpu/cpudevice.h
+++ b/src/cpu/cpudevice.h
@@ -54,7 +54,7 @@ public:
 
 	virtual const char * device_name(void);
 	virtual std::string device_name_s(void) { return _cpuname; };
-	virtual std::string human_name_s(void);
+	virtual std::string human_name(void);
 
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual bool show_in_list(void) {return false;};

--- a/src/cpu/cpudevice.h
+++ b/src/cpu/cpudevice.h
@@ -48,12 +48,10 @@ protected:
 	std::vector<device *>child_devices;
 
 public:
-	cpudevice(const char *classname = "cpu", const char *device_name = "cpu0", class abstract_cpu *_cpu = NULL);
-	virtual const char * class_name(void) { return _class.c_str(); };
-	virtual std::string class_name_s(void) { return _class; };
+	cpudevice(const std::string &classname = "cpu", const std::string &device_name = "cpu0", class abstract_cpu *_cpu = NULL);
+	virtual std::string class_name(void) { return _class; };
 
-	virtual const char * device_name(void);
-	virtual std::string device_name_s(void) { return _cpuname; };
+	virtual std::string device_name(void);
 	virtual std::string human_name(void);
 
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);

--- a/src/cpu/dram_rapl_device.cpp
+++ b/src/cpu/dram_rapl_device.cpp
@@ -29,7 +29,7 @@
 #include "dram_rapl_device.h"
 
 
-dram_rapl_device::dram_rapl_device(cpudevice *parent, const char *classname, const char *dev_name, class abstract_cpu *_cpu)
+dram_rapl_device::dram_rapl_device(cpudevice *parent, const string &classname, const string &dev_name, class abstract_cpu *_cpu)
 	: cpudevice(classname, dev_name, _cpu),
 	  device_valid(false)
 {

--- a/src/cpu/dram_rapl_device.h
+++ b/src/cpu/dram_rapl_device.h
@@ -47,7 +47,7 @@ public:
 	~dram_rapl_device() { delete rapl; }
 	virtual const char * device_name(void) {return "DRAM";};
 	virtual std::string device_name_s(void) {return "DRAM";};
-	virtual std::string human_name_s(void) {return human_name();};
+	virtual std::string human_name_s(void) {return human_name_cstr();};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	void start_measurement(void);

--- a/src/cpu/dram_rapl_device.h
+++ b/src/cpu/dram_rapl_device.h
@@ -43,7 +43,7 @@ class dram_rapl_device: public cpudevice {
 	bool		device_valid;
 
 public:
-	dram_rapl_device(cpudevice *parent, const char *classname = "dram_core", const char *device_name = "dram_core", class abstract_cpu *_cpu = NULL);
+	dram_rapl_device(cpudevice *parent, const std::string &classname = "dram_core", const std::string &device_name = "dram_core", class abstract_cpu *_cpu = NULL);
 	~dram_rapl_device() { delete rapl; }
 	virtual std::string device_name(void) {return "DRAM";};
 	virtual std::string human_name(void) {return "DRAM";};

--- a/src/cpu/dram_rapl_device.h
+++ b/src/cpu/dram_rapl_device.h
@@ -46,6 +46,8 @@ public:
 	dram_rapl_device(cpudevice *parent, const char *classname = "dram_core", const char *device_name = "dram_core", class abstract_cpu *_cpu = NULL);
 	~dram_rapl_device() { delete rapl; }
 	virtual const char * device_name(void) {return "DRAM";};
+	virtual std::string device_name_s(void) {return "DRAM";};
+	virtual std::string human_name_s(void) {return human_name();};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	void start_measurement(void);

--- a/src/cpu/dram_rapl_device.h
+++ b/src/cpu/dram_rapl_device.h
@@ -47,7 +47,7 @@ public:
 	~dram_rapl_device() { delete rapl; }
 	virtual const char * device_name(void) {return "DRAM";};
 	virtual std::string device_name_s(void) {return "DRAM";};
-	virtual std::string human_name_s(void) {return human_name_cstr();};
+	virtual std::string human_name(void) {return "DRAM";};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	void start_measurement(void);

--- a/src/cpu/dram_rapl_device.h
+++ b/src/cpu/dram_rapl_device.h
@@ -45,8 +45,7 @@ class dram_rapl_device: public cpudevice {
 public:
 	dram_rapl_device(cpudevice *parent, const char *classname = "dram_core", const char *device_name = "dram_core", class abstract_cpu *_cpu = NULL);
 	~dram_rapl_device() { delete rapl; }
-	virtual const char * device_name(void) {return "DRAM";};
-	virtual std::string device_name_s(void) {return "DRAM";};
+	virtual std::string device_name(void) {return "DRAM";};
 	virtual std::string human_name(void) {return "DRAM";};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);

--- a/src/cpu/intel_cpus.cpp
+++ b/src/cpu/intel_cpus.cpp
@@ -735,7 +735,7 @@ std::string nhm_cpu::fill_pstate_line(int line_nr)
 	}
 
 	if (line_nr == LEVEL_HEADER) {
-		return std::format(_(" CPU {}"), number);
+		return pt_format(_(" CPU {}"), number);
 	}
 
 	if (line_nr == LEVEL_C0) {

--- a/src/cpu/intel_cpus.cpp
+++ b/src/cpu/intel_cpus.cpp
@@ -244,7 +244,7 @@ nhm_core::nhm_core(int model)
 void nhm_core::measurement_start(void)
 {
 	ifstream file;
-	char filename[PATH_MAX];
+	std::string filename;
 
 	/* the abstract function needs to be first since it clears all state */
 	abstract_cpu::measurement_start();
@@ -270,9 +270,9 @@ void nhm_core::measurement_start(void)
 	}
 
 
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpufreq/stats/time_in_state", first_cpu);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/stats/time_in_state", first_cpu);
 
-	file.open(filename, ios::in);
+	file.open(filename.c_str(), ios::in);
 
 	if (file) {
 		char line[1024];
@@ -649,7 +649,7 @@ void nhm_package::measurement_end(void)
 void nhm_cpu::measurement_start(void)
 {
 	ifstream file;
-	char filename[PATH_MAX];
+	std::string filename;
 
 	cpu_linux::measurement_start();
 
@@ -661,9 +661,9 @@ void nhm_cpu::measurement_start(void)
 
 	insert_cstate("active", _("C0 active"), 0, aperf_before, 1);
 
-	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%i/cpufreq/stats/time_in_state", first_cpu);
+	filename = std::format("/sys/devices/system/cpu/cpu{}/cpufreq/stats/time_in_state", first_cpu);
 
-	file.open(filename, ios::in);
+	file.open(filename.c_str(), ios::in);
 
 	if (file) {
 		char line[1024];

--- a/src/cpu/intel_cpus.cpp
+++ b/src/cpu/intel_cpus.cpp
@@ -348,7 +348,7 @@ void nhm_core::measurement_end(void)
 				if (!state)
 					continue;
 
-				update_pstate(  state->freq, state->human_name, state->time_before, state->before_count);
+				update_pstate(  state->freq, state->human_name.c_str(), state->time_before, state->before_count);
 				finalize_pstate(state->freq,                    state->time_after,  state->after_count);
 			}
 		}
@@ -356,10 +356,11 @@ void nhm_core::measurement_end(void)
 	total_stamp = 0;
 }
 
-char * nhm_core::fill_pstate_line(int line_nr, char *buffer)
+#include <format>
+
+std::string nhm_core::fill_pstate_line(int line_nr)
 {
 	const int intel_pstate = is_intel_pstate_driver_loaded();
-	buffer[0] = 0;
 	unsigned int i;
 
 	if (!intel_pstate && total_stamp ==0) {
@@ -370,16 +371,13 @@ char * nhm_core::fill_pstate_line(int line_nr, char *buffer)
 	}
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_("  Core"));
-		return buffer;
+		return _("  Core");
 	}
 
 	if (intel_pstate > 0 || line_nr >= (int)pstates.size() || line_nr < 0)
-		return buffer;
+		return "";
 
-	sprintf(buffer," %5.1f%% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
-
-	return buffer;
+	return std::format(" {:5.1f}% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
 }
 
 nhm_package::nhm_package(int model)
@@ -492,10 +490,9 @@ nhm_package::nhm_package(int model)
 	}
 }
 
-char * nhm_package::fill_pstate_line(int line_nr, char *buffer)
+std::string nhm_package::fill_pstate_line(int line_nr)
 {
 	const int intel_pstate = is_intel_pstate_driver_loaded();
-	buffer[0] = 0;
 	unsigned int i;
 
 	if (!intel_pstate && total_stamp ==0) {
@@ -507,16 +504,13 @@ char * nhm_package::fill_pstate_line(int line_nr, char *buffer)
 
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_("  Package"));
-		return buffer;
+		return _("  Package");
 	}
 
 	if (intel_pstate > 0 || line_nr >= (int)pstates.size() || line_nr < 0)
-		return buffer;
+		return "";
 
-	sprintf(buffer," %5.1f%% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
-
-	return buffer;
+	return std::format(" {:5.1f}% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
 }
 
 
@@ -644,7 +638,7 @@ void nhm_package::measurement_end(void)
 				if (!state)
 					continue;
 
-				update_pstate(  state->freq, state->human_name, state->time_before, state->before_count);
+				update_pstate(  state->freq, state->human_name.c_str(), state->time_before, state->before_count);
 				finalize_pstate(state->freq,                    state->time_after,  state->after_count);
 			}
 		}
@@ -720,16 +714,15 @@ void nhm_cpu::measurement_end(void)
 
 }
 
-char * nhm_cpu::fill_pstate_name(int line_nr, char *buffer)
+std::string nhm_cpu::fill_pstate_name(int line_nr)
 {
 	if (line_nr == LEVEL_C0) {
-		sprintf(buffer, _("Average"));
-		return buffer;
+		return _("Average");
 	}
-	return cpu_linux::fill_pstate_name(line_nr, buffer);
+	return cpu_linux::fill_pstate_name(line_nr);
 }
 
-char * nhm_cpu::fill_pstate_line(int line_nr, char *buffer)
+std::string nhm_cpu::fill_pstate_line(int line_nr)
 {
 	const int intel_pstate = is_intel_pstate_driver_loaded();
 
@@ -742,22 +735,18 @@ char * nhm_cpu::fill_pstate_line(int line_nr, char *buffer)
 	}
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_(" CPU %i"), number);
-		return buffer;
+		return std::format(_(" CPU {}"), number);
 	}
 
 	if (line_nr == LEVEL_C0) {
 		double F;
 		F = 1.0 * (tsc_after - tsc_before) * (aperf_after - aperf_before) / (mperf_after - mperf_before) / time_factor * 1000;
-		hz_to_human(F, buffer, 1);
-		return buffer;
+		return hz_to_human(F, 1);
 	}
 	if (intel_pstate > 0 || line_nr >= (int)pstates.size() || line_nr < 0)
-		return buffer;
+		return "";
 
-	sprintf(buffer," %5.1f%% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
-
-	return buffer;
+	return std::format(" {:5.1f}% ", percentage(1.0* (pstates[line_nr]->time_after) / total_stamp));
 }
 
 

--- a/src/cpu/intel_cpus.h
+++ b/src/cpu/intel_cpus.h
@@ -84,7 +84,7 @@ public:
 	virtual void	measurement_end(void);
 	virtual int     can_collapse(void) { return 0;};
 
-	virtual char *  fill_pstate_line(int line_nr, char *buffer);
+	virtual std::string  fill_pstate_line(int line_nr);
 };
 
 class nhm_core: public cpu_core, public intel_util
@@ -107,7 +107,7 @@ public:
 	virtual void	measurement_end(void);
 	virtual int     can_collapse(void) { return 0;};
 
-	virtual char *  fill_pstate_line(int line_nr, char *buffer);
+	virtual std::string  fill_pstate_line(int line_nr);
 };
 
 class nhm_cpu: public cpu_linux, public intel_util
@@ -126,8 +126,8 @@ public:
 	virtual void	measurement_end(void);
 	virtual int     can_collapse(void) { return 0;};
 
-	virtual char *  fill_pstate_name(int line_nr, char *buffer);
-	virtual char *  fill_pstate_line(int line_nr, char *buffer);
+	virtual std::string  fill_pstate_name(int line_nr);
+	virtual std::string  fill_pstate_line(int line_nr);
 	virtual int	has_pstate_level(int level);
 };
 
@@ -163,9 +163,9 @@ public:
 	virtual void	measurement_end(void);
 	virtual int     can_collapse(void) { return 0;};
 
-	virtual char *  fill_pstate_line(int line_nr, char *buffer);
-	virtual char *  fill_pstate_name(int line_nr, char *buffer);
-	virtual char *  fill_cstate_line(int line_nr, char *buffer, const char *separator);
+	virtual std::string  fill_pstate_line(int line_nr);
+	virtual std::string  fill_pstate_name(int line_nr);
+	virtual std::string  fill_cstate_line(int line_nr, const char *separator);
 	virtual int	has_pstate_level(int level) { return 0; };
 	virtual int	has_pstates(void) { return 0; };
 	virtual void	wiggle(void) { };

--- a/src/cpu/intel_cpus.h
+++ b/src/cpu/intel_cpus.h
@@ -165,7 +165,7 @@ public:
 
 	virtual std::string  fill_pstate_line(int line_nr);
 	virtual std::string  fill_pstate_name(int line_nr);
-	virtual std::string  fill_cstate_line(int line_nr, const char *separator);
+	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator);
 	virtual int	has_pstate_level(int level) { return 0; };
 	virtual int	has_pstates(void) { return 0; };
 	virtual void	wiggle(void) { };

--- a/src/cpu/intel_gpu.cpp
+++ b/src/cpu/intel_gpu.cpp
@@ -25,6 +25,7 @@
 #include "intel_cpus.h"
 #include <iostream>
 #include <fstream>
+#include <format>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -55,18 +56,14 @@ void i965_core::measurement_start(void)
 	update_cstate("gpu rc6pp", "RC6pp", 0, rc6pp_before, 1, 3);
 }
 
-char * i965_core::fill_cstate_line(int line_nr, char *buffer, const char *separator)
+std::string i965_core::fill_cstate_line(int line_nr, const char *separator)
 {
-	buffer[0] = 0;
 	double ratio, d = -1.0, time_delta;
 
 	if (line_nr == LEVEL_HEADER) {
-		sprintf(buffer,_("  GPU "));
-		return buffer;
+		return _("  GPU ");
 	}
 
-	buffer[0] = 0;
-	
 	time_delta  = 1000000 * (after.tv_sec - before.tv_sec) + after.tv_usec - before.tv_usec;
 	ratio = 100000.0/time_delta;
 
@@ -84,7 +81,7 @@ char * i965_core::fill_cstate_line(int line_nr, char *buffer, const char *separa
 		d = ratio * (rc6pp_after - rc6pp_before);
 		break;
 	default:
-		return buffer;
+		return "";
 	}
 		
 	/* cope with rounding errors due to the measurement interval */
@@ -93,9 +90,7 @@ char * i965_core::fill_cstate_line(int line_nr, char *buffer, const char *separa
 	if (d > 100.0)
 		d = 100.0;
 	
-	sprintf(buffer,"%5.1f%%", d);
-
-	return buffer;
+	return std::format("{:5.1f}%", d);
 }
 
 
@@ -108,15 +103,13 @@ void i965_core::measurement_end(void)
 	rc6pp_after = read_sysfs("/sys/class/drm/card0/power/rc6pp_residency_ms", NULL);
 }
 
-char * i965_core::fill_pstate_line(int line_nr, char *buffer)
+std::string i965_core::fill_pstate_line(int line_nr)
 {
-	buffer[0] = 0;
-	return buffer;
+	return "";
 }
 
-char * i965_core::fill_pstate_name(int line_nr, char *buffer)
+std::string i965_core::fill_pstate_name(int line_nr)
 {
-	buffer[0] = 0;
-	return buffer;
+	return "";
 }
 

--- a/src/cpu/intel_gpu.cpp
+++ b/src/cpu/intel_gpu.cpp
@@ -56,7 +56,7 @@ void i965_core::measurement_start(void)
 	update_cstate("gpu rc6pp", "RC6pp", 0, rc6pp_before, 1, 3);
 }
 
-std::string i965_core::fill_cstate_line(int line_nr, const char *separator)
+std::string i965_core::fill_cstate_line(int line_nr, const string &separator)
 {
 	double ratio, d = -1.0, time_delta;
 

--- a/src/cpu/rapl/rapl_interface.cpp
+++ b/src/cpu/rapl/rapl_interface.cpp
@@ -70,7 +70,7 @@
 #define PP0_DOMAIN_PRESENT	0x04
 #define PP1_DOMAIN_PRESENT	0x08
 
-c_rapl_interface::c_rapl_interface(const char *dev_name, int cpu) :
+c_rapl_interface::c_rapl_interface(const string &dev_name, int cpu) :
 	powercap_sysfs_present(false),
 	powercap_core_path(),
 	powercap_uncore_path(),
@@ -92,7 +92,7 @@ c_rapl_interface::c_rapl_interface(const char *dev_name, int cpu) :
 
 	rapl_domains = 0;
 
-	if (dev_name) {
+	if (!dev_name.empty()) {
 		string base_path = "/sys/class/powercap/intel-rapl/";
 		if ((dir = opendir(base_path.c_str())) != NULL) {
 			while ((entry = readdir(dir)) != NULL) {

--- a/src/cpu/rapl/rapl_interface.h
+++ b/src/cpu/rapl/rapl_interface.h
@@ -51,7 +51,7 @@ protected:
 	double last_pp1_energy_status;
 
 public:
-	c_rapl_interface(const char *dev_name = "package-0", int cpu = 0);
+	c_rapl_interface(const std::string &dev_name = "package-0", int cpu = 0);
 
 	int get_rapl_power_unit(uint64_t *value);
 	double get_power_unit();

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -141,9 +141,9 @@ ahci::ahci(char *_name, char *path): device()
 	diskname = model_name((char *)sysfs_path.c_str(), _name);
 
 	if (diskname.empty())
-		humanname = std::format(_("SATA link: {}"), _name);
+		humanname = pt_format(_("SATA link: {}"), _name);
 	else
-		humanname = std::format(_("SATA disk: {}"), diskname);
+		humanname = pt_format(_("SATA disk: {}"), diskname);
 }
 
 void ahci::start_measurement(void)

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -113,7 +113,7 @@ static string model_name(char *path, char *shortname)
 	return "";
 }
 
-ahci::ahci(char *_name, char *path): device()
+ahci::ahci(const string &_name, const string &path): device()
 {
 	std::string diskname;
 
@@ -127,7 +127,7 @@ ahci::ahci(char *_name, char *path): device()
 	start_partial = 0;
 	sysfs_path = path;
 
-	register_sysfs_path(sysfs_path.c_str());
+	register_sysfs_path(sysfs_path);
 
 	name = std::format("ahci:{}", _name);
 	active_index = get_param_index("ahci-link-power-active");
@@ -138,7 +138,7 @@ ahci::ahci(char *_name, char *path): device()
 	slumber_rindex = get_result_index(std::format("{}-slumber", name));
 	devslp_rindex = get_result_index(std::format("{}-devslp", name));
 
-	diskname = model_name((char *)sysfs_path.c_str(), _name);
+	diskname = model_name((char *)sysfs_path.c_str(), (char *)_name.c_str());
 
 	if (diskname.empty())
 		humanname = pt_format(_("SATA link: {}"), _name);
@@ -288,8 +288,7 @@ void create_all_ahcis(void)
 		file << 1 ;
 		file.close();
 
-		bl = new class ahci(entry->d_name, (char *)std::format("/sys/class/scsi_host/{}", entry->d_name).c_str());
-		all_devices.push_back(bl);
+		bl = new class ahci(entry->d_name, std::format("/sys/class/scsi_host/{}", entry->d_name));		all_devices.push_back(bl);
 		register_parameter("ahci-link-power-active", 0.6);  /* active sata link takes about 0.6 W */
 		register_parameter("ahci-link-power-partial");
 		links.push_back(bl);

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -40,6 +40,7 @@ using namespace std;
 #include "../parameters/parameters.h"
 #include "report/report-data-html.h"
 #include <string.h>
+#include <format>
 
 vector <class ahci *> links;
 
@@ -115,9 +116,7 @@ static string model_name(char *path, char *shortname)
 
 ahci::ahci(char *_name, char *path): device()
 {
-	char buffer[4096];
-	char devname[128];
-	string diskname;
+	std::string diskname;
 
 	end_active = 0;
 	end_slumber = 0;
@@ -131,29 +130,21 @@ ahci::ahci(char *_name, char *path): device()
 
 	register_sysfs_path(sysfs_path);
 
-	snprintf(devname, sizeof(devname), "ahci:%s", _name);
-	pt_strcpy(name, devname);
+	name = std::format("ahci:{}", _name);
 	active_index = get_param_index("ahci-link-power-active");
 	partial_index = get_param_index("ahci-link-power-partial");
 
-	snprintf(buffer, sizeof(buffer), "%s-active", name);
-	active_rindex = get_result_index(buffer);
-
-	snprintf(buffer, sizeof(buffer), "%s-partial", name);
-	partial_rindex = get_result_index(buffer);
-
-	snprintf(buffer, sizeof(buffer), "%s-slumber", name);
-	slumber_rindex = get_result_index(buffer);
-
-	snprintf(buffer, sizeof(buffer), "%s-devslp", name);
-	devslp_rindex = get_result_index(buffer);
+	active_rindex = get_result_index(std::format("{}-active", name).c_str());
+	partial_rindex = get_result_index(std::format("{}-partial", name).c_str());
+	slumber_rindex = get_result_index(std::format("{}-slumber", name).c_str());
+	devslp_rindex = get_result_index(std::format("{}-devslp", name).c_str());
 
 	diskname = model_name(path, _name);
 
-	if (strlen(diskname.c_str()) == 0)
-		snprintf(humanname, sizeof(humanname), _("SATA link: %s"), _name);
+	if (diskname.empty())
+		humanname = std::format(_("SATA link: {}"), _name);
 	else
-		snprintf(humanname, sizeof(humanname), _("SATA disk: %s"), diskname.c_str());
+		humanname = std::format(_("SATA disk: {}"), diskname);
 }
 
 void ahci::start_measurement(void)
@@ -197,7 +188,6 @@ void ahci::start_measurement(void)
 void ahci::end_measurement(void)
 {
 	char filename[PATH_MAX];
-	char powername[4096];
 	ifstream file;
 	double p;
 	double total;
@@ -245,29 +235,25 @@ void ahci::end_measurement(void)
 	p = (end_active - start_active) / total * 100.0;
 	if (p < 0)
 		 p = 0;
-	snprintf(powername, sizeof(powername), "%s-active", name);
-	report_utilization(powername, p);
+	report_utilization(std::format("{}-active", name).c_str(), p);
 
 	/* percent in partial */
 	p = (end_partial - start_partial) / total * 100.0;
 	if (p < 0)
 		 p = 0;
-	snprintf(powername, sizeof(powername), "%s-partial", name);
-	report_utilization(powername, p);
+	report_utilization(std::format("{}-partial", name).c_str(), p);
 
 	/* percent in slumber */
 	p = (end_slumber - start_slumber) / total * 100.0;
 	if (p < 0)
 		 p = 0;
-	snprintf(powername, sizeof(powername), "%s-slumber", name);
-	report_utilization(powername, p);
+	report_utilization(std::format("{}-slumber", name).c_str(), p);
 
 	/* percent in devslp */
 	p = (end_devslp - start_devslp) / total * 100.0;
 	if (p < 0)
 		 p = 0;
-	snprintf(powername, sizeof(powername), "%s-devslp", name);
-	report_utilization(powername, p);
+	report_utilization(std::format("{}-devslp", name).c_str(), p);
 }
 
 
@@ -281,11 +267,6 @@ double ahci::utilization(void)
 		p = 0;
 
 	return p;
-}
-
-const char * ahci::device_name(void)
-{
-	return name;
 }
 
 void create_all_ahcis(void)
@@ -402,27 +383,22 @@ void ahci_create_device_stats_table(void)
 	delete [] ahci_data;
 }
 
-void ahci::report_device_stats(string *ahci_data, int idx)
+void ahci::report_device_stats(std::string *ahci_data, int idx)
 {
 	int offset=(idx*5+5);
-	char util[128];
 	double active_util = get_result_value(active_rindex, &all_results);
 	double partial_util = get_result_value(partial_rindex, &all_results);
 	double slumber_util = get_result_value(slumber_rindex, &all_results);
 	double devslp_util = get_result_value(devslp_rindex, &all_results);
 
-	snprintf(util, sizeof(util), "%5.1f",  active_util);
-	ahci_data[offset]= util;
+	ahci_data[offset]= std::format("{:5.1f}",  active_util);
 	offset +=1;
 
-	snprintf(util, sizeof(util), "%5.1f",  partial_util);
-	ahci_data[offset]= util;
+	ahci_data[offset]= std::format("{:5.1f}",  partial_util);
 	offset +=1;
 
-	snprintf(util, sizeof(util), "%5.1f",  slumber_util);
-	ahci_data[offset]= util;
+	ahci_data[offset]= std::format("{:5.1f}",  slumber_util);
 	offset +=1;
 
-	snprintf(util, sizeof(util), "%5.1f",  devslp_util);
-	ahci_data[offset]= util;
+	ahci_data[offset]= std::format("{:5.1f}",  devslp_util);
 }

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -49,11 +49,11 @@ static string disk_name(char *path, char *target, char *shortname)
 
 	DIR *dir;
 	struct dirent *dirent;
-	char pathname[PATH_MAX];
 	string diskname = "";
+	std::string pathname;
 
-	snprintf(pathname, sizeof(pathname), "%s/%s", path, target);
-	dir = opendir(pathname);
+	pathname = std::format("{}/{}", path, target);
+	dir = opendir(pathname.c_str());
 	if (!dir)
 		return diskname;
 
@@ -66,8 +66,7 @@ static string disk_name(char *path, char *target, char *shortname)
 		if (!strchr(dirent->d_name, ':'))
 			continue;
 
-		snprintf(line, sizeof(line), "%s/%s/model", pathname, dirent->d_name);
-		file = fopen(line, "r");
+		file = fopen(std::format("{}/{}/model", pathname, dirent->d_name).c_str(), "r");
 		if (file) {
 			if (fgets(line, sizeof(line), file) == NULL) {
 				fclose(file);
@@ -91,11 +90,11 @@ static string model_name(char *path, char *shortname)
 
 	DIR *dir;
 	struct dirent *dirent;
-	char pathname[PATH_MAX];
+	std::string pathname;
 
-	snprintf(pathname, sizeof(pathname), "%s/device", path);
+	pathname = std::format("{}/device", path);
 
-	dir = opendir(pathname);
+	dir = opendir(pathname.c_str());
 	if (!dir)
 		return strdup(shortname);
 
@@ -107,7 +106,7 @@ static string model_name(char *path, char *shortname)
 			continue;
 		if (!strstr(dirent->d_name, "target"))
 			continue;
-		return disk_name(pathname, dirent->d_name, shortname);
+		return disk_name((char *)pathname.c_str(), dirent->d_name, shortname);
 	}
 	closedir(dir);
 
@@ -126,9 +125,9 @@ ahci::ahci(char *_name, char *path): device()
 	start_slumber = 0;
 	start_devslp = 0;
 	start_partial = 0;
-	pt_strcpy(sysfs_path, path);
+	sysfs_path = path;
 
-	register_sysfs_path(sysfs_path);
+	register_sysfs_path(sysfs_path.c_str());
 
 	name = std::format("ahci:{}", _name);
 	active_index = get_param_index("ahci-link-power-active");
@@ -139,7 +138,7 @@ ahci::ahci(char *_name, char *path): device()
 	slumber_rindex = get_result_index(std::format("{}-slumber", name));
 	devslp_rindex = get_result_index(std::format("{}-devslp", name));
 
-	diskname = model_name(path, _name);
+	diskname = model_name((char *)sysfs_path.c_str(), _name);
 
 	if (diskname.empty())
 		humanname = std::format(_("SATA link: {}"), _name);
@@ -149,31 +148,26 @@ ahci::ahci(char *_name, char *path): device()
 
 void ahci::start_measurement(void)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 
-	snprintf(filename, sizeof(filename), "%s/ahci_alpm_active", sysfs_path);
 	try {
-		file.open(filename, ios::in);
+		file.open(std::format("{}/ahci_alpm_active", sysfs_path), ios::in);
 		if (file) {
 			file >> start_active;
 		}
 		file.close();
-		snprintf(filename, sizeof(filename), "%s/ahci_alpm_partial", sysfs_path);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/ahci_alpm_partial", sysfs_path), ios::in);
 
 		if (file) {
 			file >> start_partial;
 		}
 		file.close();
-		snprintf(filename, sizeof(filename), "%s/ahci_alpm_slumber", sysfs_path);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/ahci_alpm_slumber", sysfs_path), ios::in);
 		if (file) {
 			file >> start_slumber;
 		}
 		file.close();
-		snprintf(filename, sizeof(filename), "%s/ahci_alpm_devslp", sysfs_path);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/ahci_alpm_devslp", sysfs_path), ios::in);
 		if (file) {
 			file >> start_devslp;
 		}
@@ -187,32 +181,27 @@ void ahci::start_measurement(void)
 
 void ahci::end_measurement(void)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 	double p;
 	double total;
 
 	try {
-		snprintf(filename, sizeof(filename), "%s/ahci_alpm_active", sysfs_path);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/ahci_alpm_active", sysfs_path), ios::in);
 		if (file) {
 			file >> end_active;
 		}
 		file.close();
-		snprintf(filename, sizeof(filename), "%s/ahci_alpm_partial", sysfs_path);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/ahci_alpm_partial", sysfs_path), ios::in);
 		if (file) {
 			file >> end_partial;
 		}
 		file.close();
-		snprintf(filename, sizeof(filename), "%s/ahci_alpm_slumber", sysfs_path);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/ahci_alpm_slumber", sysfs_path), ios::in);
 		if (file) {
 			file >> end_slumber;
 		}
 		file.close();
-		snprintf(filename, sizeof(filename), "%s/ahci_alpm_devslp", sysfs_path);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/ahci_alpm_devslp", sysfs_path), ios::in);
 		if (file) {
 			file >> end_devslp;
 		}
@@ -273,7 +262,6 @@ void create_all_ahcis(void)
 {
 	struct dirent *entry;
 	DIR *dir;
-	char filename[PATH_MAX];
 
 	dir = opendir("/sys/class/scsi_host/");
 	if (!dir)
@@ -287,22 +275,20 @@ void create_all_ahcis(void)
 			break;
 		if (entry->d_name[0] == '.')
 			continue;
-		snprintf(filename, sizeof(filename), "/sys/class/scsi_host/%s/ahci_alpm_accounting", entry->d_name);
 
-		check_file.open(filename, ios::in);
+		check_file.open(std::format("/sys/class/scsi_host/{}/ahci_alpm_accounting", entry->d_name), ios::in);
 		check_file.get();
 		check_file.close();
 		if (check_file.bad())
 			continue;
 
-		file.open(filename, ios::in);
+		file.open(std::format("/sys/class/scsi_host/{}/ahci_alpm_accounting", entry->d_name), ios::in);
 		if (!file)
 			continue;
 		file << 1 ;
 		file.close();
-		snprintf(filename, sizeof(filename), "/sys/class/scsi_host/%s", entry->d_name);
 
-		bl = new class ahci(entry->d_name, filename);
+		bl = new class ahci(entry->d_name, (char *)std::format("/sys/class/scsi_host/{}", entry->d_name).c_str());
 		all_devices.push_back(bl);
 		register_parameter("ahci-link-power-active", 0.6);  /* active sata link takes about 0.6 W */
 		register_parameter("ahci-link-power-partial");

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -134,10 +134,10 @@ ahci::ahci(char *_name, char *path): device()
 	active_index = get_param_index("ahci-link-power-active");
 	partial_index = get_param_index("ahci-link-power-partial");
 
-	active_rindex = get_result_index(std::format("{}-active", name).c_str());
-	partial_rindex = get_result_index(std::format("{}-partial", name).c_str());
-	slumber_rindex = get_result_index(std::format("{}-slumber", name).c_str());
-	devslp_rindex = get_result_index(std::format("{}-devslp", name).c_str());
+	active_rindex = get_result_index(std::format("{}-active", name));
+	partial_rindex = get_result_index(std::format("{}-partial", name));
+	slumber_rindex = get_result_index(std::format("{}-slumber", name));
+	devslp_rindex = get_result_index(std::format("{}-devslp", name));
 
 	diskname = model_name(path, _name);
 

--- a/src/devices/ahci.h
+++ b/src/devices/ahci.h
@@ -48,7 +48,7 @@ class ahci: public device {
 	std::string humanname;
 public:
 
-	ahci(char *_name, char *path);
+	ahci(const std::string &_name, const std::string &path);
 
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);

--- a/src/devices/ahci.h
+++ b/src/devices/ahci.h
@@ -55,10 +55,9 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * class_name(void) { return "ahci";};
+	virtual std::string class_name(void) { return "ahci";};
 
-	virtual const char * device_name(void) { return name.c_str(); };
-	virtual std::string device_name_s(void) { return name; };
+	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(partial_rindex) + utilization_power_valid(active_rindex);};

--- a/src/devices/ahci.h
+++ b/src/devices/ahci.h
@@ -59,7 +59,7 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name(void) { return humanname.c_str(); };
+	virtual const char * human_name_cstr(void) { return humanname.c_str(); };
 	virtual std::string human_name_s(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(partial_rindex) + utilization_power_valid(active_rindex);};

--- a/src/devices/ahci.h
+++ b/src/devices/ahci.h
@@ -38,14 +38,14 @@ class ahci: public device {
 	uint64_t start_slumber, end_slumber;
 	uint64_t start_devslp, end_devslp;
 	char sysfs_path[PATH_MAX];
-	char name[4096];
+	std::string name;
 	int partial_rindex;
 	int active_rindex;
 	int slumber_rindex;
 	int devslp_rindex;
 	int partial_index;
 	int active_index;
-	char humanname[4096];
+	std::string humanname;
 public:
 
 	ahci(char *_name, char *path);
@@ -57,12 +57,14 @@ public:
 
 	virtual const char * class_name(void) { return "ahci";};
 
-	virtual const char * device_name(void);
-	virtual const char * human_name(void) { return humanname;};
+	virtual const char * device_name(void) { return name.c_str(); };
+	virtual std::string device_name_s(void) { return name; };
+	virtual const char * human_name(void) { return humanname.c_str(); };
+	virtual std::string human_name_s(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(partial_rindex) + utilization_power_valid(active_rindex);};
 	virtual int grouping_prio(void) { return 1; };
-	virtual void report_device_stats(string *ahci_data, int idx);
+	virtual void report_device_stats(std::string *ahci_data, int idx);
 };
 
 extern void create_all_ahcis(void);

--- a/src/devices/ahci.h
+++ b/src/devices/ahci.h
@@ -59,8 +59,7 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name_cstr(void) { return humanname.c_str(); };
-	virtual std::string human_name_s(void) { return humanname; };
+	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(partial_rindex) + utilization_power_valid(active_rindex);};
 	virtual int grouping_prio(void) { return 1; };

--- a/src/devices/ahci.h
+++ b/src/devices/ahci.h
@@ -37,7 +37,7 @@ class ahci: public device {
 	uint64_t start_partial, end_partial;
 	uint64_t start_slumber, end_slumber;
 	uint64_t start_devslp, end_devslp;
-	char sysfs_path[PATH_MAX];
+	std::string sysfs_path;
 	std::string name;
 	int partial_rindex;
 	int active_rindex;

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -183,16 +183,10 @@ void alsa::register_power_with_devlist(struct result_bundle *results, struct par
 		register_devpower(name, power_usage(results, bundle), this);
 }
 
-std::string alsa::human_name_s(void)
+std::string alsa::human_name(void)
 {
 	if (!guilty.empty())
 		return std::format("{} ({})", humanname, guilty);
 
 	return humanname;
-}
-
-const char * alsa::human_name_cstr(void)
-{
-	pt_strcpy(temp_buf, human_name_s().c_str());
-	return temp_buf;
 }

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -191,7 +191,7 @@ std::string alsa::human_name_s(void)
 	return humanname;
 }
 
-const char * alsa::human_name(void)
+const char * alsa::human_name_cstr(void)
 {
 	pt_strcpy(temp_buf, human_name_s().c_str());
 	return temp_buf;

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -41,7 +41,7 @@ using namespace std;
 #include <unistd.h>
 #include <format>
 
-alsa::alsa(const char *_name, const char *path): device()
+alsa::alsa(const string &_name, const string &path): device()
 {
 	ifstream file;
 
@@ -145,7 +145,7 @@ static void create_all_alsa_callback(const char *d_name)
 	if (access(std::format("/sys/class/sound/{}/power_on_acct", d_name).c_str(), R_OK) != 0)
 		return;
 
-	bl = new class alsa(d_name, std::format("/sys/class/sound/{}", d_name).c_str());
+	bl = new class alsa(d_name, std::format("/sys/class/sound/{}", d_name));
 	all_devices.push_back(bl);
 	register_parameter("alsa-codec-power", 0.5);
 }

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -56,7 +56,7 @@ alsa::alsa(const char *_name, const char *path): device()
 
 	name = std::format("alsa:{}", _name);
 	humanname = std::format("alsa:{}", _name);
-	rindex = get_result_index(name.c_str());
+	rindex = get_result_index(name);
 
 	model[0] = 0;
 	vendor[0] = 0;
@@ -131,7 +131,7 @@ void alsa::end_measurement(void)
 	}
 
 	p = (end_active - start_active) / (0.001 + end_active + end_inactive - start_active - start_inactive) * 100.0;
-	report_utilization(name.c_str(), p);
+	report_utilization(name, p);
 }
 
 
@@ -190,9 +190,9 @@ double alsa::power_usage(struct result_bundle *result, struct parameter_bundle *
 void alsa::register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle)
 {
 	if (name.length() > 7)
-		register_devpower(name.substr(7).c_str(), power_usage(results, bundle), this);
+		register_devpower(name.substr(7), power_usage(results, bundle), this);
 	else
-		register_devpower(name.c_str(), power_usage(results, bundle), this);
+		register_devpower(name, power_usage(results, bundle), this);
 }
 
 std::string alsa::human_name_s(void)

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -70,11 +70,11 @@ alsa::alsa(const char *_name, const char *path): device()
 		file.close();
 	}
 	if (strlen(model) && strlen(vendor))
-		humanname = std::format(_("Audio codec {}: {} ({})"), name, model, vendor);
+		humanname = pt_format(_("Audio codec {}: {} ({})"), name, model, vendor);
 	else if (strlen(model))
-		humanname = std::format(_("Audio codec {}: {}"), _name, model);
+		humanname = pt_format(_("Audio codec {}: {}"), _name, model);
 	else if (strlen(vendor))
-		humanname = std::format(_("Audio codec {}: {}"), _name, vendor);
+		humanname = pt_format(_("Audio codec {}: {}"), _name, vendor);
 }
 
 void alsa::start_measurement(void)

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -45,14 +45,13 @@ alsa::alsa(const char *_name, const char *path): device()
 {
 	ifstream file;
 
-	char devname[4096];
 	char model[4096];
 	char vendor[4096];
 	end_active = 0;
 	start_active = 0;
 	end_inactive = 0;
 	start_inactive = 0;
-	pt_strcpy(sysfs_path, path);
+	sysfs_path = path;
 
 	name = std::format("alsa:{}", _name);
 	humanname = std::format("alsa:{}", _name);
@@ -60,14 +59,12 @@ alsa::alsa(const char *_name, const char *path): device()
 
 	model[0] = 0;
 	vendor[0] = 0;
-	snprintf(devname, sizeof(devname), "%s/modelname", path);
-	file.open(devname);
+	file.open(std::format("{}/modelname", path));
 	if (file) {
 		file.getline(model, sizeof(model));
 		file.close();
 	}
-	snprintf(devname, sizeof(devname), "%s/vendor_name", path);
-	file.open(devname);
+	file.open(std::format("{}/vendor_name", path));
 	if (file) {
 		file.getline(vendor, sizeof(vendor));
 		file.close();
@@ -82,18 +79,15 @@ alsa::alsa(const char *_name, const char *path): device()
 
 void alsa::start_measurement(void)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 
-	snprintf(filename, sizeof(filename), "%s/power_off_acct", sysfs_path);
 	try {
-		file.open(filename, ios::in);
+		file.open(std::format("{}/power_off_acct", sysfs_path));
 		if (file) {
 			file >> start_inactive;
 		}
 		file.close();
-		snprintf(filename, sizeof(filename), "%s/power_on_acct", sysfs_path);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/power_on_acct", sysfs_path));
 
 		if (file) {
 			file >> start_active;
@@ -107,19 +101,16 @@ void alsa::start_measurement(void)
 
 void alsa::end_measurement(void)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 	double p;
 
-	snprintf(filename, sizeof(filename), "%s/power_off_acct", sysfs_path);
 	try {
-		file.open(filename, ios::in);
+		file.open(std::format("{}/power_off_acct", sysfs_path));
 		if (file) {
 			file >> end_inactive;
 		}
 		file.close();
-		snprintf(filename, sizeof(filename), "%s/power_on_acct", sysfs_path);
-		file.open(filename, ios::in);
+		file.open(std::format("{}/power_on_acct", sysfs_path));
 
 		if (file) {
 			file >> end_active;
@@ -146,18 +137,15 @@ double alsa::utilization(void)
 
 static void create_all_alsa_callback(const char *d_name)
 {
-	char filename[PATH_MAX];
 	class alsa *bl;
 
 	if (strncmp(d_name, "hwC", 3) != 0)
 		return;
 
-	snprintf(filename, sizeof(filename), "/sys/class/sound/%s/power_on_acct", d_name);
-	if (access(filename, R_OK) != 0)
+	if (access(std::format("/sys/class/sound/{}/power_on_acct", d_name).c_str(), R_OK) != 0)
 		return;
 
-	snprintf(filename, sizeof(filename), "/sys/class/sound/%s", d_name);
-	bl = new class alsa(d_name, filename);
+	bl = new class alsa(d_name, std::format("/sys/class/sound/{}", d_name).c_str());
 	all_devices.push_back(bl);
 	register_parameter("alsa-codec-power", 0.5);
 }

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -39,6 +39,7 @@ using namespace std;
 
 #include <string.h>
 #include <unistd.h>
+#include <format>
 
 alsa::alsa(const char *_name, const char *path): device()
 {
@@ -58,7 +59,6 @@ alsa::alsa(const char *_name, const char *path): device()
 	pt_strcpy(name, devname);
 	rindex = get_result_index(name);
 
-	guilty[0] = 0;
 	model[0] = 0;
 	vendor[0] = 0;
 	snprintf(devname, sizeof(devname), "%s/modelname", path);
@@ -201,7 +201,7 @@ void alsa::register_power_with_devlist(struct result_bundle *results, struct par
 const char * alsa::human_name(void)
 {
 	pt_strcpy(temp_buf, humanname);
-	if (strlen(guilty) > 0)
-		snprintf(temp_buf, sizeof(temp_buf), "%s (%s)", humanname, guilty);
+	if (!guilty.empty())
+		pt_strcpy(temp_buf, std::format("{} ({})", humanname, guilty).c_str());
 	return temp_buf;
 }

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -55,7 +55,7 @@ alsa::alsa(const char *_name, const char *path): device()
 	pt_strcpy(sysfs_path, path);
 
 	snprintf(devname, sizeof(devname), "alsa:%s", _name);
-	snprintf(humanname, sizeof(humanname), "alsa:%s", _name);
+	humanname = std::format("alsa:{}", _name);
 	pt_strcpy(name, devname);
 	rindex = get_result_index(name);
 
@@ -74,11 +74,11 @@ alsa::alsa(const char *_name, const char *path): device()
 		file.close();
 	}
 	if (strlen(model) && strlen(vendor))
-		snprintf(humanname, sizeof(humanname), _("Audio codec %s: %s (%s)"), name, model, vendor);
+		humanname = std::format(_("Audio codec {}: {} ({})"), name, model, vendor);
 	else if (strlen(model))
-		snprintf(humanname, sizeof(humanname), _("Audio codec %s: %s"), _name, model);
+		humanname = std::format(_("Audio codec {}: {}"), _name, model);
 	else if (strlen(vendor))
-		snprintf(humanname, sizeof(humanname), _("Audio codec %s: %s"), _name, vendor);
+		humanname = std::format(_("Audio codec {}: {}"), _name, vendor);
 }
 
 void alsa::start_measurement(void)
@@ -198,10 +198,16 @@ void alsa::register_power_with_devlist(struct result_bundle *results, struct par
 	register_devpower(&name[7], power_usage(results, bundle), this);
 }
 
+std::string alsa::human_name_s(void)
+{
+	if (!guilty.empty())
+		return std::format("{} ({})", humanname, guilty);
+
+	return humanname;
+}
+
 const char * alsa::human_name(void)
 {
-	pt_strcpy(temp_buf, humanname);
-	if (!guilty.empty())
-		pt_strcpy(temp_buf, std::format("{} ({})", humanname, guilty).c_str());
+	pt_strcpy(temp_buf, human_name_s().c_str());
 	return temp_buf;
 }

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -54,10 +54,9 @@ alsa::alsa(const char *_name, const char *path): device()
 	start_inactive = 0;
 	pt_strcpy(sysfs_path, path);
 
-	snprintf(devname, sizeof(devname), "alsa:%s", _name);
+	name = std::format("alsa:{}", _name);
 	humanname = std::format("alsa:{}", _name);
-	pt_strcpy(name, devname);
-	rindex = get_result_index(name);
+	rindex = get_result_index(name.c_str());
 
 	model[0] = 0;
 	vendor[0] = 0;
@@ -132,7 +131,7 @@ void alsa::end_measurement(void)
 	}
 
 	p = (end_active - start_active) / (0.001 + end_active + end_inactive - start_active - start_inactive) * 100.0;
-	report_utilization(name, p);
+	report_utilization(name.c_str(), p);
 }
 
 
@@ -143,11 +142,6 @@ double alsa::utilization(void)
 	p = (end_active - start_active) / (0.001 + end_active - start_active + end_inactive - start_inactive) * 100.0;
 
 	return p;
-}
-
-const char * alsa::device_name(void)
-{
-	return name;
 }
 
 static void create_all_alsa_callback(const char *d_name)
@@ -195,7 +189,10 @@ double alsa::power_usage(struct result_bundle *result, struct parameter_bundle *
 
 void alsa::register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle)
 {
-	register_devpower(&name[7], power_usage(results, bundle), this);
+	if (name.length() > 7)
+		register_devpower(name.substr(7).c_str(), power_usage(results, bundle), this);
+	else
+		register_devpower(name.c_str(), power_usage(results, bundle), this);
 }
 
 std::string alsa::human_name_s(void)

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -31,13 +31,14 @@
 
 #include <stdint.h>
 #include <limits.h>
+#include <string>
 
 class alsa: public device {
 	uint64_t start_active, end_active;
 	uint64_t start_inactive, end_inactive;
 	char sysfs_path[PATH_MAX];
 	char name[4096];
-	char humanname[4096];
+	std::string humanname;
 	char temp_buf[4096];
 	int rindex;
 public:
@@ -53,6 +54,7 @@ public:
 
 	virtual const char * device_name(void);
 	virtual const char * human_name(void);
+	virtual std::string human_name_s(void);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex);};
 

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -36,7 +36,7 @@
 class alsa: public device {
 	uint64_t start_active, end_active;
 	uint64_t start_inactive, end_inactive;
-	char sysfs_path[PATH_MAX];
+	std::string sysfs_path;
 	std::string name;
 	std::string humanname;
 	char temp_buf[4096];

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -49,10 +49,9 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * class_name(void) { return "alsa";};
+	virtual std::string class_name(void) { return "alsa";};
 
-	virtual const char * device_name(void) { return name.c_str(); };
-	virtual std::string device_name_s(void) { return name; };
+	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex);};

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -39,7 +39,6 @@ class alsa: public device {
 	std::string sysfs_path;
 	std::string name;
 	std::string humanname;
-	char temp_buf[4096];
 	int rindex;
 public:
 
@@ -54,8 +53,7 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name_cstr(void);
-	virtual std::string human_name_s(void);
+	virtual std::string human_name(void);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex);};
 

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -54,7 +54,7 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name(void);
+	virtual const char * human_name_cstr(void);
 	virtual std::string human_name_s(void);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex);};

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -42,7 +42,7 @@ class alsa: public device {
 	int rindex;
 public:
 
-	alsa(const char *_name, const char *path);
+	alsa(const std::string &_name, const std::string &path);
 
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -37,7 +37,7 @@ class alsa: public device {
 	uint64_t start_active, end_active;
 	uint64_t start_inactive, end_inactive;
 	char sysfs_path[PATH_MAX];
-	char name[4096];
+	std::string name;
 	std::string humanname;
 	char temp_buf[4096];
 	int rindex;
@@ -52,7 +52,8 @@ public:
 
 	virtual const char * class_name(void) { return "alsa";};
 
-	virtual const char * device_name(void);
+	virtual const char * device_name(void) { return name.c_str(); };
+	virtual std::string device_name_s(void) { return name; };
 	virtual const char * human_name(void);
 	virtual std::string human_name_s(void);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);

--- a/src/devices/backlight.cpp
+++ b/src/devices/backlight.cpp
@@ -50,7 +50,7 @@ backlight::backlight(const char *_name, const char *path): device()
 	pt_strcpy(sysfs_path, path);
 	register_sysfs_path(sysfs_path);
 	name = std::format("backlight:{}", _name);
-	r_index = get_result_index(name.c_str());
+	r_index = get_result_index(name);
 	r_index_power = 0;
 }
 
@@ -136,8 +136,8 @@ void backlight::end_measurement(void)
 		p = 0;
 	}
 
-	report_utilization(name.c_str(), p);
-	report_utilization(std::format("{}-power", name).c_str(), _backlight);
+	report_utilization(name, p);
+	report_utilization(std::format("{}-power", name), _backlight);
 }
 
 
@@ -207,7 +207,7 @@ double backlight::power_usage(struct result_bundle *result, struct parameter_bun
 	factor = get_parameter_value(blp_index, bundle);
 
 	if (!r_index_power) {
-		r_index_power = get_result_index(std::format("{}-power", name).c_str());
+		r_index_power = get_result_index(std::format("{}-power", name));
 	}
 	_utilization = get_result_value(r_index_power, result);
 

--- a/src/devices/backlight.cpp
+++ b/src/devices/backlight.cpp
@@ -47,8 +47,8 @@ backlight::backlight(const char *_name, const char *path): device()
 	max_level = 0;
 	start_level = 0;
 	end_level = 0;
-	pt_strcpy(sysfs_path, path);
-	register_sysfs_path(sysfs_path);
+	sysfs_path = path;
+	register_sysfs_path(sysfs_path.c_str());
 	name = std::format("backlight:{}", _name);
 	r_index = get_result_index(name);
 	r_index_power = 0;
@@ -56,18 +56,15 @@ backlight::backlight(const char *_name, const char *path): device()
 
 void backlight::start_measurement(void)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 
-	snprintf(filename, sizeof(filename), "%s/max_brightness", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/max_brightness", sysfs_path));
 	if (file) {
 		file >> max_level;
 	}
 	file.close();
 
-	snprintf(filename, sizeof(filename), "%s/actual_brightness", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/actual_brightness", sysfs_path));
 	if (file) {
 		file >> start_level;
 		file.close();
@@ -78,8 +75,7 @@ static int dpms_screen_on(void)
 {
 	DIR *dir;
 	struct dirent *entry;
-	char filename[PATH_MAX];
-	char line[4096];
+	std::string line;
 	ifstream file;
 
 	dir = opendir("/sys/class/drm/card0");
@@ -92,21 +88,19 @@ static int dpms_screen_on(void)
 
 		if (strncmp(entry->d_name, "card", 4) != 0)
 			continue;
-		snprintf(filename, sizeof(filename), "/sys/class/drm/card0/%s/enabled", entry->d_name);
-		file.open(filename, ios::in);
+		file.open(std::format("/sys/class/drm/card0/{}/enabled", entry->d_name));
 		if (!file)
 			continue;
-		file.getline(line, sizeof(line));
+		getline(file, line);
 		file.close();
-		if (strcmp(line, "enabled") != 0)
+		if (line != "enabled")
 			continue;
-		snprintf(filename, sizeof(filename), "/sys/class/drm/card0/%s/dpms", entry->d_name);
-		file.open(filename, ios::in);
+		file.open(std::format("/sys/class/drm/card0/{}/dpms", entry->d_name));
 		if (!file)
 			continue;
-		file.getline(line, sizeof(line));
+		getline(file, line);
 		file.close();
-		if (strcmp(line, "On") == 0) {
+		if (line == "On") {
 			closedir(dir);
 			return 1;
 		}
@@ -117,13 +111,11 @@ static int dpms_screen_on(void)
 
 void backlight::end_measurement(void)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 	double p;
 	int _backlight = 0;
 
-	snprintf(filename, sizeof(filename), "%s/actual_brightness", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/actual_brightness", sysfs_path));
 	if (file) {
 		file >> end_level;
 	}
@@ -152,9 +144,7 @@ double backlight::utilization(void)
 static void create_all_backlights_callback(const char *d_name)
 {
 	class backlight *bl;
-	char filename[PATH_MAX];
-	snprintf(filename, sizeof(filename), "/sys/class/backlight/%s", d_name);
-	bl = new class backlight(d_name, filename);
+	bl = new class backlight(d_name, std::format("/sys/class/backlight/{}", d_name).c_str());
 	all_devices.push_back(bl);
 }
 

--- a/src/devices/backlight.cpp
+++ b/src/devices/backlight.cpp
@@ -41,14 +41,14 @@ using namespace std;
 #include <format>
 
 
-backlight::backlight(const char *_name, const char *path): device()
+backlight::backlight(const string &_name, const string &path): device()
 {
 	min_level = 0;
 	max_level = 0;
 	start_level = 0;
 	end_level = 0;
 	sysfs_path = path;
-	register_sysfs_path(sysfs_path.c_str());
+	register_sysfs_path(sysfs_path);
 	name = std::format("backlight:{}", _name);
 	r_index = get_result_index(name);
 	r_index_power = 0;
@@ -144,7 +144,7 @@ double backlight::utilization(void)
 static void create_all_backlights_callback(const char *d_name)
 {
 	class backlight *bl;
-	bl = new class backlight(d_name, std::format("/sys/class/backlight/{}", d_name).c_str());
+	bl = new class backlight(d_name, std::format("/sys/class/backlight/{}", d_name));
 	all_devices.push_back(bl);
 }
 

--- a/src/devices/backlight.cpp
+++ b/src/devices/backlight.cpp
@@ -38,6 +38,7 @@ using namespace std;
 #include "../parameters/parameters.h"
 
 #include <string.h>
+#include <format>
 
 
 backlight::backlight(const char *_name, const char *path): device()
@@ -48,8 +49,8 @@ backlight::backlight(const char *_name, const char *path): device()
 	end_level = 0;
 	pt_strcpy(sysfs_path, path);
 	register_sysfs_path(sysfs_path);
-	snprintf(name, sizeof(name) - 1, "backlight:%s", _name);
-	r_index = get_result_index(name);
+	name = std::format("backlight:{}", _name);
+	r_index = get_result_index(name.c_str());
 	r_index_power = 0;
 }
 
@@ -117,7 +118,6 @@ static int dpms_screen_on(void)
 void backlight::end_measurement(void)
 {
 	char filename[PATH_MAX];
-	char powername[4096];
 	ifstream file;
 	double p;
 	int _backlight = 0;
@@ -136,9 +136,8 @@ void backlight::end_measurement(void)
 		p = 0;
 	}
 
-	report_utilization(name, p);
-	snprintf(powername, sizeof(powername), "%s-power", name);
-	report_utilization(powername, _backlight);
+	report_utilization(name.c_str(), p);
+	report_utilization(std::format("{}-power", name).c_str(), _backlight);
 }
 
 
@@ -148,11 +147,6 @@ double backlight::utilization(void)
 
 	p = 100.0 * (end_level + start_level) / 2 / max_level;
 	return p;
-}
-
-const char * backlight::device_name(void)
-{
-	return name;
 }
 
 static void create_all_backlights_callback(const char *d_name)
@@ -179,7 +173,6 @@ double backlight::power_usage(struct result_bundle *result, struct parameter_bun
 	double power;
 	double factor;
 	double _utilization;
-	char powername[4096];
 	static int bl_index = 0, blp_index = 0, bl_boost_index40 = 0, bl_boost_index80, bl_boost_index100;
 
 	if (!bl_index)
@@ -214,8 +207,7 @@ double backlight::power_usage(struct result_bundle *result, struct parameter_bun
 	factor = get_parameter_value(blp_index, bundle);
 
 	if (!r_index_power) {
-		sprintf(powername, "%s-power", name);
-		r_index_power = get_result_index(powername);
+		r_index_power = get_result_index(std::format("{}-power", name).c_str());
 	}
 	_utilization = get_result_value(r_index_power, result);
 

--- a/src/devices/backlight.h
+++ b/src/devices/backlight.h
@@ -33,7 +33,7 @@
 class backlight: public device {
 	int min_level, max_level;
 	int start_level, end_level;
-	char sysfs_path[PATH_MAX];
+	std::string sysfs_path;
 	std::string name;
 	int r_index;
 	int r_index_power;

--- a/src/devices/backlight.h
+++ b/src/devices/backlight.h
@@ -50,8 +50,7 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name_cstr(void) { return "Display backlight";};
-	virtual std::string human_name_s(void) { return human_name_cstr(); };
+	virtual std::string human_name(void) { return "Display backlight";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int grouping_prio(void) { return 10; };
 };

--- a/src/devices/backlight.h
+++ b/src/devices/backlight.h
@@ -46,10 +46,9 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * class_name(void) { return "backlight";};
+	virtual std::string class_name(void) { return "backlight";};
 
-	virtual const char * device_name(void) { return name.c_str(); };
-	virtual std::string device_name_s(void) { return name; };
+	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void) { return "Display backlight";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int grouping_prio(void) { return 10; };

--- a/src/devices/backlight.h
+++ b/src/devices/backlight.h
@@ -26,6 +26,7 @@
 #define _INCLUDE_GUARD_BACKLIGHT_H
 
 #include <limits.h>
+#include <string>
 
 #include "device.h"
 
@@ -33,7 +34,7 @@ class backlight: public device {
 	int min_level, max_level;
 	int start_level, end_level;
 	char sysfs_path[PATH_MAX];
-	char name[4096];
+	std::string name;
 	int r_index;
 	int r_index_power;
 public:
@@ -47,8 +48,10 @@ public:
 
 	virtual const char * class_name(void) { return "backlight";};
 
-	virtual const char * device_name(void);
+	virtual const char * device_name(void) { return name.c_str(); };
+	virtual std::string device_name_s(void) { return name; };
 	virtual const char * human_name(void) { return "Display backlight";};
+	virtual std::string human_name_s(void) { return human_name(); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int grouping_prio(void) { return 10; };
 };

--- a/src/devices/backlight.h
+++ b/src/devices/backlight.h
@@ -50,8 +50,8 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name(void) { return "Display backlight";};
-	virtual std::string human_name_s(void) { return human_name(); };
+	virtual const char * human_name_cstr(void) { return "Display backlight";};
+	virtual std::string human_name_s(void) { return human_name_cstr(); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int grouping_prio(void) { return 10; };
 };

--- a/src/devices/backlight.h
+++ b/src/devices/backlight.h
@@ -39,7 +39,7 @@ class backlight: public device {
 	int r_index_power;
 public:
 
-	backlight(const char *_name, const char *path);
+	backlight(const std::string &_name, const std::string &path);
 
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -44,15 +44,19 @@ static DIR *dir = NULL;
 
 static vector<class devfreq *> all_devfreq;
 
-devfreq::devfreq(const char* dpath): device()
+devfreq::devfreq(const string &dpath): device()
 {
 	dir_name = dpath;
 }
 
-uint64_t devfreq::parse_freq_time(char* pchr)
+uint64_t devfreq::parse_freq_time(const string &pchr_s)
 {
-	char *cptr, *pptr = pchr;
+	char *cptr, *pptr;
+	char pchr[pchr_s.length() + 1];
 	uint64_t ctime;
+
+	strcpy(pchr, pchr_s.c_str());
+	pptr = pchr;
 
 	cptr = strtok(pchr, " :");
 	while (cptr != NULL) {
@@ -118,7 +122,7 @@ void devfreq::update_devfreq_freq_state(uint64_t freq, uint64_t time)
 	state->time_after = time;
 }
 
-void devfreq::parse_devfreq_trans_stat(const char *dname)
+void devfreq::parse_devfreq_trans_stat(const string &dname)
 {
 	ifstream file;
 	std::string filename;
@@ -163,14 +167,14 @@ void devfreq::start_measurement(void)
 	sample_time = 0;
 
 	gettimeofday(&stamp_before, NULL);
-	parse_devfreq_trans_stat(dir_name.c_str());
+	parse_devfreq_trans_stat(dir_name);
 	/* add device idle state */
 	update_devfreq_freq_state(0, 0);
 }
 
 void devfreq::end_measurement(void)
 {
-	parse_devfreq_trans_stat(dir_name.c_str());
+	parse_devfreq_trans_stat(dir_name);
 	gettimeofday(&stamp_after, NULL);
 	process_time_stamps();
 }
@@ -185,23 +189,21 @@ double devfreq::utilization(void)
 	return 0;
 }
 
-void devfreq::fill_freq_utilization(unsigned int idx, char *buf)
+string devfreq::fill_freq_utilization(unsigned int idx)
 {
-	buf[0] = 0;
-
 	if (idx < dstates.size() && dstates[idx]) {
 		class frequency *state = dstates[idx];
-		sprintf(buf, " %5.1f%% ", percentage(1.0 * state->time_after / sample_time));
+		return std::format(" {:5.1f}% ", percentage(1.0 * state->time_after / sample_time));
 	}
+	return "";
 }
 
-void devfreq::fill_freq_name(unsigned int idx, char *buf)
+string devfreq::fill_freq_name(unsigned int idx)
 {
-	buf[0] = 0;
-
 	if (idx < dstates.size() && dstates[idx]) {
-		sprintf(buf, "%-15s", dstates[idx]->human_name.c_str());
+		return std::format("{:<15}", dstates[idx]->human_name);
 	}
+	return "";
 }
 
 void start_devfreq_measurement(void)
@@ -264,8 +266,6 @@ void display_devfreq_devices(void)
 {
 	unsigned int i, j;
 	WINDOW *win;
-	char fline[1024];
-	char buf[128];
 
 	win = get_ncurses_win("Device Freq stats");
         if (!win)
@@ -290,14 +290,9 @@ void display_devfreq_devices(void)
 		wprintw(win, "\n%s\n", df->device_name().c_str());
 
 		for(j=0; j < df->dstates.size(); j++) {
-			memset(fline, 0, sizeof(fline));
-			strcpy(fline, "\t");
-			df->fill_freq_name(j, buf);
-			strcat(fline, buf);
-			df->fill_freq_utilization(j, buf);
-			strcat(fline, buf);
-			strcat(fline, "\n");
-			wprintw(win, "%s", fline);
+			std::string f_name = df->fill_freq_name(j);
+			std::string f_util = df->fill_freq_utilization(j);
+			wprintw(win, "\t%s%s\n", f_name.c_str(), f_util.c_str());
 		}
 		wprintw(win, "\n");
 	}

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -25,6 +25,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <format>
 
 #include <dirent.h>
 #include <stdlib.h>
@@ -45,7 +46,7 @@ static vector<class devfreq *> all_devfreq;
 
 devfreq::devfreq(const char* dpath): device()
 {
-	pt_strcpy(dir_name, dpath);
+	dir_name = dpath;
 }
 
 uint64_t devfreq::parse_freq_time(char* pchr)
@@ -118,13 +119,13 @@ void devfreq::update_devfreq_freq_state(uint64_t freq, uint64_t time)
 	state->time_after = time;
 }
 
-void devfreq::parse_devfreq_trans_stat(char *dname)
+void devfreq::parse_devfreq_trans_stat(const char *dname)
 {
 	ifstream file;
-	char filename[256];
+	std::string filename;
 
-	snprintf(filename, sizeof(filename), "/sys/class/devfreq/%s/trans_stat", dir_name);
-	file.open(filename);
+	filename = std::format("/sys/class/devfreq/{}/trans_stat", dir_name);
+	file.open(filename.c_str());
 
 	if (!file)
 		return;
@@ -163,14 +164,14 @@ void devfreq::start_measurement(void)
 	sample_time = 0;
 
 	gettimeofday(&stamp_before, NULL);
-	parse_devfreq_trans_stat(dir_name);
+	parse_devfreq_trans_stat(dir_name.c_str());
 	/* add device idle state */
 	update_devfreq_freq_state(0, 0);
 }
 
 void devfreq::end_measurement(void)
 {
-	parse_devfreq_trans_stat(dir_name);
+	parse_devfreq_trans_stat(dir_name.c_str());
 	gettimeofday(&stamp_after, NULL);
 	process_time_stamps();
 }

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -74,7 +74,7 @@ void devfreq::process_time_stamps()
 			+ ((stamp_after.tv_usec - stamp_before.tv_usec) );
 
 	for (i=0; i < dstates.size()-1; i++) {
-		struct frequency *state = dstates[i];
+		class frequency *state = dstates[i];
 		state->time_after = 1000 * (state->time_after - state->time_before);
 		active_time += state->time_after;
 	}
@@ -84,27 +84,26 @@ void devfreq::process_time_stamps()
 
 void devfreq::add_devfreq_freq_state(uint64_t freq, uint64_t time)
 {
-	struct frequency *state;
+	class frequency *state;
 
-	state = new(std::nothrow) struct frequency;
+	state = new(std::nothrow) class frequency;
 	if (!state)
 		return;
 
-	memset(state, 0, sizeof(*state));
 	dstates.push_back(state);
 
 	state->freq = freq;
 	if (freq == 0)
-		strcpy(state->human_name, "Idle");
+		state->human_name = "Idle";
 	else
-		hz_to_human(freq, state->human_name);
+		state->human_name = hz_to_human(freq);
 	state->time_before = time;
 }
 
 void devfreq::update_devfreq_freq_state(uint64_t freq, uint64_t time)
 {
 	unsigned int i;
-	struct frequency *state = NULL;
+	class frequency *state = NULL;
 
 	for(i=0; i < dstates.size(); i++) {
 		if (freq == dstates[i]->freq)
@@ -191,7 +190,7 @@ void devfreq::fill_freq_utilization(unsigned int idx, char *buf)
 	buf[0] = 0;
 
 	if (idx < dstates.size() && dstates[idx]) {
-		struct frequency *state = dstates[idx];
+		class frequency *state = dstates[idx];
 		sprintf(buf, " %5.1f%% ", percentage(1.0 * state->time_after / sample_time));
 	}
 }
@@ -201,7 +200,7 @@ void devfreq::fill_freq_name(unsigned int idx, char *buf)
 	buf[0] = 0;
 
 	if (idx < dstates.size() && dstates[idx]) {
-		sprintf(buf, "%-15s", dstates[idx]->human_name);
+		sprintf(buf, "%-15s", dstates[idx]->human_name.c_str());
 	}
 }
 

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -287,7 +287,7 @@ void display_devfreq_devices(void)
 	for (i=0; i<all_devfreq.size(); i++) {
 
 		class devfreq *df = all_devfreq[i];
-		wprintw(win, "\n%s\n", df->device_name());
+		wprintw(win, "\n%s\n", df->device_name().c_str());
 
 		for(j=0; j < df->dstates.size(); j++) {
 			memset(fline, 0, sizeof(fline));

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -28,18 +28,19 @@
 #include "device.h"
 #include "../parameters/parameters.h"
 #include <sys/time.h>
+#include <string>
 
 struct frequency;
 
 class devfreq: public device {
-	char dir_name[128];
+	std::string dir_name;
 	struct timeval  stamp_before, stamp_after;
 	double sample_time;
 
 	uint64_t parse_freq_time(char *ptr);
 	void add_devfreq_freq_state(uint64_t freq, uint64_t time);
 	void update_devfreq_freq_state(uint64_t freq, uint64_t time);
-	void parse_devfreq_trans_stat(char *dname);
+	void parse_devfreq_trans_stat(const char *dname);
 	void process_time_stamps();
 
 public:
@@ -57,8 +58,10 @@ public:
 
 	virtual const char * class_name(void) { return "devfreq";};
 
-	virtual const char * device_name(void) { return dir_name;};
+	virtual const char * device_name(void) { return dir_name.c_str(); };
+	virtual std::string device_name_s(void) { return dir_name; };
 	virtual const char * human_name(void) { return "devfreq";};
+	virtual std::string human_name_s(void) { return human_name(); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return " rpm"; };
 	virtual int power_valid(void) { return 0; /*utilization_power_valid(r_index);*/};

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -61,7 +61,7 @@ public:
 	virtual std::string device_name(void) { return dir_name; };
 	virtual std::string human_name(void) { return "devfreq";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual const char * util_units(void) { return " rpm"; };
+	virtual std::string util_units(void) { return " rpm"; };
 	virtual int power_valid(void) { return 0; /*utilization_power_valid(r_index);*/};
 	virtual int grouping_prio(void) { return 1; };
 };

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -60,8 +60,7 @@ public:
 
 	virtual const char * device_name(void) { return dir_name.c_str(); };
 	virtual std::string device_name_s(void) { return dir_name; };
-	virtual const char * human_name_cstr(void) { return "devfreq";};
-	virtual std::string human_name_s(void) { return human_name_cstr(); };
+	virtual std::string human_name(void) { return "devfreq";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return " rpm"; };
 	virtual int power_valid(void) { return 0; /*utilization_power_valid(r_index);*/};

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -37,19 +37,19 @@ class devfreq: public device {
 	struct timeval  stamp_before, stamp_after;
 	double sample_time;
 
-	uint64_t parse_freq_time(char *ptr);
+	uint64_t parse_freq_time(const std::string &ptr);
 	void add_devfreq_freq_state(uint64_t freq, uint64_t time);
 	void update_devfreq_freq_state(uint64_t freq, uint64_t time);
-	void parse_devfreq_trans_stat(const char *dname);
+	void parse_devfreq_trans_stat(const std::string &dname);
 	void process_time_stamps();
 
 public:
 
 	vector<class frequency *> dstates;
 
-	devfreq(const char *c);
-	void fill_freq_utilization(unsigned int idx, char *buf);
-	void fill_freq_name(unsigned int idx, char *buf);
+	devfreq(const std::string &c);
+	std::string fill_freq_utilization(unsigned int idx);
+	std::string fill_freq_name(unsigned int idx);
 
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -60,8 +60,8 @@ public:
 
 	virtual const char * device_name(void) { return dir_name.c_str(); };
 	virtual std::string device_name_s(void) { return dir_name; };
-	virtual const char * human_name(void) { return "devfreq";};
-	virtual std::string human_name_s(void) { return human_name(); };
+	virtual const char * human_name_cstr(void) { return "devfreq";};
+	virtual std::string human_name_s(void) { return human_name_cstr(); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return " rpm"; };
 	virtual int power_valid(void) { return 0; /*utilization_power_valid(r_index);*/};

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -30,7 +30,7 @@
 #include <sys/time.h>
 #include <string>
 
-struct frequency;
+class frequency;
 
 class devfreq: public device {
 	std::string dir_name;
@@ -45,7 +45,7 @@ class devfreq: public device {
 
 public:
 
-	vector<struct frequency *> dstates;
+	vector<class frequency *> dstates;
 
 	devfreq(const char *c);
 	void fill_freq_utilization(unsigned int idx, char *buf);

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -56,10 +56,9 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * class_name(void) { return "devfreq";};
+	virtual std::string class_name(void) { return "devfreq";};
 
-	virtual const char * device_name(void) { return dir_name.c_str(); };
-	virtual std::string device_name_s(void) { return dir_name; };
+	virtual std::string device_name(void) { return dir_name; };
 	virtual std::string human_name(void) { return "devfreq";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return " rpm"; };

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -64,22 +64,19 @@ device::device(void)
 
 void device::register_sysfs_path(const char *path)
 {
-	char current_path[PATH_MAX + 1];
+	std::string current_path = path;
 	int iter = 0;
 	char resolved_path[PATH_MAX + 1];
 
-	pt_strcpy(current_path, path);
-
 	while (iter++ < 10) {
-		char test_path[PATH_MAX + 1];
-		snprintf(test_path, sizeof(test_path), "%s/device", current_path);
-		if (access(test_path, R_OK) == 0)
-			strcpy(current_path, test_path);
+		std::string test_path = current_path + "/device";
+		if (access(test_path.c_str(), R_OK) == 0)
+			current_path = test_path;
 		else
 			break;
 	}
 
-	if (realpath(current_path, resolved_path))
+	if (realpath(current_path.c_str(), resolved_path))
 		real_path = resolved_path;
 	else
 		real_path.clear();

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -62,7 +62,7 @@ device::device(void)
 }
 
 
-void device::register_sysfs_path(const char *path)
+void device::register_sysfs_path(const std::string &path)
 {
 	std::string current_path = path;
 	int iter = 0;

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -213,7 +213,7 @@ void report_devices(void)
 		wprintw(win, "%s %s %s\n",
 			power.c_str(),
 			util.c_str(),
-			all_devices[i]->human_name_s().c_str()
+			all_devices[i]->human_name().c_str()
 			);
 	}
 }
@@ -307,7 +307,7 @@ void show_report_devices(void)
 		device_data[idx]= util;
 		idx+=1;
 
-		device_data[idx]= all_devices[i]->human_name_s();
+		device_data[idx]= all_devices[i]->human_name();
 		idx+=1;
 
 		if (show_power) {

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -59,7 +59,6 @@ device::device(void)
 	cached_valid = 0;
 	hide = 0;
 
-	memset(guilty, 0, sizeof(guilty));
 	memset(real_path, 0, sizeof(real_path));
 }
 

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -190,7 +190,7 @@ void report_devices(void)
 
 		util = "";
 
-		if (all_devices[i]->util_units()) {
+		if (!all_devices[i]->util_units().empty()) {
 			if (all_devices[i]->utilization() < 1000)
 				util = std::format("{:5.1f}{}",  all_devices[i]->utilization(),  all_devices[i]->util_units());
 			else
@@ -280,7 +280,7 @@ void show_report_devices(void)
 		std::string util;
 		std::string power;
 
-		if (all_devices[i]->util_units()) {
+		if (!all_devices[i]->util_units().empty()) {
 			if (all_devices[i]->utilization() < 1000)
 				util = std::format("{:5.1f}{}",
 					all_devices[i]->utilization(),

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -213,7 +213,7 @@ void report_devices(void)
 		wprintw(win, "%s %s %s\n",
 			power.c_str(),
 			util.c_str(),
-			all_devices[i]->human_name()
+			all_devices[i]->human_name_s().c_str()
 			);
 	}
 }

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -30,6 +30,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <format>
 
 using namespace std;
 
@@ -149,8 +150,8 @@ void report_devices(void)
 	int show_power;
 	double pw;
 
-	char util[128];
-	char power[128];
+	std::string util;
+	char power_buf[128];
 
 	win = get_ncurses_win("Device stats");
         if (!win)
@@ -189,28 +190,30 @@ void report_devices(void)
 
 	for (i = 0; i < all_devices.size(); i++) {
 		double P;
+		std::string power;
 
-		util[0] = 0;
+		util = "";
 
 		if (all_devices[i]->util_units()) {
 			if (all_devices[i]->utilization() < 1000)
-				sprintf(util, "%5.1f%s",  all_devices[i]->utilization(),  all_devices[i]->util_units());
+				util = std::format("{:5.1f}{}",  all_devices[i]->utilization(),  all_devices[i]->util_units());
 			else
-				sprintf(util, "%5i%s",  (int)all_devices[i]->utilization(),  all_devices[i]->util_units());
+				util = std::format("{:5d}{}",  (int)all_devices[i]->utilization(),  all_devices[i]->util_units());
 		}
-		while (strlen(util) < 13) strcat(util, " ");
+		while (util.length() < 13) util.append(" ");
 
 		P = all_devices[i]->power_usage(&all_results, &all_parameters);
 
-		format_watts(P, power, 11);
+		format_watts(P, power_buf, 11);
+		power = power_buf;
 
 		if (!show_power || !all_devices[i]->power_valid())
-			strcpy(power, "           ");
+			power = "           ";
 
 
 		wprintw(win, "%s %s %s\n",
-			power,
-			util,
+			power.c_str(),
+			util.c_str(),
 			all_devices[i]->human_name()
 			);
 	}
@@ -280,35 +283,36 @@ void show_report_devices(void)
 
 	for (i = 0; i < all_devices.size(); i++) {
 		double P;
-		char util[128];
-		char power[128];
+		std::string util;
+		std::string power;
+		char power_buf[128];
 
-		util[0] = 0;
 		if (all_devices[i]->util_units()) {
 			if (all_devices[i]->utilization() < 1000)
-				sprintf(util, "%5.1f%s",
+				util = std::format("{:5.1f}{}",
 					all_devices[i]->utilization(),
 					all_devices[i]->util_units());
 			else
-				sprintf(util, "%5i%s",
+				util = std::format("{:5d}{}",
 					(int)all_devices[i]->utilization(),
 					all_devices[i]->util_units());
 		}
 
 		P = all_devices[i]->power_usage(&all_results, &all_parameters);
-		format_watts(P, power, 11);
+		format_watts(P, power_buf, 11);
+		power = power_buf;
 
 		if (!show_power || !all_devices[i]->power_valid())
-			strcpy(power, "           ");
+			power = "           ";
 
-		device_data[idx]= string(util);
+		device_data[idx]= util;
 		idx+=1;
 
-		device_data[idx]= string(all_devices[i]->human_name());
+		device_data[idx]= all_devices[i]->human_name_s();
 		idx+=1;
 
 		if (show_power) {
-			device_data[idx]= string(power);
+			device_data[idx]= power;
 			idx+=1;
 		}
 	}

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -59,8 +59,6 @@ device::device(void)
 {
 	cached_valid = 0;
 	hide = 0;
-
-	memset(real_path, 0, sizeof(real_path));
 }
 
 
@@ -68,6 +66,8 @@ void device::register_sysfs_path(const char *path)
 {
 	char current_path[PATH_MAX + 1];
 	int iter = 0;
+	char resolved_path[PATH_MAX + 1];
+
 	pt_strcpy(current_path, path);
 
 	while (iter++ < 10) {
@@ -79,8 +79,10 @@ void device::register_sysfs_path(const char *path)
 			break;
 	}
 
-	if (!realpath(current_path, real_path))
-		real_path[0] = 0;
+	if (realpath(current_path, resolved_path))
+		real_path = resolved_path;
+	else
+		real_path.clear();
 }
 
 void device::start_measurement(void)

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -150,7 +150,6 @@ void report_devices(void)
 	double pw;
 
 	std::string util;
-	char power_buf[128];
 
 	win = get_ncurses_win("Device stats");
         if (!win)
@@ -167,17 +166,15 @@ void report_devices(void)
 
 	pw = global_power();
 	if (pw > 0.0001) {
-		char buf[32];
 		wprintw(win, _("The battery reports a discharge rate of %sW\n"),
-				fmt_prefix(pw, buf));
+				fmt_prefix(pw).c_str());
 		wprintw(win, _("The energy consumed was %sJ\n"),
-				fmt_prefix(global_joules(), buf));
+				fmt_prefix(global_joules()).c_str());
 	}
 
 	if (show_power) {
-		char buf[32];
 		wprintw(win, _("System baseline power is estimated at %sW\n"),
-				fmt_prefix(get_parameter_value("base power"), buf));
+				fmt_prefix(get_parameter_value("base power")).c_str());
 	}
 
 	if (pw > 0.0001 || show_power)
@@ -203,8 +200,7 @@ void report_devices(void)
 
 		P = all_devices[i]->power_usage(&all_results, &all_parameters);
 
-		format_watts(P, power_buf, 11);
-		power = power_buf;
+		power = format_watts(P, 11);
 
 		if (!show_power || !all_devices[i]->power_valid())
 			power = "           ";
@@ -252,22 +248,21 @@ void show_report_devices(void)
 	int summary_size=2;
 	string *summary = new string[summary_size];
 	pw = global_power();
-	char buf[32];
 	if (pw > 0.0001) {
 		summary[0]= __("The battery reports a discharge rate of: ");
-		summary[1]=string(fmt_prefix(pw, buf));
+		summary[1]=fmt_prefix(pw);
 		summary[1].append(" W");
 		report.add_summary_list(summary, summary_size);
 
 		summary[0]= __("The energy consumed was : ");
-		summary[1]=string(fmt_prefix(global_joules(), buf));
+		summary[1]=fmt_prefix(global_joules());
 		summary[1].append(" J");
 		report.add_summary_list(summary, summary_size);
 	}
 
 	if (show_power) {
 		summary[0]=__("The system baseline power is estimated at: ");
-		summary[1]=string(fmt_prefix(get_parameter_value("base power"), buf));
+		summary[1]=fmt_prefix(get_parameter_value("base power"));
 		summary[1].append(" W");
 		report.add_summary_list(summary, summary_size);
 	}
@@ -284,7 +279,6 @@ void show_report_devices(void)
 		double P;
 		std::string util;
 		std::string power;
-		char power_buf[128];
 
 		if (all_devices[i]->util_units()) {
 			if (all_devices[i]->utilization() < 1000)
@@ -298,8 +292,7 @@ void show_report_devices(void)
 		}
 
 		P = all_devices[i]->power_usage(&all_results, &all_parameters);
-		format_watts(P, power_buf, 11);
-		power = power_buf;
+		power = format_watts(P, 11);
 
 		if (!show_power || !all_devices[i]->power_valid())
 			power = "           ";

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -48,18 +48,16 @@ public:
 
 	virtual ~device() {};
 
-	void register_sysfs_path(const char *path);
+	void register_sysfs_path(const std::string &path);
 
 	virtual double	utilization(void); /* percentage */
 
 	virtual const char * util_units(void) { return "%"; };
 
-	virtual const char * class_name(void) { return "abstract device";};
-	virtual std::string class_name_s(void) { return class_name(); };
-	virtual const char * device_name(void) { return "abstract device";};
-	virtual std::string device_name_s(void) { return device_name(); };
+	virtual std::string class_name(void) { return "abstract device";};
+	virtual std::string device_name(void) { return "abstract device";};
 
-	virtual std::string human_name(void) { return device_name_s(); };
+	virtual std::string human_name(void) { return device_name(); };
 
 	virtual double power_usage(struct result_bundle *results, struct parameter_bundle *bundle) { return 0.0; };
 

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -39,7 +39,7 @@ public:
 	bool hide;
 
 	std::string guilty;
-	char real_path[PATH_MAX+1];
+	std::string real_path;
 
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -52,7 +52,7 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * util_units(void) { return "%"; };
+	virtual std::string util_units(void) { return "%"; };
 
 	virtual std::string class_name(void) { return "abstract device";};
 	virtual std::string device_name(void) { return "abstract device";};

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -59,8 +59,7 @@ public:
 	virtual const char * device_name(void) { return "abstract device";};
 	virtual std::string device_name_s(void) { return device_name(); };
 
-	virtual const char * human_name_cstr(void) { return device_name(); };
-	virtual std::string human_name_s(void) { return human_name_cstr(); };
+	virtual std::string human_name(void) { return device_name_s(); };
 
 	virtual double power_usage(struct result_bundle *results, struct parameter_bundle *bundle) { return 0.0; };
 

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -38,7 +38,7 @@ public:
 	int cached_valid;
 	bool hide;
 
-	char guilty[4096];
+	std::string guilty;
 	char real_path[PATH_MAX+1];
 
 	virtual void start_measurement(void);

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -28,6 +28,7 @@
 
 #include <vector>
 #include <limits.h>
+#include <string>
 
 struct parameter_bundle;
 struct result_bundle;
@@ -54,9 +55,12 @@ public:
 	virtual const char * util_units(void) { return "%"; };
 
 	virtual const char * class_name(void) { return "abstract device";};
+	virtual std::string class_name_s(void) { return class_name(); };
 	virtual const char * device_name(void) { return "abstract device";};
+	virtual std::string device_name_s(void) { return device_name(); };
 
 	virtual const char * human_name(void) { return device_name(); };
+	virtual std::string human_name_s(void) { return human_name(); };
 
 	virtual double power_usage(struct result_bundle *results, struct parameter_bundle *bundle) { return 0.0; };
 
@@ -71,7 +75,7 @@ public:
 
 using namespace std;
 
-extern vector<class device *> all_devices;
+extern std::vector<class device *> all_devices;
 
 extern void devices_start_measurement(void);
 extern void devices_end_measurement(void);

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -59,8 +59,8 @@ public:
 	virtual const char * device_name(void) { return "abstract device";};
 	virtual std::string device_name_s(void) { return device_name(); };
 
-	virtual const char * human_name(void) { return device_name(); };
-	virtual std::string human_name_s(void) { return human_name(); };
+	virtual const char * human_name_cstr(void) { return device_name(); };
+	virtual std::string human_name_s(void) { return human_name_cstr(); };
 
 	virtual double power_usage(struct result_bundle *results, struct parameter_bundle *bundle) { return 0.0; };
 

--- a/src/devices/gpu_rapl_device.h
+++ b/src/devices/gpu_rapl_device.h
@@ -47,7 +47,7 @@ public:
 	virtual const char * class_name(void) { return "GPU core";};
 	virtual const char * device_name(void) { return "GPU core";};
 	virtual std::string device_name_s(void) { return "GPU core";};
-	virtual std::string human_name_s(void) { return "GPU core";};
+	virtual std::string human_name(void) { return "GPU core";};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual void start_measurement(void);

--- a/src/devices/gpu_rapl_device.h
+++ b/src/devices/gpu_rapl_device.h
@@ -44,9 +44,8 @@ class gpu_rapl_device: public i915gpu {
 
 public:
 	gpu_rapl_device(i915gpu *parent);
-	virtual const char * class_name(void) { return "GPU core";};
-	virtual const char * device_name(void) { return "GPU core";};
-	virtual std::string device_name_s(void) { return "GPU core";};
+	virtual std::string class_name(void) { return "GPU core";};
+	virtual std::string device_name(void) { return "GPU core";};
 	virtual std::string human_name(void) { return "GPU core";};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);

--- a/src/devices/gpu_rapl_device.h
+++ b/src/devices/gpu_rapl_device.h
@@ -46,6 +46,8 @@ public:
 	gpu_rapl_device(i915gpu *parent);
 	virtual const char * class_name(void) { return "GPU core";};
 	virtual const char * device_name(void) { return "GPU core";};
+	virtual std::string device_name_s(void) { return "GPU core";};
+	virtual std::string human_name_s(void) { return "GPU core";};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual void start_measurement(void);

--- a/src/devices/i915-gpu.cpp
+++ b/src/devices/i915-gpu.cpp
@@ -52,14 +52,6 @@ i915gpu::i915gpu(): device()
 	rindex = get_result_index("gpu-operations");
 }
 
-const char * i915gpu::device_name(void)
-{
-	if (child_devices.size())
-		return "GPU misc";
-	else
-		return "GPU";
-}
-
 void i915gpu::start_measurement(void)
 {
 }

--- a/src/devices/i915-gpu.h
+++ b/src/devices/i915-gpu.h
@@ -42,14 +42,13 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * class_name(void) { return "GPU";};
+	virtual std::string class_name(void) { return "GPU";};
 
-	virtual const char * device_name(void) {
+	virtual std::string device_name(void) {
 		if (child_devices.size())
 			return "GPU misc";
 		return "GPU";
 	};
-	virtual std::string device_name_s(void) { return device_name(); };
 	virtual std::string human_name(void) { return "Intel GPU"; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual bool show_in_list(void) {return false;};

--- a/src/devices/i915-gpu.h
+++ b/src/devices/i915-gpu.h
@@ -50,8 +50,7 @@ public:
 		return "GPU";
 	};
 	virtual std::string device_name_s(void) { return device_name(); };
-	virtual const char * human_name_cstr(void) { return "Intel GPU"; };
-	virtual std::string human_name_s(void) { return human_name_cstr(); };
+	virtual std::string human_name(void) { return "Intel GPU"; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual bool show_in_list(void) {return false;};
 	virtual const char * util_units(void) { return " ops/s"; };

--- a/src/devices/i915-gpu.h
+++ b/src/devices/i915-gpu.h
@@ -52,7 +52,7 @@ public:
 	virtual std::string human_name(void) { return "Intel GPU"; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual bool show_in_list(void) {return false;};
-	virtual const char * util_units(void) { return " ops/s"; };
+	virtual std::string util_units(void) { return " ops/s"; };
 
 	virtual void add_child(device *dev_ptr) { child_devices.push_back(dev_ptr);}
 };

--- a/src/devices/i915-gpu.h
+++ b/src/devices/i915-gpu.h
@@ -50,8 +50,8 @@ public:
 		return "GPU";
 	};
 	virtual std::string device_name_s(void) { return device_name(); };
-	virtual const char * human_name(void) { return "Intel GPU"; };
-	virtual std::string human_name_s(void) { return human_name(); };
+	virtual const char * human_name_cstr(void) { return "Intel GPU"; };
+	virtual std::string human_name_s(void) { return human_name_cstr(); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual bool show_in_list(void) {return false;};
 	virtual const char * util_units(void) { return " ops/s"; };

--- a/src/devices/i915-gpu.h
+++ b/src/devices/i915-gpu.h
@@ -31,7 +31,7 @@
 class i915gpu: public device {
 	int index;
 	int rindex;
-	vector<device *>child_devices;
+	std::vector<device *>child_devices;
 
 public:
 
@@ -44,7 +44,14 @@ public:
 
 	virtual const char * class_name(void) { return "GPU";};
 
-	virtual const char * device_name(void);
+	virtual const char * device_name(void) {
+		if (child_devices.size())
+			return "GPU misc";
+		return "GPU";
+	};
+	virtual std::string device_name_s(void) { return device_name(); };
+	virtual const char * human_name(void) { return "Intel GPU"; };
+	virtual std::string human_name_s(void) { return human_name(); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual bool show_in_list(void) {return false;};
 	virtual const char * util_units(void) { return " ops/s"; };

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -129,7 +129,6 @@ network::network(const char *_name, const char *path): device()
 {
 	char line[4096];
 	std::string filename(path);
-	char devname[128];
 	start_up = 0;
 	end_up = 0;
 	start_speed = 0;
@@ -144,33 +143,26 @@ network::network(const char *_name, const char *path): device()
 
 	pt_strcpy(sysfs_path, path);
 	register_sysfs_path(sysfs_path);
-	pt_strcpy(devname, _name);
+	name = _name;
 	humanname = std::format("nic:{}", _name);
-	pt_strcpy(name, devname);
 
-	snprintf(devname, sizeof(devname), "%s-up", _name);
-	index_up = get_param_index(devname);
-	rindex_up = get_result_index(devname);
+	index_up = get_param_index(std::format("{}-up", _name));
+	rindex_up = get_result_index(std::format("{}-up", _name));
 
-	snprintf(devname, sizeof(devname), "%s-powerunsave", _name);
-	index_powerunsave = get_param_index(devname);
-	rindex_powerunsave = get_result_index(devname);
+	index_powerunsave = get_param_index(std::format("{}-powerunsave", _name));
+	rindex_powerunsave = get_result_index(std::format("{}-powerunsave", _name));
 
-	snprintf(devname, sizeof(devname), "%s-link-100", _name);
-	index_link_100 = get_param_index(devname);
-	rindex_link_100 = get_result_index(devname);
+	index_link_100 = get_param_index(std::format("{}-link-100", _name));
+	rindex_link_100 = get_result_index(std::format("{}-link-100", _name));
 
-	snprintf(devname, sizeof(devname), "%s-link-1000", _name);
-	index_link_1000 = get_param_index(devname);
-	rindex_link_1000 = get_result_index(devname);
+	index_link_1000 = get_param_index(std::format("{}-link-1000", _name));
+	rindex_link_1000 = get_result_index(std::format("{}-link-1000", _name));
 
-	snprintf(devname, sizeof(devname), "%s-link-high", _name);
-	index_link_high = get_param_index(devname);
-	rindex_link_high = get_result_index(devname);
+	index_link_high = get_param_index(std::format("{}-link-high", _name));
+	rindex_link_high = get_result_index(std::format("{}-link-high", _name));
 
-	snprintf(devname, sizeof(devname), "%s-packets", _name);
-	index_pkts = get_param_index(devname);
-	rindex_pkts = get_result_index(devname);
+	index_pkts = get_param_index(std::format("{}-packets", _name));
+	rindex_pkts = get_result_index(std::format("{}-packets", _name));
 
 	memset(line, 0, 4096);
 	filename.append("/device/driver");
@@ -280,9 +272,9 @@ void network::start_measurement(void)
 	end_up = 1;
 	end_speed = 0;
 
-	start_speed = iface_speed(name);
+	start_speed = iface_speed(name.c_str());
 
-	start_up = net_iface_up(name);
+	start_up = net_iface_up(name.c_str());
 
 	do_proc_net_dev();
 	start_pkts = pkts;
@@ -297,8 +289,8 @@ void network::end_measurement(void)
 
 	gettimeofday(&after, NULL);
 
-	end_speed = iface_speed(name);
-	end_up = net_iface_up(name);
+	end_speed = iface_speed(name.c_str());
+	end_up = net_iface_up(name.c_str());
 	do_proc_net_dev();
 	end_pkts = pkts;
 
@@ -324,7 +316,7 @@ void network::end_measurement(void)
 	if (start_pkts > end_pkts)
 		end_pkts = start_pkts;
 
-	u_powerunsave = 100 - 100 * get_wifi_power_saving(name);
+	u_powerunsave = 100 - 100 * get_wifi_power_saving(name.c_str());
 
 	report_utilization(rindex_link_100, u_100);
 	report_utilization(rindex_link_1000, u_1000);
@@ -340,38 +332,20 @@ double network::utilization(void)
 	return (end_pkts - start_pkts) / (duration + 0.001);
 }
 
-const char * network::device_name(void)
-{
-	return name;
-}
-
 static void netdev_callback(const char *d_name)
 {
-	char devname[128];
-
 	std::string f_name("/sys/class/net/");
 	if (strcmp(d_name, "lo") == 0)
 		return;
 
 	f_name.append(d_name);
 
-	snprintf(devname, sizeof(devname), "%s-up", d_name);
-	register_parameter(devname);
-
-	snprintf(devname, sizeof(devname), "%s-powerunsave", d_name);
-	register_parameter(devname);
-
-	snprintf(devname, sizeof(devname), "%s-link-100", d_name);
-	register_parameter(devname);
-
-	snprintf(devname, sizeof(devname), "%s-link-1000", d_name);
-	register_parameter(devname);
-
-	snprintf(devname, sizeof(devname), "%s-link-high", d_name);
-	register_parameter(devname);
-
-	snprintf(devname, sizeof(devname), "%s-packets", d_name);
-	register_parameter(devname);
+	register_parameter(std::format("{}-up", d_name));
+	register_parameter(std::format("{}-powerunsave", d_name));
+	register_parameter(std::format("{}-link-100", d_name));
+	register_parameter(std::format("{}-link-1000", d_name));
+	register_parameter(std::format("{}-link-high", d_name));
+	register_parameter(std::format("{}-packets", d_name));
 
 	network *bl = new(std::nothrow) class network(d_name, f_name.c_str());
 	if (bl) {

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -43,6 +43,7 @@ using namespace std;
 #include "../lib.h"
 #include "../parameters/parameters.h"
 #include "../process/process.h"
+#include "../tuning/wifi.h"
 extern "C" {
 #include "../tuning/iw.h"
 }
@@ -316,7 +317,7 @@ void network::end_measurement(void)
 	if (start_pkts > end_pkts)
 		end_pkts = start_pkts;
 
-	u_powerunsave = 100 - 100 * get_wifi_power_saving(name.c_str());
+	u_powerunsave = 100 - 100 * get_wifi_power_saving(name);
 
 	report_utilization(rindex_link_100, u_100);
 	report_utilization(rindex_link_1000, u_1000);

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -315,7 +315,7 @@ void network::end_measurement(void)
 	if (start_pkts > end_pkts)
 		end_pkts = start_pkts;
 
-	u_powerunsave = 100 - 100 * get_wifi_power_saving(name);
+	u_powerunsave = 100 - 100 * get_wifi_power_saving(name.c_str());
 
 	report_utilization(rindex_link_100, u_100);
 	report_utilization(rindex_link_1000, u_1000);

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -166,7 +166,7 @@ network::network(const char *_name, const char *path): device()
 
 	memset(line, 0, 4096);
 	if (readlink(std::format("{}/device/driver", path).c_str(), line, 4096) > 0) {
-		humanname = std::format(_("Network interface: {} ({})"), _name,  basename(line));
+		humanname = pt_format(_("Network interface: {} ({})"), _name,  basename(line));
 	};
 }
 

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -129,7 +129,6 @@ static void do_proc_net_dev(void)
 network::network(const char *_name, const char *path): device()
 {
 	char line[4096];
-	std::string filename(path);
 	start_up = 0;
 	end_up = 0;
 	start_speed = 0;
@@ -142,8 +141,8 @@ network::network(const char *_name, const char *path): device()
 	valid_high = -1;
 	valid_powerunsave = -1;
 
-	pt_strcpy(sysfs_path, path);
-	register_sysfs_path(sysfs_path);
+	sysfs_path = path;
+	register_sysfs_path(sysfs_path.c_str());
 	name = _name;
 	humanname = std::format("nic:{}", _name);
 
@@ -166,8 +165,7 @@ network::network(const char *_name, const char *path): device()
 	rindex_pkts = get_result_index(std::format("{}-packets", _name));
 
 	memset(line, 0, 4096);
-	filename.append("/device/driver");
-	if (readlink(filename.c_str(), line, 4096) > 0) {
+	if (readlink(std::format("{}/device/driver", path).c_str(), line, 4096) > 0) {
 		humanname = std::format(_("Network interface: {} ({})"), _name,  basename(line));
 	};
 }

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -126,7 +126,7 @@ static void do_proc_net_dev(void)
 }
 
 
-network::network(const char *_name, const char *path): device()
+network::network(const string &_name, const string &path): device()
 {
 	char line[4096];
 	start_up = 0;
@@ -142,7 +142,7 @@ network::network(const char *_name, const char *path): device()
 	valid_powerunsave = -1;
 
 	sysfs_path = path;
-	register_sysfs_path(sysfs_path.c_str());
+	register_sysfs_path(sysfs_path);
 	name = _name;
 	humanname = std::format("nic:{}", _name);
 
@@ -346,7 +346,7 @@ static void netdev_callback(const char *d_name)
 	register_parameter(std::format("{}-link-high", d_name));
 	register_parameter(std::format("{}-packets", d_name));
 
-	network *bl = new(std::nothrow) class network(d_name, f_name.c_str());
+	network *bl = new(std::nothrow) class network(d_name, f_name);
 	if (bl) {
 		all_devices.push_back(bl);
 		nics[d_name] = bl;

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -48,6 +48,7 @@ extern "C" {
 }
 
 #include <string.h>
+#include <format>
 #include <net/if.h>
 #include <linux/sockios.h>
 #include <sys/ioctl.h>
@@ -144,7 +145,7 @@ network::network(const char *_name, const char *path): device()
 	pt_strcpy(sysfs_path, path);
 	register_sysfs_path(sysfs_path);
 	pt_strcpy(devname, _name);
-	sprintf(humanname, "nic:%s", _name);
+	humanname = std::format("nic:{}", _name);
 	pt_strcpy(name, devname);
 
 	snprintf(devname, sizeof(devname), "%s-up", _name);
@@ -174,7 +175,7 @@ network::network(const char *_name, const char *path): device()
 	memset(line, 0, 4096);
 	filename.append("/device/driver");
 	if (readlink(filename.c_str(), line, 4096) > 0) {
-		snprintf(humanname, sizeof(humanname), _("Network interface: %s (%s)"), _name,  basename(line));
+		humanname = std::format(_("Network interface: {} ({})"), _name,  basename(line));
 	};
 }
 

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -64,13 +64,13 @@ public:
 	uint64_t pkts;
 	double duration;
 
-	network(const char *_name, const char *path);
+	network(const std::string &_name, const std::string &path);
 
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);
 
 	virtual double	utilization(void);
-	virtual const char * util_units(void) { return " pkts/s"; };
+	virtual std::string util_units(void) { return " pkts/s"; };
 
 	virtual std::string class_name(void) { return "ethernet";};
 

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -27,6 +27,7 @@
 
 #include <sys/time.h>
 #include <limits.h>
+#include <string>
 
 #include "device.h"
 #include "../parameters/parameters.h"
@@ -41,7 +42,7 @@ class network: public device {
 
 	char sysfs_path[PATH_MAX];
 	char name[4096];
-	char humanname[4096];
+	std::string humanname;
 	int index_up;
 	int rindex_up;
 	int index_link_100;
@@ -74,7 +75,8 @@ public:
 	virtual const char * class_name(void) { return "ethernet";};
 
 	virtual const char * device_name(void);
-	virtual const char * human_name(void) { return humanname; };
+	virtual const char * human_name(void) { return humanname.c_str(); };
+	virtual std::string human_name_s(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex_up) + utilization_power_valid(rindex_link_100) + utilization_power_valid(rindex_link_1000)  + utilization_power_valid(rindex_link_high);};
 	virtual int grouping_prio(void) { return 10; };

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -76,8 +76,7 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name_cstr(void) { return humanname.c_str(); };
-	virtual std::string human_name_s(void) { return humanname; };
+	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex_up) + utilization_power_valid(rindex_link_100) + utilization_power_valid(rindex_link_1000)  + utilization_power_valid(rindex_link_high);};
 	virtual int grouping_prio(void) { return 10; };

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -72,10 +72,9 @@ public:
 	virtual double	utilization(void);
 	virtual const char * util_units(void) { return " pkts/s"; };
 
-	virtual const char * class_name(void) { return "ethernet";};
+	virtual std::string class_name(void) { return "ethernet";};
 
-	virtual const char * device_name(void) { return name.c_str(); };
-	virtual std::string device_name_s(void) { return name; };
+	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex_up) + utilization_power_valid(rindex_link_100) + utilization_power_valid(rindex_link_1000)  + utilization_power_valid(rindex_link_high);};

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -41,7 +41,7 @@ class network: public device {
 	int end_speed; /* 0 is "no link" */
 
 	char sysfs_path[PATH_MAX];
-	char name[4096];
+	std::string name;
 	std::string humanname;
 	int index_up;
 	int rindex_up;
@@ -74,7 +74,8 @@ public:
 
 	virtual const char * class_name(void) { return "ethernet";};
 
-	virtual const char * device_name(void);
+	virtual const char * device_name(void) { return name.c_str(); };
+	virtual std::string device_name_s(void) { return name; };
 	virtual const char * human_name(void) { return humanname.c_str(); };
 	virtual std::string human_name_s(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -76,7 +76,7 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name(void) { return humanname.c_str(); };
+	virtual const char * human_name_cstr(void) { return humanname.c_str(); };
 	virtual std::string human_name_s(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex_up) + utilization_power_valid(rindex_link_100) + utilization_power_valid(rindex_link_1000)  + utilization_power_valid(rindex_link_high);};

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -40,7 +40,7 @@ class network: public device {
 	int start_speed; /* 0 is "no link" */
 	int end_speed; /* 0 is "no link" */
 
-	char sysfs_path[PATH_MAX];
+	std::string sysfs_path;
 	std::string name;
 	std::string humanname;
 	int index_up;

--- a/src/devices/rfkill.cpp
+++ b/src/devices/rfkill.cpp
@@ -42,7 +42,7 @@ using namespace std;
 #include <unistd.h>
 #include <format>
 
-rfkill::rfkill(char *_name, char *path): device()
+rfkill::rfkill(const string &_name, const string &path): device()
 {
 	char line[4096];
 	start_soft = 0;
@@ -50,7 +50,7 @@ rfkill::rfkill(char *_name, char *path): device()
 	end_soft = 0;
 	end_hard = 0;
 	sysfs_path = path;
-	register_sysfs_path(sysfs_path.c_str());
+	register_sysfs_path(sysfs_path);
 	name = std::format("radio:{}", _name);
 	humanname = std::format("radio:{}", _name);
 	register_parameter(name);
@@ -133,7 +133,7 @@ static void create_all_rfkills_callback(const char *d_name)
 		file.close();
 	}
 
-	bl = new class rfkill((char *)name.c_str(), (char *)std::format("/sys/class/rfkill/{}", d_name).c_str());
+	bl = new class rfkill(name, std::format("/sys/class/rfkill/{}", d_name));
 	all_devices.push_back(bl);
 }
 

--- a/src/devices/rfkill.cpp
+++ b/src/devices/rfkill.cpp
@@ -59,10 +59,10 @@ rfkill::rfkill(char *_name, char *path): device()
 
 	memset(line, 0, 4096);
 	if (readlink(std::format("{}/device/driver", path).c_str(), line, sizeof(line)) > 0) {
-		humanname = std::format(_("Radio device: {}"), basename(line));
+		humanname = pt_format(_("Radio device: {}"), basename(line));
 	}
 	if (readlink(std::format("{}/device/device/driver", path).c_str(), line, sizeof(line)) > 0) {
-		humanname = std::format(_("Radio device: {}"), basename(line));
+		humanname = pt_format(_("Radio device: {}"), basename(line));
 	}
 }
 

--- a/src/devices/rfkill.cpp
+++ b/src/devices/rfkill.cpp
@@ -40,33 +40,32 @@ using namespace std;
 
 #include <string.h>
 #include <unistd.h>
+#include <format>
 
 rfkill::rfkill(char *_name, char *path): device()
 {
 	char line[4096];
 	char filename[PATH_MAX];
-	char devname[128];
 	start_soft = 0;
 	start_hard = 0;
 	end_soft = 0;
 	end_hard = 0;
 	pt_strcpy(sysfs_path, path);
 	register_sysfs_path(sysfs_path);
-	snprintf(devname, sizeof(devname), "radio:%s", _name);
-	snprintf(humanname, sizeof(humanname), "radio:%s", _name);
-	pt_strcpy(name, devname);
-	register_parameter(devname);
-	index = get_param_index(devname);
-	rindex = get_result_index(name);
+	name = std::format("radio:{}", _name);
+	humanname = std::format("radio:{}", _name);
+	register_parameter(name.c_str());
+	index = get_param_index(name.c_str());
+	rindex = get_result_index(name.c_str());
 
 	memset(line, 0, 4096);
 	snprintf(filename, sizeof(filename), "%s/device/driver", path);
 	if (readlink(filename, line, sizeof(line)) > 0) {
-		snprintf(humanname, sizeof(humanname), _("Radio device: %s"), basename(line));
+		humanname = std::format(_("Radio device: {}"), basename(line));
 	}
 	snprintf(filename, sizeof(filename), "%s/device/device/driver", path);
 	if (readlink(filename, line, sizeof(line)) > 0) {
-		snprintf(humanname, sizeof(humanname), _("Radio device: %s"), basename(line));
+		humanname = std::format(_("Radio device: {}"), basename(line));
 	}
 }
 
@@ -113,7 +112,7 @@ void rfkill::end_measurement(void)
 	}
 	file.close();
 
-	report_utilization(name, utilization());
+	report_utilization(name.c_str(), utilization());
 }
 
 
@@ -129,11 +128,6 @@ double rfkill::utilization(void)
 	p = 100 - 50.0 * rfk;
 
 	return p;
-}
-
-const char * rfkill::device_name(void)
-{
-	return name;
 }
 
 static void create_all_rfkills_callback(const char *d_name)

--- a/src/devices/rfkill.cpp
+++ b/src/devices/rfkill.cpp
@@ -54,9 +54,9 @@ rfkill::rfkill(char *_name, char *path): device()
 	register_sysfs_path(sysfs_path);
 	name = std::format("radio:{}", _name);
 	humanname = std::format("radio:{}", _name);
-	register_parameter(name.c_str());
-	index = get_param_index(name.c_str());
-	rindex = get_result_index(name.c_str());
+	register_parameter(name);
+	index = get_param_index(name);
+	rindex = get_result_index(name);
 
 	memset(line, 0, 4096);
 	snprintf(filename, sizeof(filename), "%s/device/driver", path);
@@ -112,7 +112,7 @@ void rfkill::end_measurement(void)
 	}
 	file.close();
 
-	report_utilization(name.c_str(), utilization());
+	report_utilization(name, utilization());
 }
 
 

--- a/src/devices/rfkill.cpp
+++ b/src/devices/rfkill.cpp
@@ -45,13 +45,12 @@ using namespace std;
 rfkill::rfkill(char *_name, char *path): device()
 {
 	char line[4096];
-	char filename[PATH_MAX];
 	start_soft = 0;
 	start_hard = 0;
 	end_soft = 0;
 	end_hard = 0;
-	pt_strcpy(sysfs_path, path);
-	register_sysfs_path(sysfs_path);
+	sysfs_path = path;
+	register_sysfs_path(sysfs_path.c_str());
 	name = std::format("radio:{}", _name);
 	humanname = std::format("radio:{}", _name);
 	register_parameter(name);
@@ -59,19 +58,16 @@ rfkill::rfkill(char *_name, char *path): device()
 	rindex = get_result_index(name);
 
 	memset(line, 0, 4096);
-	snprintf(filename, sizeof(filename), "%s/device/driver", path);
-	if (readlink(filename, line, sizeof(line)) > 0) {
+	if (readlink(std::format("{}/device/driver", path).c_str(), line, sizeof(line)) > 0) {
 		humanname = std::format(_("Radio device: {}"), basename(line));
 	}
-	snprintf(filename, sizeof(filename), "%s/device/device/driver", path);
-	if (readlink(filename, line, sizeof(line)) > 0) {
+	if (readlink(std::format("{}/device/device/driver", path).c_str(), line, sizeof(line)) > 0) {
 		humanname = std::format(_("Radio device: {}"), basename(line));
 	}
 }
 
 void rfkill::start_measurement(void)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 
 	start_hard = 1;
@@ -79,15 +75,13 @@ void rfkill::start_measurement(void)
 	end_hard = 1;
 	end_soft = 1;
 
-	snprintf(filename, sizeof(filename), "%s/hard", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/hard", sysfs_path), ios::in);
 	if (file) {
 		file >> start_hard;
 	}
 	file.close();
 
-	snprintf(filename, sizeof(filename), "%s/soft", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/soft", sysfs_path), ios::in);
 	if (file) {
 		file >> start_soft;
 	}
@@ -96,17 +90,14 @@ void rfkill::start_measurement(void)
 
 void rfkill::end_measurement(void)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 
-	snprintf(filename, sizeof(filename), "%s/hard", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/hard", sysfs_path), ios::in);
 	if (file) {
 		file >> end_hard;
 	}
 	file.close();
-	snprintf(filename, sizeof(filename), "%s/soft", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/soft", sysfs_path), ios::in);
 	if (file) {
 		file >> end_soft;
 	}
@@ -132,21 +123,17 @@ double rfkill::utilization(void)
 
 static void create_all_rfkills_callback(const char *d_name)
 {
-	char filename[PATH_MAX];
-	char name[4096] = {0};
+	std::string name(d_name);
 	class rfkill *bl;
 	ifstream file;
 
-	snprintf(filename, sizeof(filename), "/sys/class/rfkill/%s/name", d_name);
-	strncpy(name, d_name, sizeof(name) - 1);
-	file.open(filename, ios::in);
+	file.open(std::format("/sys/class/rfkill/{}/name", d_name), ios::in);
 	if (file) {
-		file.getline(name, 100);
+		getline(file, name);
 		file.close();
 	}
 
-	snprintf(filename, sizeof(filename), "/sys/class/rfkill/%s", d_name);
-	bl = new class rfkill(name, filename);
+	bl = new class rfkill((char *)name.c_str(), (char *)std::format("/sys/class/rfkill/{}", d_name).c_str());
 	all_devices.push_back(bl);
 }
 

--- a/src/devices/rfkill.h
+++ b/src/devices/rfkill.h
@@ -52,8 +52,7 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name_cstr(void) { return humanname.c_str(); };
-	virtual std::string human_name_s(void) { return humanname; };
+	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex);};
 	virtual int grouping_prio(void) { return 5; };

--- a/src/devices/rfkill.h
+++ b/src/devices/rfkill.h
@@ -48,10 +48,9 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * class_name(void) { return "radio";};
+	virtual std::string class_name(void) { return "radio";};
 
-	virtual const char * device_name(void) { return name.c_str(); };
-	virtual std::string device_name_s(void) { return name; };
+	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex);};

--- a/src/devices/rfkill.h
+++ b/src/devices/rfkill.h
@@ -34,7 +34,7 @@
 class rfkill: public device {
 	int start_soft, end_soft;
 	int start_hard, end_hard;
-	char sysfs_path[PATH_MAX];
+	std::string sysfs_path;
 	std::string name;
 	std::string humanname;
 	int index;

--- a/src/devices/rfkill.h
+++ b/src/devices/rfkill.h
@@ -41,7 +41,7 @@ class rfkill: public device {
 	int rindex;
 public:
 
-	rfkill(char *_name, char *path);
+	rfkill(const std::string &_name, const std::string &path);
 
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);

--- a/src/devices/rfkill.h
+++ b/src/devices/rfkill.h
@@ -26,6 +26,7 @@
 #define _INCLUDE_GUARD_RFKILL_H
 
 #include <limits.h>
+#include <string>
 
 #include "device.h"
 #include "../parameters/parameters.h"
@@ -34,8 +35,8 @@ class rfkill: public device {
 	int start_soft, end_soft;
 	int start_hard, end_hard;
 	char sysfs_path[PATH_MAX];
-	char name[4096];
-	char humanname[4096];
+	std::string name;
+	std::string humanname;
 	int index;
 	int rindex;
 public:
@@ -49,8 +50,10 @@ public:
 
 	virtual const char * class_name(void) { return "radio";};
 
-	virtual const char * device_name(void);
-	virtual const char * human_name(void) { return humanname; };
+	virtual const char * device_name(void) { return name.c_str(); };
+	virtual std::string device_name_s(void) { return name; };
+	virtual const char * human_name(void) { return humanname.c_str(); };
+	virtual std::string human_name_s(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex);};
 	virtual int grouping_prio(void) { return 5; };

--- a/src/devices/rfkill.h
+++ b/src/devices/rfkill.h
@@ -52,7 +52,7 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name(void) { return humanname.c_str(); };
+	virtual const char * human_name_cstr(void) { return humanname.c_str(); };
 	virtual std::string human_name_s(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(rindex);};

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <limits.h>
+#include <format>
 
 #include "../parameters/parameters.h"
 #include "../lib.h"
@@ -42,18 +43,18 @@ runtime_pmdevice::runtime_pmdevice(const char *_name, const char *path) : device
 {
 	pt_strcpy(sysfs_path, path);
 	register_sysfs_path(sysfs_path);
-	pt_strcpy(name, _name);
-	snprintf(humanname, sizeof(humanname), "runtime-%s", _name);
+	name = _name;
+	humanname = std::format("runtime-{}", _name);
 
-	index = get_param_index(humanname);
-	r_index = get_result_index(humanname);
+	index = get_param_index(humanname.c_str());
+	r_index = get_result_index(humanname.c_str());
 
 	before_suspended_time = 0;
 	before_active_time = 0;
 	after_suspended_time = 0;
 	after_active_time = 0;
 
-	register_parameter(humanname);
+	register_parameter(humanname.c_str());
 }
 
 void runtime_pmdevice::start_measurement(void)
@@ -113,16 +114,6 @@ double runtime_pmdevice::utilization(void) /* percentage */
 	return d;
 }
 
-const char * runtime_pmdevice::device_name(void)
-{
-	return name;
-}
-
-const char * runtime_pmdevice::human_name(void)
-{
-	return humanname;
-}
-
 
 double runtime_pmdevice::power_usage(struct result_bundle *result, struct parameter_bundle *bundle)
 {
@@ -139,9 +130,9 @@ double runtime_pmdevice::power_usage(struct result_bundle *result, struct parame
 	return power;
 }
 
-void runtime_pmdevice::set_human_name(char *_name)
+void runtime_pmdevice::set_human_name(const char *_name)
 {
-	pt_strcpy(humanname, _name);
+	humanname = _name;
 }
 
 
@@ -198,8 +189,7 @@ static void do_bus(const char *bus)
 		dev = new class runtime_pmdevice(entry->d_name, filename);
 
 		if (strcmp(bus, "i2c") == 0) {
-			string devname;
-			char dev_name[4096];
+			std::string devname;
 			bool is_adapter = false;
 
 			snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/new_device", bus, entry->d_name);
@@ -213,8 +203,7 @@ static void do_bus(const char *bus)
 				file.close();
 			}
 
-			snprintf(dev_name, sizeof(dev_name), _("I2C %s (%s): %s"), (is_adapter ? _("Adapter") : _("Device")), entry->d_name, devname.c_str());
-			dev->set_human_name(dev_name);
+			dev->set_human_name(std::format(_("I2C {} ({}): {}"), (is_adapter ? _("Adapter") : _("Device")), entry->d_name, devname).c_str());
 		}
 
 		if (strcmp(bus, "pci") == 0) {
@@ -237,10 +226,8 @@ static void do_bus(const char *bus)
 			}
 
 			if (vendor && device) {
-				char devname[4096];
-				snprintf(devname, sizeof(devname), _("PCI Device: %s"),
-					pci_id_to_name(vendor, device, filename, 4095));
-				dev->set_human_name(devname);
+				dev->set_human_name(std::format(_("PCI Device: {}"),
+					pci_id_to_name(vendor, device, filename, 4095)).c_str());
 			}
 		}
 		all_devices.push_back(dev);

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -41,8 +41,8 @@
 
 runtime_pmdevice::runtime_pmdevice(const char *_name, const char *path) : device()
 {
-	pt_strcpy(sysfs_path, path);
-	register_sysfs_path(sysfs_path);
+	sysfs_path = path;
+	register_sysfs_path(sysfs_path.c_str());
 	name = _name;
 	humanname = std::format("runtime-{}", _name);
 
@@ -59,7 +59,6 @@ runtime_pmdevice::runtime_pmdevice(const char *_name, const char *path) : device
 
 void runtime_pmdevice::start_measurement(void)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 
 	before_suspended_time = 0;
@@ -67,15 +66,13 @@ void runtime_pmdevice::start_measurement(void)
         after_suspended_time = 0;
 	after_active_time = 0;
 
-	snprintf(filename, sizeof(filename), "%s/power/runtime_suspended_time", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/power/runtime_suspended_time", sysfs_path), ios::in);
 	if (!file)
 		return;
 	file >> before_suspended_time;
 	file.close();
 
-	snprintf(filename, sizeof(filename), "%s/power/runtime_active_time", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/power/runtime_active_time", sysfs_path), ios::in);
 	if (!file)
 		return;
 	file >> before_active_time;
@@ -84,18 +81,15 @@ void runtime_pmdevice::start_measurement(void)
 
 void runtime_pmdevice::end_measurement(void)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 
-	snprintf(filename, sizeof(filename), "%s/power/runtime_suspended_time", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/power/runtime_suspended_time", sysfs_path), ios::in);
 	if (!file)
 		return;
 	file >> after_suspended_time;
 	file.close();
 
-	snprintf(filename, sizeof(filename), "%s/power/runtime_active_time", sysfs_path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/power/runtime_active_time", sysfs_path), ios::in);
 	if (!file)
 		return;
 	file >> after_active_time;
@@ -138,27 +132,24 @@ void runtime_pmdevice::set_human_name(const char *_name)
 
 int device_has_runtime_pm(const char *sysfs_path)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 	unsigned long value;
 
-	snprintf(filename, sizeof(filename), "%s/power/runtime_suspended_time", sysfs_path);
-	file.open(filename, ios::in);
-	if (!file)
-		return 0;
-	file >> value;
-	file.close();
-	if (value)
-		return 1;
+	file.open(std::format("{}/power/runtime_suspended_time", sysfs_path), ios::in);
+	if (file) {
+		file >> value;
+		file.close();
+		if (value)
+			return 1;
+	}
 
-	snprintf(filename, sizeof(filename), "%s/power/runtime_active_time", sysfs_path);
-	file.open(filename, ios::in);
-	if (!file)
-		return 0;
-	file >> value;
-	file.close();
-	if (value)
-		return 1;
+	file.open(std::format("{}/power/runtime_active_time", sysfs_path), ios::in);
+	if (file) {
+		file >> value;
+		file.close();
+		if (value)
+			return 1;
+	}
 
 	return 0;
 }
@@ -169,10 +160,8 @@ static void do_bus(const char *bus)
 
 	struct dirent *entry;
 	DIR *dir;
-	char filename[PATH_MAX];
 
-	snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/", bus);
-	dir = opendir(filename);
+	dir = opendir(std::format("/sys/bus/{}/devices/", bus).c_str());
 	if (!dir)
 		return;
 	while (1) {
@@ -185,19 +174,16 @@ static void do_bus(const char *bus)
 		if (entry->d_name[0] == '.')
 			continue;
 
-		snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s", bus, entry->d_name);
-		dev = new class runtime_pmdevice(entry->d_name, filename);
+		dev = new class runtime_pmdevice(entry->d_name, std::format("/sys/bus/{}/devices/{}", bus, entry->d_name).c_str());
 
 		if (strcmp(bus, "i2c") == 0) {
 			std::string devname;
 			bool is_adapter = false;
 
-			snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/new_device", bus, entry->d_name);
-			if (access(filename, W_OK) == 0)
+			if (access(std::format("/sys/bus/{}/devices/{}/new_device", bus, entry->d_name).c_str(), W_OK) == 0)
 				is_adapter = true;
 
-			snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/name", bus, entry->d_name);
-			file.open(filename, ios::in);
+			file.open(std::format("/sys/bus/{}/devices/{}/name", bus, entry->d_name), ios::in);
 			if (file) {
 				getline(file, devname);
 				file.close();
@@ -208,18 +194,16 @@ static void do_bus(const char *bus)
 
 		if (strcmp(bus, "pci") == 0) {
 			uint16_t vendor = 0, device = 0;
+			char filename[4096];
 
-			snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/vendor", bus, entry->d_name);
-
-			file.open(filename, ios::in);
+			file.open(std::format("/sys/bus/{}/devices/{}/vendor", bus, entry->d_name), ios::in);
 			if (file) {
 				file >> hex >> vendor;
 				file.close();
 			}
 
 
-			snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/device", bus, entry->d_name);
-			file.open(filename, ios::in);
+			file.open(std::format("/sys/bus/{}/devices/{}/device", bus, entry->d_name), ios::in);
 			if (file) {
 				file >> hex >> device;
 				file.close();

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -39,10 +39,10 @@
 #include <iostream>
 #include <fstream>
 
-runtime_pmdevice::runtime_pmdevice(const char *_name, const char *path) : device()
+runtime_pmdevice::runtime_pmdevice(const string &_name, const string &path) : device()
 {
 	sysfs_path = path;
-	register_sysfs_path(sysfs_path.c_str());
+	register_sysfs_path(sysfs_path);
 	name = _name;
 	humanname = std::format("runtime-{}", _name);
 
@@ -53,7 +53,6 @@ runtime_pmdevice::runtime_pmdevice(const char *_name, const char *path) : device
 	before_active_time = 0;
 	after_suspended_time = 0;
 	after_active_time = 0;
-
 	register_parameter(humanname);
 }
 
@@ -174,8 +173,7 @@ static void do_bus(const char *bus)
 		if (entry->d_name[0] == '.')
 			continue;
 
-		dev = new class runtime_pmdevice(entry->d_name, std::format("/sys/bus/{}/devices/{}", bus, entry->d_name).c_str());
-
+		dev = new class runtime_pmdevice(entry->d_name, std::format("/sys/bus/{}/devices/{}", bus, entry->d_name));
 		if (strcmp(bus, "i2c") == 0) {
 			std::string devname;
 			bool is_adapter = false;

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -46,15 +46,15 @@ runtime_pmdevice::runtime_pmdevice(const char *_name, const char *path) : device
 	name = _name;
 	humanname = std::format("runtime-{}", _name);
 
-	index = get_param_index(humanname.c_str());
-	r_index = get_result_index(humanname.c_str());
+	index = get_param_index(humanname);
+	r_index = get_result_index(humanname);
 
 	before_suspended_time = 0;
 	before_active_time = 0;
 	after_suspended_time = 0;
 	after_active_time = 0;
 
-	register_parameter(humanname.c_str());
+	register_parameter(humanname);
 }
 
 void runtime_pmdevice::start_measurement(void)

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -130,7 +130,7 @@ void runtime_pmdevice::set_human_name(const string &_name)
 }
 
 
-int device_has_runtime_pm(const char *sysfs_path)
+bool device_has_runtime_pm(const string &sysfs_path)
 {
 	ifstream file;
 	unsigned long value;
@@ -140,7 +140,7 @@ int device_has_runtime_pm(const char *sysfs_path)
 		file >> value;
 		file.close();
 		if (value)
-			return 1;
+			return true;
 	}
 
 	file.open(std::format("{}/power/runtime_active_time", sysfs_path), ios::in);
@@ -148,10 +148,10 @@ int device_has_runtime_pm(const char *sysfs_path)
 		file >> value;
 		file.close();
 		if (value)
-			return 1;
+			return true;
 	}
 
-	return 0;
+	return false;
 }
 
 static void do_bus(const char *bus)

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -124,7 +124,12 @@ double runtime_pmdevice::power_usage(struct result_bundle *result, struct parame
 	return power;
 }
 
-void runtime_pmdevice::set_human_name(const char *_name)
+void runtime_pmdevice::set_human_name_cstr(const char *_name)
+{
+	set_human_name(string(_name ? _name : ""));
+}
+
+void runtime_pmdevice::set_human_name(const string &_name)
 {
 	humanname = _name;
 }
@@ -189,7 +194,7 @@ static void do_bus(const char *bus)
 				file.close();
 			}
 
-			dev->set_human_name(pt_format(_("I2C {} ({}): {}"), (is_adapter ? _("Adapter") : _("Device")), entry->d_name, devname).c_str());
+			dev->set_human_name(pt_format(_("I2C {} ({}): {}"), (is_adapter ? _("Adapter") : _("Device")), entry->d_name, devname));
 		}
 
 		if (strcmp(bus, "pci") == 0) {
@@ -211,7 +216,7 @@ static void do_bus(const char *bus)
 
 			if (vendor && device) {
 				dev->set_human_name(pt_format(_("PCI Device: {}"),
-					pci_id_to_name(vendor, device, filename, 4095)).c_str());
+					pci_id_to_name(vendor, device, filename, 4095)));
 			}
 		}
 		all_devices.push_back(dev);

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -189,7 +189,7 @@ static void do_bus(const char *bus)
 				file.close();
 			}
 
-			dev->set_human_name(std::format(_("I2C {} ({}): {}"), (is_adapter ? _("Adapter") : _("Device")), entry->d_name, devname).c_str());
+			dev->set_human_name(pt_format(_("I2C {} ({}): {}"), (is_adapter ? _("Adapter") : _("Device")), entry->d_name, devname).c_str());
 		}
 
 		if (strcmp(bus, "pci") == 0) {
@@ -210,7 +210,7 @@ static void do_bus(const char *bus)
 			}
 
 			if (vendor && device) {
-				dev->set_human_name(std::format(_("PCI Device: {}"),
+				dev->set_human_name(pt_format(_("PCI Device: {}"),
 					pci_id_to_name(vendor, device, filename, 4095)).c_str());
 			}
 		}

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -124,11 +124,6 @@ double runtime_pmdevice::power_usage(struct result_bundle *result, struct parame
 	return power;
 }
 
-void runtime_pmdevice::set_human_name_cstr(const char *_name)
-{
-	set_human_name(string(_name ? _name : ""));
-}
-
 void runtime_pmdevice::set_human_name(const string &_name)
 {
 	humanname = _name;

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -194,7 +194,7 @@ static void do_bus(const char *bus)
 
 		if (strcmp(bus, "pci") == 0) {
 			uint16_t vendor = 0, device = 0;
-			char filename[4096];
+			std::string pci_name;
 
 			file.open(std::format("/sys/bus/{}/devices/{}/vendor", bus, entry->d_name), ios::in);
 			if (file) {
@@ -211,7 +211,7 @@ static void do_bus(const char *bus)
 
 			if (vendor && device) {
 				dev->set_human_name(pt_format(_("PCI Device: {}"),
-					pci_id_to_name(vendor, device, filename, 4095)));
+					pci_id_to_name(vendor, device, pci_name, 4095)));
 			}
 		}
 		all_devices.push_back(dev);

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -52,12 +52,13 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name(void) { return humanname.c_str(); };
+	virtual const char * human_name_cstr(void) { return humanname.c_str(); };
 	virtual std::string human_name_s(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};
 
-	void set_human_name(const char *name);
+	void set_human_name_cstr(const char *name);
+	void set_human_name(const std::string &name);
 	virtual int grouping_prio(void) { return 1; };
 };
 

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -34,7 +34,7 @@
 class runtime_pmdevice: public device {
 	uint64_t before_suspended_time, before_active_time;
 	uint64_t after_suspended_time, after_active_time;
-	char sysfs_path[PATH_MAX];
+	std::string sysfs_path;
 	std::string name;
 	std::string humanname;
 	int index;

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -62,7 +62,7 @@ public:
 
 extern void create_all_runtime_pm_devices(void);
 
-extern int device_has_runtime_pm(const char *sysfs_path);
+extern bool device_has_runtime_pm(const std::string &sysfs_path);
 
 
 #endif

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -48,10 +48,9 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * class_name(void) { return "runtime_pm";};
+	virtual std::string class_name(void) { return "runtime_pm";};
 
-	virtual const char * device_name(void) { return name.c_str(); };
-	virtual std::string device_name_s(void) { return name; };
+	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -26,6 +26,7 @@
 #define _INCLUDE_GUARD_RUNTIMEPM_H
 
 #include <limits.h>
+#include <string>
 
 #include "device.h"
 #include "../parameters/parameters.h"
@@ -34,8 +35,8 @@ class runtime_pmdevice: public device {
 	uint64_t before_suspended_time, before_active_time;
 	uint64_t after_suspended_time, after_active_time;
 	char sysfs_path[PATH_MAX];
-	char name[4096];
-	char humanname[4096];
+	std::string name;
+	std::string humanname;
 	int index;
 	int r_index;
 public:
@@ -49,12 +50,14 @@ public:
 
 	virtual const char * class_name(void) { return "runtime_pm";};
 
-	virtual const char * device_name(void);
-	virtual const char * human_name(void);
+	virtual const char * device_name(void) { return name.c_str(); };
+	virtual std::string device_name_s(void) { return name; };
+	virtual const char * human_name(void) { return humanname.c_str(); };
+	virtual std::string human_name_s(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};
 
-	void set_human_name(char *name);
+	void set_human_name(const char *name);
 	virtual int grouping_prio(void) { return 1; };
 };
 

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -52,12 +52,10 @@ public:
 
 	virtual const char * device_name(void) { return name.c_str(); };
 	virtual std::string device_name_s(void) { return name; };
-	virtual const char * human_name_cstr(void) { return humanname.c_str(); };
-	virtual std::string human_name_s(void) { return humanname; };
+	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};
 
-	void set_human_name_cstr(const char *name);
 	void set_human_name(const std::string &name);
 	virtual int grouping_prio(void) { return 1; };
 };

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -41,7 +41,7 @@ class runtime_pmdevice: public device {
 	int r_index;
 public:
 
-	runtime_pmdevice(const char *_name, const char *path);
+	runtime_pmdevice(const std::string &_name, const std::string &path);
 
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);

--- a/src/devices/thinkpad-fan.cpp
+++ b/src/devices/thinkpad-fan.cpp
@@ -75,12 +75,12 @@ double thinkpad_fan::utilization(void)
 
 void create_thinkpad_fan(void)
 {
-	char filename[PATH_MAX];
+	std::string filename;
 	class thinkpad_fan *fan;
 
-	pt_strcpy(filename, "/sys/devices/platform/thinkpad_hwmon/fan1_input");
+	filename = "/sys/devices/platform/thinkpad_hwmon/fan1_input";
 
-	if (access(filename, R_OK) !=0)
+	if (access(filename.c_str(), R_OK) !=0)
 		return;
 
 	register_parameter("thinkpad-fan", 10);

--- a/src/devices/thinkpad-fan.h
+++ b/src/devices/thinkpad-fan.h
@@ -42,10 +42,9 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * class_name(void) { return "fan";};
+	virtual std::string class_name(void) { return "fan";};
 
-	virtual const char * device_name(void) { return "Fan-1";};
-	virtual std::string device_name_s(void) { return human_name(); };
+	virtual std::string device_name(void) { return "Fan-1";};
 	virtual std::string human_name(void) { return "Laptop fan";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return " rpm"; };

--- a/src/devices/thinkpad-fan.h
+++ b/src/devices/thinkpad-fan.h
@@ -45,7 +45,9 @@ public:
 	virtual const char * class_name(void) { return "fan";};
 
 	virtual const char * device_name(void) { return "Fan-1";};
+	virtual std::string device_name_s(void) { return human_name(); };
 	virtual const char * human_name(void) { return "Laptop fan";};
+	virtual std::string human_name_s(void) { return human_name(); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return " rpm"; };
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};

--- a/src/devices/thinkpad-fan.h
+++ b/src/devices/thinkpad-fan.h
@@ -45,9 +45,8 @@ public:
 	virtual const char * class_name(void) { return "fan";};
 
 	virtual const char * device_name(void) { return "Fan-1";};
-	virtual std::string device_name_s(void) { return human_name_cstr(); };
-	virtual const char * human_name_cstr(void) { return "Laptop fan";};
-	virtual std::string human_name_s(void) { return human_name_cstr(); };
+	virtual std::string device_name_s(void) { return human_name(); };
+	virtual std::string human_name(void) { return "Laptop fan";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return " rpm"; };
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};

--- a/src/devices/thinkpad-fan.h
+++ b/src/devices/thinkpad-fan.h
@@ -47,7 +47,7 @@ public:
 	virtual std::string device_name(void) { return "Fan-1";};
 	virtual std::string human_name(void) { return "Laptop fan";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual const char * util_units(void) { return " rpm"; };
+	virtual std::string util_units(void) { return " rpm"; };
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};
 	virtual int grouping_prio(void) { return 1; };
 };

--- a/src/devices/thinkpad-fan.h
+++ b/src/devices/thinkpad-fan.h
@@ -45,9 +45,9 @@ public:
 	virtual const char * class_name(void) { return "fan";};
 
 	virtual const char * device_name(void) { return "Fan-1";};
-	virtual std::string device_name_s(void) { return human_name(); };
-	virtual const char * human_name(void) { return "Laptop fan";};
-	virtual std::string human_name_s(void) { return human_name(); };
+	virtual std::string device_name_s(void) { return human_name_cstr(); };
+	virtual const char * human_name_cstr(void) { return "Laptop fan";};
+	virtual std::string human_name_s(void) { return human_name_cstr(); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return " rpm"; };
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};

--- a/src/devices/thinkpad-light.cpp
+++ b/src/devices/thinkpad-light.cpp
@@ -73,12 +73,12 @@ double thinkpad_light::utilization(void)
 
 void create_thinkpad_light(void)
 {
-	char filename[PATH_MAX];
+	std::string filename;
 	class thinkpad_light *light;
 
-	pt_strcpy(filename, "/sys/devices/platform/thinkpad_acpi/leds/tpacpi::thinklight/brightness");
+	filename = "/sys/devices/platform/thinkpad_acpi/leds/tpacpi::thinklight/brightness";
 
-	if (access(filename, R_OK) !=0)
+	if (access(filename.c_str(), R_OK) !=0)
 		return;
 
 	register_parameter("thinkpad-light", 10);

--- a/src/devices/thinkpad-light.h
+++ b/src/devices/thinkpad-light.h
@@ -45,7 +45,9 @@ public:
 	virtual const char * class_name(void) { return "light";};
 
 	virtual const char * device_name(void) { return "Light-1";};
+	virtual std::string device_name_s(void) { return human_name(); };
 	virtual const char * human_name(void) { return "Thinkpad light";};
+	virtual std::string human_name_s(void) { return human_name(); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return "%"; };
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};

--- a/src/devices/thinkpad-light.h
+++ b/src/devices/thinkpad-light.h
@@ -45,9 +45,8 @@ public:
 	virtual const char * class_name(void) { return "light";};
 
 	virtual const char * device_name(void) { return "Light-1";};
-	virtual std::string device_name_s(void) { return human_name_cstr(); };
-	virtual const char * human_name_cstr(void) { return "Thinkpad light";};
-	virtual std::string human_name_s(void) { return human_name_cstr(); };
+	virtual std::string device_name_s(void) { return human_name(); };
+	virtual std::string human_name(void) { return "Thinkpad light";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return "%"; };
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};

--- a/src/devices/thinkpad-light.h
+++ b/src/devices/thinkpad-light.h
@@ -47,7 +47,7 @@ public:
 	virtual std::string device_name(void) { return "Light-1";};
 	virtual std::string human_name(void) { return "Thinkpad light";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual const char * util_units(void) { return "%"; };
+	virtual std::string util_units(void) { return "%"; };
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};
 	virtual int grouping_prio(void) { return 1; };
 };

--- a/src/devices/thinkpad-light.h
+++ b/src/devices/thinkpad-light.h
@@ -45,9 +45,9 @@ public:
 	virtual const char * class_name(void) { return "light";};
 
 	virtual const char * device_name(void) { return "Light-1";};
-	virtual std::string device_name_s(void) { return human_name(); };
-	virtual const char * human_name(void) { return "Thinkpad light";};
-	virtual std::string human_name_s(void) { return human_name(); };
+	virtual std::string device_name_s(void) { return human_name_cstr(); };
+	virtual const char * human_name_cstr(void) { return "Thinkpad light";};
+	virtual std::string human_name_s(void) { return human_name_cstr(); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return "%"; };
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};

--- a/src/devices/thinkpad-light.h
+++ b/src/devices/thinkpad-light.h
@@ -42,10 +42,9 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * class_name(void) { return "light";};
+	virtual std::string class_name(void) { return "light";};
 
-	virtual const char * device_name(void) { return "Light-1";};
-	virtual std::string device_name_s(void) { return human_name(); };
+	virtual std::string device_name(void) { return "Light-1";};
 	virtual std::string human_name(void) { return "Thinkpad light";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual const char * util_units(void) { return "%"; };

--- a/src/devices/usb.cpp
+++ b/src/devices/usb.cpp
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <limits.h>
+#include <format>
 
 #include "../lib.h"
 #include "../devlist.h"
@@ -47,8 +48,8 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 	pt_strcpy(sysfs_path, path);
 	register_sysfs_path(sysfs_path);
 	pt_strcpy(name, _name);
-	pt_strcpy(devname, devid);
-	snprintf(humanname, sizeof(humanname), _("USB device: %s"), pretty_print(devid, vendor, 4096));
+	devname = devid;
+	humanname = std::format(_("USB device: {}"), pretty_print(devid, vendor, 4096));
 	active_before = 0;
 	active_after = 0;
 	connected_before = 0;
@@ -56,7 +57,7 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 	busnum = 0;
 	devnum = 0;
 
-	index = get_param_index(devname);
+	index = get_param_index(devname.c_str());
 	r_index = get_result_index(name);
 	rootport = 0;
 	cached_valid = 0;
@@ -91,11 +92,11 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 		file.close();
 	};
 	if (strlen(vendor) && strlen(product))
-		snprintf(humanname, sizeof(humanname), _("USB device: %s (%s)"), product, vendor);
+		humanname = std::format(_("USB device: {} ({})"), product, vendor);
 	else if (strlen(product))
-		snprintf(humanname, sizeof(humanname), _("USB device: %s"), product);
+		humanname = std::format(_("USB device: {}"), product);
 	else if (strlen(vendor))
-		snprintf(humanname, sizeof(humanname), _("USB device: %s"), vendor);
+		humanname = std::format(_("USB device: {}"), vendor);
 
 	/* For usbdevfs we need bus number and device number */
 	snprintf(filename, sizeof(filename), "%s/busnum", path);
@@ -172,16 +173,6 @@ double usbdevice::utilization(void) /* percentage */
 	if (d > 99.8)
 		d = 100.0;
 	return d;
-}
-
-const char * usbdevice::device_name(void)
-{
-	return name;
-}
-
-const char * usbdevice::human_name(void)
-{
-	return humanname;
 }
 
 void usbdevice::register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle)

--- a/src/devices/usb.cpp
+++ b/src/devices/usb.cpp
@@ -48,7 +48,7 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 	register_sysfs_path(sysfs_path.c_str());
 	name = _name;
 	devname = devid;
-	humanname = std::format(_("USB device: {}"), pretty_print(devid, vendor, 4096));
+	humanname = pt_format(_("USB device: {}"), pretty_print(devid, vendor, 4096));
 	active_before = 0;
 	active_after = 0;
 	connected_before = 0;
@@ -88,11 +88,11 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 		file.close();
 	};
 	if (strlen(vendor) && strlen(product))
-		humanname = std::format(_("USB device: {} ({})"), product, vendor);
+		humanname = pt_format(_("USB device: {} ({})"), product, vendor);
 	else if (strlen(product))
-		humanname = std::format(_("USB device: {}"), product);
+		humanname = pt_format(_("USB device: {}"), product);
 	else if (strlen(vendor))
-		humanname = std::format(_("USB device: {}"), vendor);
+		humanname = pt_format(_("USB device: {}"), vendor);
 
 	/* For usbdevfs we need bus number and device number */
 	file.open(std::format("{}/busnum", path), ios::in);

--- a/src/devices/usb.cpp
+++ b/src/devices/usb.cpp
@@ -47,7 +47,7 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 
 	pt_strcpy(sysfs_path, path);
 	register_sysfs_path(sysfs_path);
-	pt_strcpy(name, _name);
+	name = _name;
 	devname = devid;
 	humanname = std::format(_("USB device: {}"), pretty_print(devid, vendor, 4096));
 	active_before = 0;

--- a/src/devices/usb.cpp
+++ b/src/devices/usb.cpp
@@ -41,12 +41,11 @@
 usbdevice::usbdevice(const char *_name, const char *path, const char *devid): device()
 {
 	ifstream file;
-	char filename[PATH_MAX];
 	char vendor[4096];
 	char product[4096];
 
-	pt_strcpy(sysfs_path, path);
-	register_sysfs_path(sysfs_path);
+	sysfs_path = path;
+	register_sysfs_path(sysfs_path.c_str());
 	name = _name;
 	devname = devid;
 	humanname = std::format(_("USB device: {}"), pretty_print(devid, vendor, 4096));
@@ -64,8 +63,7 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 
 
 	/* root ports and hubs should count as 0 power ... their activity is derived */
-	snprintf(filename, sizeof(filename), "%s/bDeviceClass", path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/bDeviceClass", path), ios::in);
 	if (file) {
 		int dclass = 0;
 
@@ -77,16 +75,14 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 
 	vendor[0] = 0;
 	product[0] = 0;
-	snprintf(filename, sizeof(filename), "%s/manufacturer", path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/manufacturer", path), ios::in);
 	if (file) {
 		file.getline(vendor, 2047);
 		if (strstr(vendor, "Linux "))
 			vendor[0] = 0;
 		file.close();
 	};
-	snprintf(filename, sizeof(filename), "%s/product", path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/product", path), ios::in);
 	if (file) {
 		file.getline(product, 2040);
 		file.close();
@@ -99,15 +95,13 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 		humanname = std::format(_("USB device: {}"), vendor);
 
 	/* For usbdevfs we need bus number and device number */
-	snprintf(filename, sizeof(filename), "%s/busnum", path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/busnum", path), ios::in);
 	if (file) {
 
 		file >> busnum;
 		file.close();
 	};
-	snprintf(filename, sizeof(filename), "%s/devnum", path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/devnum", path), ios::in);
 	if (file) {
 
 		file >> devnum;
@@ -120,22 +114,19 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 void usbdevice::start_measurement(void)
 {
 	ifstream file;
-	char fullpath[PATH_MAX];
 
 	active_before = 0;
 	active_after = 0;
 	connected_before = 0;
 	connected_after = 0;
 
-	snprintf(fullpath, sizeof(fullpath), "%s/power/active_duration", sysfs_path);
-	file.open(fullpath, ios::in);
+	file.open(std::format("{}/power/active_duration", sysfs_path), ios::in);
 	if (file) {
 		file >> active_before;
 	}
 	file.close();
 
-	snprintf(fullpath, sizeof(fullpath), "%s/power/connected_duration", sysfs_path);
-	file.open(fullpath, ios::in);
+	file.open(std::format("{}/power/connected_duration", sysfs_path), ios::in);
 	if (file) {
 		file >> connected_before;
 	}
@@ -145,17 +136,14 @@ void usbdevice::start_measurement(void)
 void usbdevice::end_measurement(void)
 {
 	ifstream file;
-	char fullpath[PATH_MAX];
 
-	snprintf(fullpath, sizeof(fullpath), "%s/power/active_duration", sysfs_path);
-	file.open(fullpath, ios::in);
+	file.open(std::format("{}/power/active_duration", sysfs_path), ios::in);
 	if (file) {
 		file >> active_after;
 	}
 	file.close();
 
-	snprintf(fullpath, sizeof(fullpath), "%s/power/connected_duration", sysfs_path);
-	file.open(fullpath, ios::in);
+	file.open(std::format("{}/power/connected_duration", sysfs_path), ios::in);
 	if (file) {
 		file >> connected_after;
 	}
@@ -206,35 +194,28 @@ double usbdevice::power_usage(struct result_bundle *result, struct parameter_bun
 
 static void create_all_usb_devices_callback(const char *d_name)
 {
-	char filename[PATH_MAX];
 	ifstream file;
 	class usbdevice *usb;
-	char device_name[PATH_MAX];
 	char vendorid[64], devid[64];
-	char devid_name[4096];
 
-	snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s", d_name);
-	snprintf(device_name, sizeof(device_name), "%s/power/active_duration", filename);
-	if (access(device_name, R_OK) != 0)
+	if (access(std::format("/sys/bus/usb/devices/{}/power/active_duration", d_name).c_str(), R_OK) != 0)
 		return;
 
-	snprintf(device_name, sizeof(device_name), "%s/idVendor", filename);
-	file.open(device_name, ios::in);
+	file.open(std::format("/sys/bus/usb/devices/{}/idVendor", d_name), ios::in);
 	if (file)
 		file.getline(vendorid, 64);
 	file.close();
-	snprintf(device_name, sizeof(device_name), "%s/idProduct", filename);
-	file.open(device_name, ios::in);
+	file.open(std::format("/sys/bus/usb/devices/{}/idProduct", d_name), ios::in);
 	if (file)
 		file.getline(devid, 64);
 	file.close();
 
-	snprintf(devid_name, sizeof(devid_name), "usb-device-%s-%s", vendorid, devid);
-	snprintf(device_name, sizeof(device_name), "usb-device-%s-%s-%s", d_name, vendorid, devid);
-	if (result_device_exists(device_name))
+	std::string devid_name = std::format("usb-device-{}-{}", vendorid, devid);
+	std::string device_name = std::format("usb-device-{}-{}-{}", d_name, vendorid, devid);
+	if (result_device_exists(device_name.c_str()))
 		return;
 
-	usb = new class usbdevice(device_name, filename, devid_name);
+	usb = new class usbdevice(device_name.c_str(), std::format("/sys/bus/usb/devices/{}", d_name).c_str(), devid_name.c_str());
 	all_devices.push_back(usb);
 	register_parameter(devid_name, 0.1);
 }

--- a/src/devices/usb.cpp
+++ b/src/devices/usb.cpp
@@ -38,14 +38,14 @@
 #include <iostream>
 #include <fstream>
 
-usbdevice::usbdevice(const char *_name, const char *path, const char *devid): device()
+usbdevice::usbdevice(const string &_name, const string &path, const string &devid): device()
 {
 	ifstream file;
 	char vendor[4096];
 	char product[4096];
 
 	sysfs_path = path;
-	register_sysfs_path(sysfs_path.c_str());
+	register_sysfs_path(sysfs_path);
 	name = _name;
 	devname = devid;
 	humanname = pt_format(_("USB device: {}"), pretty_print(devid, vendor, 4096));
@@ -56,7 +56,7 @@ usbdevice::usbdevice(const char *_name, const char *path, const char *devid): de
 	busnum = 0;
 	devnum = 0;
 
-	index = get_param_index(devname.c_str());
+	index = get_param_index(devname);
 	r_index = get_result_index(name);
 	rootport = 0;
 	cached_valid = 0;
@@ -215,7 +215,7 @@ static void create_all_usb_devices_callback(const char *d_name)
 	if (result_device_exists(device_name.c_str()))
 		return;
 
-	usb = new class usbdevice(device_name.c_str(), std::format("/sys/bus/usb/devices/{}", d_name).c_str(), devid_name.c_str());
+	usb = new class usbdevice(device_name, std::format("/sys/bus/usb/devices/{}", d_name), devid_name);
 	all_devices.push_back(usb);
 	register_parameter(devid_name, 0.1);
 }

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -56,8 +56,7 @@ public:
 
 	virtual const char * device_name(void) { return devname.c_str(); };
 	virtual std::string device_name_s(void) { return devname; };
-	virtual const char * human_name_cstr(void) { return humanname.c_str(); };
-	virtual std::string human_name_s(void) { return humanname; };
+	virtual std::string human_name(void) { return humanname; };
 	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -52,10 +52,9 @@ public:
 
 	virtual double	utilization(void); /* percentage */
 
-	virtual const char * class_name(void) { return "usb";};
+	virtual std::string class_name(void) { return "usb";};
 
-	virtual const char * device_name(void) { return devname.c_str(); };
-	virtual std::string device_name_s(void) { return devname; };
+	virtual std::string device_name(void) { return devname; };
 	virtual std::string human_name(void) { return humanname; };
 	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -45,7 +45,7 @@ class usbdevice: public device {
 	int devnum;
 public:
 
-	usbdevice(const char *_name, const char *path, const char *devid);
+	usbdevice(const std::string &_name, const std::string &path, const std::string &devid);
 
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -56,7 +56,7 @@ public:
 
 	virtual const char * device_name(void) { return devname.c_str(); };
 	virtual std::string device_name_s(void) { return devname; };
-	virtual const char * human_name(void) { return humanname.c_str(); };
+	virtual const char * human_name_cstr(void) { return humanname.c_str(); };
 	virtual std::string human_name_s(void) { return humanname; };
 	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -26,6 +26,7 @@
 #define _INCLUDE_GUARD_USB_H
 
 #include <limits.h>
+#include <string>
 
 #include "device.h"
 #include "../parameters/parameters.h"
@@ -35,8 +36,8 @@ class usbdevice: public device {
 	int connected_before, connected_after;
 	char sysfs_path[PATH_MAX];
 	char name[4096];
-	char devname[4096];
-	char humanname[4096];
+	std::string devname;
+	std::string humanname;
 	int index;
 	int r_index;
 	int rootport;
@@ -53,8 +54,10 @@ public:
 
 	virtual const char * class_name(void) { return "usb";};
 
-	virtual const char * device_name(void);
-	virtual const char * human_name(void);
+	virtual const char * device_name(void) { return devname.c_str(); };
+	virtual std::string device_name_s(void) { return devname; };
+	virtual const char * human_name(void) { return humanname.c_str(); };
+	virtual std::string human_name_s(void) { return humanname; };
 	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual int power_valid(void) { return utilization_power_valid(r_index);};

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -34,7 +34,7 @@
 class usbdevice: public device {
 	int active_before, active_after;
 	int connected_before, connected_after;
-	char sysfs_path[PATH_MAX];
+	std::string sysfs_path;
 	std::string name;
 	std::string devname;
 	std::string humanname;

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -35,7 +35,7 @@ class usbdevice: public device {
 	int active_before, active_after;
 	int connected_before, connected_after;
 	char sysfs_path[PATH_MAX];
-	char name[4096];
+	std::string name;
 	std::string devname;
 	std::string humanname;
 	int index;

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -217,9 +217,9 @@ int charge_device_to_openers(const char *devstring, double power, class device *
 			proc = find_create_process(one[i]->comm, one[i]->pid);
 			if (proc) {
 				proc->power_charge += power;
-				if (strlen(_dev->guilty) < 2000 && strstr(_dev->guilty, one[i]->comm) == NULL) {
-					strcat(_dev->guilty, one[i]->comm);
-					strcat(_dev->guilty, " ");
+				if (_dev->guilty.length() < 2000 && _dev->guilty.find(one[i]->comm) == std::string::npos) {
+					_dev->guilty += one[i]->comm;
+					_dev->guilty += " ";
 				}
 			}
 		}
@@ -229,9 +229,9 @@ int charge_device_to_openers(const char *devstring, double power, class device *
 			proc = find_create_process(two[i]->comm, two[i]->pid);
 			if (proc) {
 				proc->power_charge += power;
-				if (strlen(_dev->guilty) < 2000 && strstr(_dev->guilty, two[i]->comm) == NULL) {
-					strcat(_dev->guilty, two[i]->comm);
-					strcat(_dev->guilty, " ");
+				if (_dev->guilty.length() < 2000 && _dev->guilty.find(two[i]->comm) == std::string::npos) {
+					_dev->guilty += two[i]->comm;
+					_dev->guilty += " ";
 				}
 			}
 		}
@@ -247,7 +247,7 @@ void clear_devpower(void)
 
 	for (i = 0; i < devpower.size(); i++) {
 		devpower[i]->power = 0.0;
-		devpower[i]->dev->guilty[0] = 0;
+		devpower[i]->dev->guilty.clear();
 	}
 }
 

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -78,15 +78,15 @@ void clean_open_devices()
 	unsigned int i=0;
 
 	for (i = 0; i < one.size(); i++) {
-		free(one[i]);
+		delete one[i];
 	}
 
 	for (i = 0; i < two.size(); i++) {
-		free(two[i]);
+		delete two[i];
 	}
 
 	for (i = 0; i < devpower.size(); i++){
-		free(devpower[i]);
+		delete devpower[i];
 	}
 }
 
@@ -94,7 +94,7 @@ void collect_open_devices(void)
 {
 	struct dirent *entry;
 	DIR *dir;
-	char filename[PATH_MAX];
+	std::string filename;
 	char link[PATH_MAX];
 	unsigned int i;
 	vector<struct devuser *> *target;
@@ -105,7 +105,7 @@ void collect_open_devices(void)
 		target = &two;
 
 	for (i = 0; i < target->size(); i++) {
-		free((*target)[i]);
+		delete (*target)[i];
 	}
 	target->resize(0);
 
@@ -125,9 +125,9 @@ void collect_open_devices(void)
 		if (strcmp(entry->d_name, "self") == 0)
 			continue;
 
-		snprintf(filename, sizeof(filename), "/proc/%s/fd/", entry->d_name);
+		filename = std::format("/proc/{}/fd/", entry->d_name);
 
-		dir2 = opendir(filename);
+		dir2 = opendir(filename.c_str());
 		if (!dir2)
 			continue;
 		while (1) {
@@ -138,9 +138,9 @@ void collect_open_devices(void)
 				break;
 			if (!isdigit(entry2->d_name[0]))
 				continue;
-			snprintf(filename, sizeof(filename), "/proc/%s/fd/%s", entry->d_name, entry2->d_name);
+			filename = std::format("/proc/{}/fd/{}", entry->d_name, entry2->d_name);
 			memset(link, 0, sizeof(link));
-			ret = readlink(filename, link, sizeof(link) - 1);
+			ret = readlink(filename.c_str(), link, sizeof(link) - 1);
 			if (ret < 0)
 				continue;
 
@@ -162,14 +162,12 @@ void collect_open_devices(void)
 				continue;
 
 			if (strncmp(link, "/dev", 4)==0) {
-				dev = (struct devuser *)malloc(sizeof(struct devuser));
+				dev = new(std::nothrow) struct devuser;
 				if (!dev)
 					continue;
 				dev->pid = strtoull(entry->d_name, NULL, 10);
-				strncpy(dev->device, link, 251);
-				dev->device[251] = '\0';
-				pt_strcpy(dev->comm, read_sysfs_string(std::format("/proc/{}/comm", entry->d_name)).c_str());
-				dev->comm[31] = '\0';
+				dev->device = link;
+				dev->comm = read_sysfs_string(std::format("/proc/{}/comm", entry->d_name));
 				target->push_back(dev);
 
 			}
@@ -194,11 +192,11 @@ int charge_device_to_openers(const char *devstring, double power, class device *
 	/* 1. count the number of openers */
 
 	for (i = 0; i < one.size(); i++) {
-		if (strstr(one[i]->device, devstring))
+		if (one[i]->device.find(devstring) != std::string::npos)
 			openers++;
 	}
 	for (i = 0; i < two.size(); i++) {
-		if (strstr(two[i]->device, devstring))
+		if (two[i]->device.find(devstring) != std::string::npos)
 			openers++;
 	}
 
@@ -213,8 +211,8 @@ int charge_device_to_openers(const char *devstring, double power, class device *
 	/* 3. for each process that has it open, add the charge */
 
 	for (i = 0; i < one.size(); i++)
-		if (strstr(one[i]->device, devstring)) {
-			proc = find_create_process(one[i]->comm, one[i]->pid);
+		if (one[i]->device.find(devstring) != std::string::npos) {
+			proc = find_create_process(one[i]->comm.c_str(), one[i]->pid);
 			if (proc) {
 				proc->power_charge += power;
 				if (_dev->guilty.find(one[i]->comm) == std::string::npos) {
@@ -225,8 +223,8 @@ int charge_device_to_openers(const char *devstring, double power, class device *
 		}
 
 	for (i = 0; i < two.size(); i++)
-		if (strstr(two[i]->device, devstring)) {
-			proc = find_create_process(two[i]->comm, two[i]->pid);
+		if (two[i]->device.find(devstring) != std::string::npos) {
+			proc = find_create_process(two[i]->comm.c_str(), two[i]->pid);
 			if (proc) {
 				proc->power_charge += power;
 				if (_dev->guilty.find(two[i]->comm) == std::string::npos) {
@@ -262,8 +260,10 @@ void register_devpower(const std::string &devstring, double power, class device 
 		}
 
 	if (!dev) {
-		dev = (struct devpower *)malloc(sizeof (struct devpower));
-		pt_strcpy(dev->device, devstring.c_str());
+		dev = new(std::nothrow) struct devpower;
+		if (!dev)
+			return;
+		dev->device = devstring;
 		dev->power = 0.0;
 		devpower.push_back(dev);
 	}
@@ -282,7 +282,7 @@ void run_devpower_list(void)
 
 	for (i = 0; i < devpower.size(); i++) {
 		int ret;
-		ret = charge_device_to_openers(devpower[i]->device, devpower[i]->power, devpower[i]->dev);
+		ret = charge_device_to_openers(devpower[i]->device.c_str(), devpower[i]->power, devpower[i]->dev);
 		if (ret)
 			devpower[i]->dev->hide = true;
 		else
@@ -297,17 +297,16 @@ static bool devlist_sort(struct devuser * i, struct devuser * j)
 	if (i->pid != j->pid)
 		return i->pid < j->pid;
 
-	return (strcmp(i->device, j->device)< 0);
+	return i->device < j->device;
 }
 
 void report_show_open_devices(void)
 {
 	vector<struct devuser *> *target;
 	unsigned int i;
-	char prev[128], proc[128];
+	std::string prev, proc;
 	int idx, cols, rows;
 
-	prev[0] = 0;
 	if (phase == 1)
 		target = &one;
 	else
@@ -336,15 +335,15 @@ void report_show_open_devices(void)
 	process_data[1]=__("Device");
 
 	for (i = 0; i < target->size(); i++) {
-		proc[0] = 0;
-		if (strcmp(prev, (*target)[i]->comm) != 0)
-			snprintf(proc, sizeof(proc), "%s", (*target)[i]->comm);
+		proc = "";
+		if (prev != (*target)[i]->comm)
+			proc = (*target)[i]->comm;
 
-		process_data[idx]=string(proc);
+		process_data[idx]=proc;
 		idx+=1;
-		process_data[idx]=string((*target)[i]->device);
+		process_data[idx]=(*target)[i]->device;
 		idx+=1;
-		snprintf(prev, sizeof(prev), "%s", (*target)[i]->comm);
+		prev = (*target)[i]->comm;
 	}
 
 	/* Report Output */

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -251,24 +251,29 @@ void clear_devpower(void)
 	}
 }
 
-void register_devpower(const char *devstring, double power, class device *_dev)
+void register_devpower(const std::string &devstring, double power, class device *_dev)
 {
 	unsigned int i;
 	struct devpower *dev =  NULL;
 
 	for (i = 0; i < devpower.size(); i++)
-		if (strcmp(devstring, devpower[i]->device) == 0) {
+		if (devstring == devpower[i]->device) {
 			dev = devpower[i];
 		}
 
 	if (!dev) {
 		dev = (struct devpower *)malloc(sizeof (struct devpower));
-		pt_strcpy(dev->device, devstring);
+		pt_strcpy(dev->device, devstring.c_str());
 		dev->power = 0.0;
 		devpower.push_back(dev);
 	}
 	dev->dev = _dev;
 	dev->power = power;
+}
+
+void register_devpower(const char *devstring, double power, class device *_dev)
+{
+	register_devpower(std::string(devstring), power, _dev);
 }
 
 void run_devpower_list(void)

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -224,7 +224,7 @@ int charge_device_to_openers(const char *devstring, double power, class device *
 
 	for (i = 0; i < two.size(); i++)
 		if (two[i]->device.find(devstring) != std::string::npos) {
-			proc = find_create_process(two[i]->comm.c_str(), two[i]->pid);
+			proc = find_create_process(two[i]->comm, two[i]->pid);
 			if (proc) {
 				proc->power_charge += power;
 				if (_dev->guilty.find(two[i]->comm) == std::string::npos) {

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -168,7 +168,7 @@ void collect_open_devices(void)
 				dev->pid = strtoull(entry->d_name, NULL, 10);
 				strncpy(dev->device, link, 251);
 				dev->device[251] = '\0';
-				strncpy(dev->comm, read_sysfs_string("/proc/%s/comm", entry->d_name).c_str(), 31);
+				pt_strcpy(dev->comm, read_sysfs_string(std::format("/proc/{}/comm", entry->d_name)).c_str());
 				dev->comm[31] = '\0';
 				target->push_back(dev);
 

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -217,7 +217,7 @@ int charge_device_to_openers(const char *devstring, double power, class device *
 			proc = find_create_process(one[i]->comm, one[i]->pid);
 			if (proc) {
 				proc->power_charge += power;
-				if (_dev->guilty.length() < 2000 && _dev->guilty.find(one[i]->comm) == std::string::npos) {
+				if (_dev->guilty.find(one[i]->comm) == std::string::npos) {
 					_dev->guilty += one[i]->comm;
 					_dev->guilty += " ";
 				}
@@ -229,7 +229,7 @@ int charge_device_to_openers(const char *devstring, double power, class device *
 			proc = find_create_process(two[i]->comm, two[i]->pid);
 			if (proc) {
 				proc->power_charge += power;
-				if (_dev->guilty.length() < 2000 && _dev->guilty.find(two[i]->comm) == std::string::npos) {
+				if (_dev->guilty.find(two[i]->comm) == std::string::npos) {
 					_dev->guilty += two[i]->comm;
 					_dev->guilty += " ";
 				}

--- a/src/devlist.h
+++ b/src/devlist.h
@@ -1,21 +1,21 @@
 #ifndef __INCLUDE_GUARD_DEVLIST_H__
 #define __INCLUDE_GUARD_DEVLIST_H__
 
+#include <string>
+
 struct devuser {
 	unsigned int pid;
-	char comm[32];
-	char device[252];
+	std::string comm;
+	std::string device;
 };
 
 class device;
 
 struct devpower {
-	char device[252];
+	std::string device;
 	double power;
 	class device *dev;
 };
-
-#include <string>
 
 extern void clean_open_devices();
 extern void collect_open_devices(void);

--- a/src/devlist.h
+++ b/src/devlist.h
@@ -15,11 +15,14 @@ struct devpower {
 	class device *dev;
 };
 
+#include <string>
+
 extern void clean_open_devices();
 extern void collect_open_devices(void);
 
 extern void clear_devpower(void);
 extern void register_devpower(const char *devstring, double power, class device *dev);
+extern void register_devpower(const std::string &devstring, double power, class device *dev);
 extern void run_devpower_list(void);
 
 extern void report_show_open_devices(void);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -154,12 +154,15 @@ void show_tab(unsigned int tab)
 	prefresh(win->win, win->ypad_pos, win->xpad_pos, 1, 0, LINES - 3, COLS - 1);
 }
 
-WINDOW *get_ncurses_win(const char *name)
+WINDOW *get_ncurses_win(const string &name)
 {
 	class tab_window *w;
 	WINDOW *win;
 
-	w= tab_windows[name];
+	if (tab_windows.count(name) == 0)
+		return NULL;
+
+	w = tab_windows[name];
 	if (!w)
 		return NULL;
 
@@ -173,18 +176,16 @@ WINDOW *get_ncurses_win(int nr)
 	class tab_window *w;
 	WINDOW *win;
 
-	w= tab_windows[tab_names[nr]];
+	if (nr < 0 || nr >= (int)tab_names.size())
+		return NULL;
+
+	w = tab_windows[tab_names[nr]];
 	if (!w)
 		return NULL;
 
 	win = w->win;
 
 	return win;
-}
-
-WINDOW *get_ncurses_win(const string &name)
-{
-	return get_ncurses_win(name.c_str());
 }
 
 void show_prev_tab(void)

--- a/src/display.h
+++ b/src/display.h
@@ -90,7 +90,6 @@ public:
 
 extern map<string, class tab_window *> tab_windows;
 
-WINDOW *get_ncurses_win(const char *name);
 WINDOW *get_ncurses_win(const string &name);
 WINDOW *get_ncurses_win(int nr);
 

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -35,6 +35,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <format>
 
 #include "lib.h"
 
@@ -107,6 +108,27 @@ char *hz_to_human(unsigned long hz, char *buffer, int digits)
 	}
 
 	return buffer;
+}
+
+std::string hz_to_human(unsigned long hz, int digits)
+{
+	unsigned long long Hz = hz;
+
+	if (Hz > 1500000) {
+		if (digits == 2)
+			return std::format("{:4.2f} GHz", (Hz + 5000.0) / 1000000.0);
+		else
+			return std::format("{:3.1f} GHz", (Hz + 5000.0) / 1000000.0);
+	}
+
+	if (Hz > 1000) {
+		if (digits == 2)
+			return std::format("{:4d} MHz", (Hz + 500) / 1000);
+		else
+			return std::format("{:6d} MHz", (Hz + 500) / 1000);
+	}
+
+	return std::format("{:9d}", Hz);
 }
 
 using namespace std;

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -409,23 +409,29 @@ static void init_pretty_print(void)
 }
 
 
-char *pretty_print(const char *str, char *buf, int len)
+char *pretty_print(const std::string &str, char *buf, int len)
 {
-	const char *p;
+	const char *p = NULL;
 
 	if (!pretty_print_init)
 		init_pretty_print();
 
-	p = pretty_prints[str].c_str();
+	if (pretty_prints.count(str))
+		p = pretty_prints[str].c_str();
 
-	if (strlen(p) == 0)
-		p = str;
+	if (!p || strlen(p) == 0)
+		p = str.c_str();
 
 	snprintf(buf, len,  "%s", p);
 
 	if (len)
 		buf[len - 1] = 0;
 	return buf;
+}
+
+char *pretty_print(const char *str, char *buf, int len)
+{
+	return pretty_print(std::string(str ? str : ""), buf, len);
 }
 
 int equals(double a, double b)

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -235,46 +235,18 @@ int read_sysfs(const string &filename, bool *ok)
 string read_sysfs_string(const string &filename)
 {
 	ifstream file;
-	char content[4096];
-	char *c;
+	string content;
 
 	file.open(filename.c_str(), ios::in);
 	if (!file)
 		return "";
 	try
 	{
-		file.getline(content, 4096);
+		getline(file, content);
 		file.close();
-		c = strchr(content, '\n');
-		if (c)
-			*c = 0;
-	} catch (std::exception &exc) {
-		file.close();
-		return "";
-	}
-	return content;
-}
-
-string read_sysfs_string(const char *format, const char *param)
-{
-	ifstream file;
-	char content[4096];
-	char *c;
-	char filename[PATH_MAX];
-
-
-	snprintf(filename, sizeof(filename), format, param);
-
-	file.open(filename, ios::in);
-	if (!file)
-		return "";
-	try
-	{
-		file.getline(content, 4096);
-		file.close();
-		c = strchr(content, '\n');
-		if (c)
-			*c = 0;
+		size_t pos = content.find('\n');
+		if (pos != string::npos)
+			content.erase(pos);
 	} catch (std::exception &exc) {
 		file.close();
 		return "";

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -306,6 +306,15 @@ char *pci_id_to_name(uint16_t vendor, uint16_t device, char *buffer, int len)
 	return ret;
 }
 
+char *pci_id_to_name(uint16_t vendor, uint16_t device, std::string &buffer, int len)
+{
+	char buf[len];
+	char *ret;
+	ret = pci_id_to_name(vendor, device, buf, len);
+	buffer = buf;
+	return ret;
+}
+
 void end_pci_access(void)
 {
 	if (pci_access)
@@ -315,6 +324,11 @@ void end_pci_access(void)
 #else
 
 char *pci_id_to_name(uint16_t vendor, uint16_t device, char *buffer, int len)
+{
+	return NULL;
+}
+
+char *pci_id_to_name(uint16_t vendor, uint16_t device, std::string &buffer, int len)
 {
 	return NULL;
 }
@@ -501,14 +515,14 @@ int read_msr(int cpu, uint64_t offset, uint64_t *value)
 	ssize_t retval;
 	uint64_t msr;
 	int fd;
-	char msr_path[256];
+	std::string msr_path;
 
-	snprintf(msr_path, sizeof(msr_path), "/dev/cpu/%d/msr", cpu);
+	msr_path = std::format("/dev/cpu/{}/msr", cpu);
 
-	if (access(msr_path, R_OK) != 0){
-		snprintf(msr_path, sizeof(msr_path), "/dev/msr%d", cpu);
+	if (access(msr_path.c_str(), R_OK) != 0){
+		msr_path = std::format("/dev/msr{}", cpu);
 
-		if (access(msr_path, R_OK) != 0){
+		if (access(msr_path.c_str(), R_OK) != 0){
 			fprintf(stderr,
 			 _("Model-specific registers (MSR)\
 			 not found (try enabling CONFIG_X86_MSR).\n"));
@@ -516,7 +530,7 @@ int read_msr(int cpu, uint64_t offset, uint64_t *value)
 		}
 	}
 
-	fd = open(msr_path, O_RDONLY);
+	fd = open(msr_path.c_str(), O_RDONLY);
 	if (fd < 0)
 		return -1;
 	retval = pread(fd, &msr, sizeof msr, offset);
@@ -537,14 +551,14 @@ int write_msr(int cpu, uint64_t offset, uint64_t value)
 #if defined(__i386__) || defined(__x86_64__)
 	ssize_t retval;
 	int fd;
-	char msr_path[256];
+	std::string msr_path;
 
-	snprintf(msr_path, sizeof(msr_path), "/dev/cpu/%d/msr", cpu);
+	msr_path = std::format("/dev/cpu/{}/msr", cpu);
 
-	if (access(msr_path, R_OK) != 0){
-		snprintf(msr_path, sizeof(msr_path), "/dev/msr%d", cpu);
+	if (access(msr_path.c_str(), R_OK) != 0){
+		msr_path = std::format("/dev/msr{}", cpu);
 
-		if (access(msr_path, R_OK) != 0){
+		if (access(msr_path.c_str(), R_OK) != 0){
 			fprintf(stderr,
 			 _("Model-specific registers (MSR)\
 			 not found (try enabling CONFIG_X86_MSR).\n"));
@@ -552,7 +566,7 @@ int write_msr(int cpu, uint64_t offset, uint64_t value)
 		}
 	}
 
-	fd = open(msr_path, O_WRONLY);
+	fd = open(msr_path.c_str(), O_WRONLY);
 	if (fd < 0)
 		return -1;
 	retval = pwrite(fd, &value, sizeof value, offset);

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -82,34 +82,6 @@ double percentage(double F)
 	return F;
 }
 
-char *hz_to_human(unsigned long hz, char *buffer, int digits)
-{
-	unsigned long long Hz;
-
-	buffer[0] = 0;
-
-	Hz = hz;
-
-	/* default: just put the Number in */
-	sprintf(buffer,"%9lli", Hz);
-
-	if (Hz>1000) {
-		if (digits == 2)
-			sprintf(buffer, "%4lli MHz", (Hz+500)/1000);
-		else
-			sprintf(buffer, "%6lli MHz", (Hz+500)/1000);
-	}
-
-	if (Hz>1500000) {
-		if (digits == 2)
-			sprintf(buffer, "%4.2f GHz", (Hz+5000.0)/1000000);
-		else
-			sprintf(buffer, "%3.1f GHz", (Hz+5000.0)/1000000);
-	}
-
-	return buffer;
-}
-
 std::string hz_to_human(unsigned long hz, int digits)
 {
 	unsigned long long Hz = hz;
@@ -123,12 +95,12 @@ std::string hz_to_human(unsigned long hz, int digits)
 
 	if (Hz > 1000) {
 		if (digits == 2)
-			return std::format("{:4d} MHz", (Hz + 500) / 1000);
+			return std::format("{:4d} MHz", (int)((Hz + 500) / 1000));
 		else
-			return std::format("{:6d} MHz", (Hz + 500) / 1000);
+			return std::format("{:6d} MHz", (int)((Hz + 500) / 1000));
 	}
 
-	return std::format("{:9d}", Hz);
+	return std::format("{:9d}", (int)Hz);
 }
 
 using namespace std;
@@ -254,9 +226,10 @@ string read_sysfs_string(const string &filename)
 	return content;
 }
 
-void align_string(char *buffer, size_t min_sz, size_t max_sz)
+void align_string(std::string &str, size_t min_sz, size_t max_sz)
 {
 	size_t sz;
+	const char *buffer = str.c_str();
 
 	/** mbsrtowcs() allows NULL dst and zero sz,
 	 * comparing to mbstowcs(), which causes undefined
@@ -264,27 +237,28 @@ void align_string(char *buffer, size_t min_sz, size_t max_sz)
 
 	/* start with mbsrtowcs() local mbstate_t * and
 	 * NULL dst pointer*/
-	sz = mbsrtowcs(NULL, (const char **)&buffer, max_sz, NULL);
+	sz = mbsrtowcs(NULL, &buffer, max_sz, NULL);
 	if (sz == (size_t)-1) {
-		buffer[min_sz] = 0x00;
 		return;
 	}
 	while (sz < min_sz) {
-		strcat(buffer, " ");
+		str += " ";
 		sz++;
 	}
 }
 
-void format_watts(double W, char *buffer, unsigned int len)
+std::string format_watts(double W, unsigned int len)
 {
-	buffer[0] = 0;
-	char buf[32];
-	sprintf(buffer, _("%7sW"), fmt_prefix(W, buf));
+	std::string buffer;
+
+	buffer = pt_format(_("{:7s}W"), fmt_prefix(W));
 
 	if (W < 0.0001)
-		sprintf(buffer, _("    0 mW"));
+		buffer = _("    0 mW");
 
 	align_string(buffer, len, len);
+
+	return buffer;
 }
 
 #ifndef HAVE_NO_PCI
@@ -344,11 +318,12 @@ int utf_ok = -1;
 
 
 /* pretty print numbers while limiting the precision */
-char *fmt_prefix(double n, char *buf)
+string fmt_prefix(double n)
 {
 	static const char prefixes[] = "yzafpnum kMGTPEZY";
 	char tmpbuf[16];
 	int omag, npfx;
+	char buf[32];
 	char *p, *q, pfx, *c;
 	int i;
 
@@ -373,8 +348,7 @@ char *fmt_prefix(double n, char *buf)
 	snprintf(tmpbuf, sizeof tmpbuf, "%.2e", n);
 	c = strchr(tmpbuf, 'e');
 	if (!c) {
-		sprintf(buf, "NaN");
-		return buf;
+		return "NaN";
 	}
 	omag = atoi(c + 1);
 
@@ -443,21 +417,11 @@ char *pretty_print(const std::string &str, char *buf, int len)
 	return buf;
 }
 
-char *pretty_print(const char *str, char *buf, int len)
-{
-	return pretty_print(std::string(str ? str : ""), buf, len);
-}
-
-int equals(double a, double b)
-{
-	return fabs(a - b) <= std::numeric_limits<double>::epsilon();
-}
-
-void process_directory(const char *d_name, callback fn)
+void process_directory(const std::string &d_name, callback fn)
 {
 	struct dirent *entry;
 	DIR *dir;
-	dir = opendir(d_name);
+	dir = opendir(d_name.c_str());
 	if (!dir)
 		return;
 	while (1) {
@@ -471,12 +435,17 @@ void process_directory(const char *d_name, callback fn)
 	closedir(dir);
 }
 
-void process_glob(const char *d_glob, callback fn)
+int equals(double a, double b)
+{
+	return fabs(a - b) <= std::numeric_limits<double>::epsilon();
+}
+
+void process_glob(const std::string &d_glob, callback fn)
 {
 	glob_t g;
 	size_t c;
 
-	switch (glob(d_glob, GLOB_ERR | GLOB_MARK | GLOB_NOSORT, NULL, &g)) {
+	switch (glob(d_glob.c_str(), GLOB_ERR | GLOB_MARK | GLOB_NOSORT, NULL, &g)) {
 	case GLOB_NOSPACE:
 		fprintf(stderr,_("glob returned GLOB_NOSPACE\n"));
 		globfree(&g);
@@ -497,16 +466,16 @@ void process_glob(const char *d_glob, callback fn)
 	globfree(&g);
 }
 
-int get_user_input(char *buf, unsigned sz)
+string get_user_input(unsigned sz)
 {
+	char buf[sz+1];
 	fflush(stdout);
 	echo();
 	/* Upon successful completion, these functions return OK. Otherwise, they return ERR. */
-	int ret = getnstr(buf, sz);
+	getnstr(buf, sz);
 	noecho();
 	fflush(stdout);
-	/* to distinguish between getnstr error and empty line */
-	return ret || strlen(buf);
+	return buf;
 }
 
 int read_msr(int cpu, uint64_t offset, uint64_t *value)

--- a/src/lib.h
+++ b/src/lib.h
@@ -57,7 +57,6 @@ extern int get_max_cpu(void);
 extern void set_max_cpu(int cpu);
 
 extern double percentage(double F);
-extern char *hz_to_human(unsigned long hz, char *buffer, int digits = 2);
 extern std::string hz_to_human(unsigned long hz, int digits = 2);
 
 
@@ -73,14 +72,13 @@ extern void write_sysfs(const string &filename, const string &value);
 extern int read_sysfs(const string &filename, bool *ok = NULL);
 extern string read_sysfs_string(const string &filename);
 
-extern void format_watts(double W, char *buffer, unsigned int len);
+extern std::string format_watts(double W, unsigned int len);
 
 extern char *pci_id_to_name(uint16_t vendor, uint16_t device, std::string &buffer, int len);
 extern void end_pci_access(void);
 
 
-extern char *fmt_prefix(double n, char *buf);
-extern char *pretty_print(const char *str, char *buf, int len);
+extern std::string fmt_prefix(double n);
 extern char *pretty_print(const std::string &str, char *buf, int len);
 extern int equals(double a, double b);
 
@@ -91,14 +89,14 @@ template<size_t N> void pt_strcpy(char (&d)[N], const char *s)
 }
 
 typedef void (*callback)(const char*);
-extern void process_directory(const char *d_name, callback fn);
-extern void process_glob(const char *glob, callback fn);
+extern void process_directory(const std::string &d_name, callback fn);
+extern void process_glob(const std::string &glob, callback fn);
 extern int utf_ok;
-extern int get_user_input(char *buf, unsigned sz);
+extern std::string get_user_input(unsigned sz);
 extern int read_msr(int cpu, uint64_t offset, uint64_t *value);
 extern int write_msr(int cpu, uint64_t offset, uint64_t value);
 
-extern void align_string(char *buffer, size_t min_sz, size_t max_sz);
+extern void align_string(std::string &str, size_t min_sz, size_t max_sz);
 
 extern void ui_notify_user_ncurses(const char *frmt, ...);
 extern void ui_notify_user_console(const char *frmt, ...);

--- a/src/lib.h
+++ b/src/lib.h
@@ -81,6 +81,7 @@ extern void end_pci_access(void);
 
 extern char *fmt_prefix(double n, char *buf);
 extern char *pretty_print(const char *str, char *buf, int len);
+extern char *pretty_print(const std::string &str, char *buf, int len);
 extern int equals(double a, double b);
 
 template<size_t N> void pt_strcpy(char (&d)[N], const char *s)

--- a/src/lib.h
+++ b/src/lib.h
@@ -25,6 +25,15 @@
 #ifndef INCLUDE_GUARD_LIB_H
 #define INCLUDE_GUARD_LIB_H
 
+#include <format>
+#include <string_view>
+
+template<typename... Args>
+inline std::string pt_format(std::string_view fmt, Args&&... args)
+{
+	return std::vformat(fmt, std::make_format_args(args...));
+}
+
 #include <libintl.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/lib.h
+++ b/src/lib.h
@@ -75,7 +75,7 @@ extern string read_sysfs_string(const string &filename);
 
 extern void format_watts(double W, char *buffer, unsigned int len);
 
-extern char *pci_id_to_name(uint16_t vendor, uint16_t device, char *buffer, int len);
+extern char *pci_id_to_name(uint16_t vendor, uint16_t device, std::string &buffer, int len);
 extern void end_pci_access(void);
 
 

--- a/src/lib.h
+++ b/src/lib.h
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <cstring>
+#include <string>
 
 /* Include only for Automake builds */
 #ifdef HAVE_CONFIG_H
@@ -48,6 +49,7 @@ extern void set_max_cpu(int cpu);
 
 extern double percentage(double F);
 extern char *hz_to_human(unsigned long hz, char *buffer, int digits = 2);
+extern std::string hz_to_human(unsigned long hz, int digits = 2);
 
 
 extern const char *kernel_function(uint64_t address);

--- a/src/lib.h
+++ b/src/lib.h
@@ -72,7 +72,6 @@ using namespace std;
 extern void write_sysfs(const string &filename, const string &value);
 extern int read_sysfs(const string &filename, bool *ok = NULL);
 extern string read_sysfs_string(const string &filename);
-extern string read_sysfs_string(const char *format, const char *param);
 
 extern void format_watts(double W, char *buffer, unsigned int len);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -217,7 +217,7 @@ extern "C" {
 	}
 }
 
-void one_measurement(int seconds, int sample_interval, char *workload)
+void one_measurement(int seconds, int sample_interval, const char *workload)
 {
 	create_all_usb_devices();
 	start_power_measurement();
@@ -294,7 +294,7 @@ void out_of_memory()
 	abort();
 }
 
-void make_report(int time, char *workload, int iterations, int sample_interval, char *file)
+void make_report(int time, const std::string &workload, int iterations, int sample_interval, const std::string &file)
 {
 
 	/* one to warm up everything */
@@ -302,16 +302,16 @@ void make_report(int time, char *workload, int iterations, int sample_interval, 
 	utf_ok = 0;
 	one_measurement(1, sample_interval, NULL);
 
-	if (!workload[0])
+	if (workload.empty())
 	  fprintf(stderr, _("Taking %d measurement(s) for a duration of %d second(s) each.\n"),iterations,time);
 	else
-	   fprintf(stderr, _("Measuring workload %s.\n"), workload);
+	   fprintf(stderr, _("Measuring workload %s.\n"), workload.c_str());
 	for (int i=0; i != iterations; i++){
-		init_report_output(file, iterations);
+		init_report_output(file.c_str(), iterations);
 		initialize_tuning();
 		initialize_wakeup();
 		/* and then the real measurement */
-		one_measurement(time, sample_interval, workload);
+		one_measurement(time, sample_interval, workload.empty() ? NULL : workload.c_str());
 		report_show_tunables();
 		report_show_wakeup();
 		finish_report_output();
@@ -434,8 +434,7 @@ int main(int argc, char **argv)
 {
 	int option_index;
 	int c;
-	char filename[PATH_MAX];
-	char workload[PATH_MAX] = {0};
+	std::string filename, workload;
 	int  iterations = 1, auto_tune = 0, sample_interval = 5;
 	bool auto_tune_dump = false;
 
@@ -467,8 +466,8 @@ int main(int argc, char **argv)
 			break;
 		case 'C':		/* csv report */
 			reporttype = REPORT_CSV;
-			snprintf(filename, sizeof(filename), "%s", optarg ? optarg : "powertop.csv");
-			if (!strlen(filename))
+			filename = optarg ? optarg : "powertop.csv";
+			if (filename.empty())
 			{
 				fprintf(stderr, _("Invalid CSV filename\n"));
 				exit(1);
@@ -483,8 +482,8 @@ int main(int argc, char **argv)
 			break;
 		case 'r':		/* html report */
 			reporttype = REPORT_HTML;
-			snprintf(filename, sizeof(filename), "%s", optarg ? optarg : "powertop.html");
-			if (!strlen(filename))
+			filename = optarg ? optarg : "powertop.html";
+			if (filename.empty())
 			{
 				fprintf(stderr, _("Invalid HTML filename\n"));
 				exit(1);
@@ -504,7 +503,7 @@ int main(int argc, char **argv)
 			time_out = (optarg ? atoi(optarg) : 20);
 			break;
 		case 'w':		/* measure workload */
-			snprintf(workload, sizeof(workload), "%s", optarg ? optarg : "");
+			workload = optarg ? optarg : "";
 			break;
 		case 'V':
 			print_version();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,12 +108,11 @@ static void print_version()
 
 static bool set_refresh_timeout()
 {
-	static char buf[4];
+	std::string buf;
 	mvprintw(1, 0, "%s (currently %u): ", _("Set refresh time out"), time_out);
-	memset(buf, '\0', sizeof(buf));
-	get_user_input(buf, sizeof(buf) - 1);
+	buf = get_user_input(3);
 	show_tab(0);
-	unsigned time = strtoul(buf, NULL, 0);
+	unsigned time = strtoul(buf.c_str(), NULL, 0);
 	if (!time) return 0;
 	if (time > 32) time = 32;
 	time_out = time;

--- a/src/measurement/acpi.cpp
+++ b/src/measurement/acpi.cpp
@@ -34,7 +34,7 @@
 
 using namespace std;
 
-acpi_power_meter::acpi_power_meter(const char *acpi_name) : power_meter(acpi_name)
+acpi_power_meter::acpi_power_meter(const string &acpi_name) : power_meter(acpi_name)
 {
 	rate = 0.0;
 	capacity = 0.0;

--- a/src/measurement/acpi.cpp
+++ b/src/measurement/acpi.cpp
@@ -34,12 +34,11 @@
 
 using namespace std;
 
-acpi_power_meter::acpi_power_meter(const char *acpi_name)
+acpi_power_meter::acpi_power_meter(const char *acpi_name) : power_meter(acpi_name)
 {
 	rate = 0.0;
 	capacity = 0.0;
 	voltage = 0.0;
-	pt_strcpy(battery_name, acpi_name);
 }
 
 /*
@@ -73,7 +72,7 @@ void acpi_power_meter::measure(void)
 	voltage = 0;
 	capacity = 0;
 
-	snprintf(filename, sizeof(filename), "/proc/acpi/battery/%s/state", battery_name);
+	snprintf(filename, sizeof(filename), "/proc/acpi/battery/%s/state", name.c_str());
 
 	file.open(filename, ios::in);
 	if (!file)

--- a/src/measurement/acpi.cpp
+++ b/src/measurement/acpi.cpp
@@ -52,7 +52,7 @@ present voltage:         12001 mV
 
 void acpi_power_meter::measure(void)
 {
-	char filename[PATH_MAX];
+	std::string filename;
 	char line[4096];
 	ifstream file;
 
@@ -69,9 +69,9 @@ void acpi_power_meter::measure(void)
 	voltage = 0;
 	capacity = 0;
 
-	snprintf(filename, sizeof(filename), "/proc/acpi/battery/%s/state", name.c_str());
+	filename = std::format("/proc/acpi/battery/{}/state", name);
 
-	file.open(filename, ios::in);
+	file.open(filename.c_str(), ios::in);
 	if (!file)
 		return;
 

--- a/src/measurement/acpi.cpp
+++ b/src/measurement/acpi.cpp
@@ -60,13 +60,10 @@ void acpi_power_meter::measure(void)
 	double _capacity = 0;
 	double _voltage = 0;
 
-	char rate_units[16];
-	char capacity_units[16];
-	char voltage_units[16];
+	std::string rate_units;
+	std::string capacity_units;
+	std::string voltage_units;
 
-	rate_units[0] = 0;
-	capacity_units[0] = 0;
-	voltage_units[0] = 0;
 
 	rate = 0;
 	voltage = 0;
@@ -96,10 +93,10 @@ void acpi_power_meter::measure(void)
 			c = strchr(c, ' ');
 			if (c) {
 				c++;
-				pt_strcpy(rate_units, c);
+				rate_units = c;
 			} else {
 				_rate = 0;
-				strcpy(rate_units, "Unknown");
+				rate_units = "Unknown";
 			}
 
 		}
@@ -111,10 +108,10 @@ void acpi_power_meter::measure(void)
 			c = strchr(c, ' ');
 			if (c) {
 				c++;
-				pt_strcpy(capacity_units, c);
+				capacity_units = c;
 			} else {
 				_capacity = 0;
-				strcpy(capacity_units, "Unknown");
+				capacity_units = "Unknown";
 			}
 		}
 		if (strstr(line, "present voltage:")) {
@@ -125,10 +122,10 @@ void acpi_power_meter::measure(void)
 			c = strchr(c, ' ');
 			if (c) {
 				c++;
-				pt_strcpy(voltage_units, c);
+				voltage_units = c;
 			} else {
 				_voltage = 0;
-				strcpy(voltage_units, "Unknown");
+				voltage_units = "Unknown";
 			}
 		}
 	}
@@ -136,59 +133,59 @@ void acpi_power_meter::measure(void)
 
 	/* BIOS report random crack-inspired units. Lets try to get to the Si-system units */
 
-	if (strcmp(voltage_units, "mV") == 0) {
+	if (voltage_units == "mV") {
 		_voltage = _voltage / 1000.0;
-		strcpy(voltage_units, "V");
+		voltage_units = "V";
 	}
 
-	if (strcmp(rate_units, "mW") == 0) {
+	if (rate_units == "mW") {
 		_rate = _rate / 1000.0;
-		strcpy(rate_units, "W");
+		rate_units = "W";
 	}
 
-	if (strcmp(rate_units, "mA") == 0) {
+	if (rate_units == "mA") {
 		_rate = _rate / 1000.0;
-		strcpy(rate_units, "A");
+		rate_units = "A";
 	}
 
-	if (strcmp(capacity_units, "mAh") == 0) {
+	if (capacity_units == "mAh") {
 		_capacity = _capacity / 1000.0;
-		strcpy(capacity_units, "Ah");
+		capacity_units = "Ah";
 	}
-	if (strcmp(capacity_units, "mWh") == 0) {
+	if (capacity_units == "mWh") {
 		_capacity = _capacity / 1000.0;
-		strcpy(capacity_units, "Wh");
+		capacity_units = "Wh";
 	}
-	if (strcmp(capacity_units, "Wh") == 0) {
+	if (capacity_units == "Wh") {
 		_capacity = _capacity * 3600.0;
-		strcpy(capacity_units, "J");
+		capacity_units = "J";
 	}
 
 
-	if (strcmp(capacity_units, "Ah") == 0 && strcmp(voltage_units, "V") == 0) {
+	if (capacity_units == "Ah" && voltage_units == "V") {
 		_capacity = _capacity * 3600.0 * _voltage;
-		strcpy(capacity_units, "J");
+		capacity_units = "J";
 	}
 
-	if (strcmp(rate_units, "A") == 0 && strcmp(voltage_units, "V")==0 ) {
+	if (rate_units == "A" && voltage_units == "V") {
 		_rate = _rate * _voltage;
-		strcpy(rate_units, "W");
+		rate_units = "W";
 	}
 
 
 
 
-	if (strcmp(capacity_units, "J") == 0)
+	if (capacity_units == "J")
 		capacity = _capacity;
 	else
 		capacity = 0.0;
 
-	if (strcmp(rate_units, "W")==0)
+	if (rate_units == "W")
 		rate = _rate;
 	else
 		rate = 0.0;
 
-	if (strcmp(voltage_units, "V")==0)
+	if (voltage_units == "V")
 		voltage = _voltage;
 	else
 		voltage = 0.0;

--- a/src/measurement/acpi.h
+++ b/src/measurement/acpi.h
@@ -33,7 +33,7 @@ class acpi_power_meter: public power_meter {
 	double voltage;
 	void measure(void);
 public:
-	acpi_power_meter(const char *_battery_name);
+	acpi_power_meter(const std::string &_battery_name);
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);
 

--- a/src/measurement/acpi.h
+++ b/src/measurement/acpi.h
@@ -28,8 +28,6 @@
 #include "measurement.h"
 
 class acpi_power_meter: public power_meter {
-	char battery_name[256];
-
 	double capacity;
 	double rate;
 	double voltage;

--- a/src/measurement/extech.cpp
+++ b/src/measurement/extech.cpp
@@ -266,13 +266,12 @@ static double extech_read(int fd)
 	return -1000.0;
 }
 
-extech_power_meter::extech_power_meter(const char *extech_name)
+extech_power_meter::extech_power_meter(const char *extech_name) : power_meter(extech_name)
 {
 	rate = 0.0;
-	pt_strcpy(dev_name, extech_name);
 	int ret;
 
-	fd = open_device(dev_name);
+	fd = open_device(name.c_str());
 	if (fd < 0)
 		return;
 

--- a/src/measurement/extech.cpp
+++ b/src/measurement/extech.cpp
@@ -266,7 +266,7 @@ static double extech_read(int fd)
 	return -1000.0;
 }
 
-extech_power_meter::extech_power_meter(const char *extech_name) : power_meter(extech_name)
+extech_power_meter::extech_power_meter(const string &extech_name) : power_meter(extech_name)
 {
 	rate = 0.0;
 	int ret;

--- a/src/measurement/extech.h
+++ b/src/measurement/extech.h
@@ -29,7 +29,6 @@
 #include "measurement.h"
 
 class extech_power_meter: public power_meter {
-	char dev_name[256];
 	int fd;
 
 	double rate;

--- a/src/measurement/extech.h
+++ b/src/measurement/extech.h
@@ -38,7 +38,7 @@ class extech_power_meter: public power_meter {
 	int end_thread;
 	pthread_t thread;
 public:
-	extech_power_meter(const char *_dev_name);
+	extech_power_meter(const std::string &_dev_name);
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);
 	virtual void sample(void);

--- a/src/measurement/measurement.cpp
+++ b/src/measurement/measurement.cpp
@@ -135,7 +135,7 @@ double global_time_left(void)
 
 void sysfs_power_meters_callback(const char *d_name)
 {
-	std::string type = read_sysfs_string("/sys/class/power_supply/%s/type", d_name);
+	std::string type = read_sysfs_string(std::format("/sys/class/power_supply/{}/type", d_name));
 
 	if (type != "Battery" && type != "UPS")
 		return;

--- a/src/measurement/measurement.h
+++ b/src/measurement/measurement.h
@@ -26,12 +26,16 @@
 #define __INCLUDE_GUARD_MEASUREMENT_H
 
 #include <vector>
+#include <string>
 
 using namespace std;
 
 class power_meter {
 	bool discharging = false;
 public:
+	std::string name;
+	power_meter(const std::string &n) : name(n) {}
+	power_meter() : name("") {}
 	virtual ~power_meter() {};
 
 	virtual void start_measurement(void);

--- a/src/measurement/opal-sensors.cpp
+++ b/src/measurement/opal-sensors.cpp
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <limits.h>
 
-opal_sensors_power_meter::opal_sensors_power_meter(const char *power_supply_name) : power_meter(power_supply_name)
+opal_sensors_power_meter::opal_sensors_power_meter(const string &power_supply_name) : power_meter(power_supply_name)
 {
 }
 

--- a/src/measurement/opal-sensors.cpp
+++ b/src/measurement/opal-sensors.cpp
@@ -29,9 +29,8 @@
 #include <stdio.h>
 #include <limits.h>
 
-opal_sensors_power_meter::opal_sensors_power_meter(const char *power_supply_name)
+opal_sensors_power_meter::opal_sensors_power_meter(const char *power_supply_name) : power_meter(power_supply_name)
 {
-	strncpy(name, power_supply_name, sizeof(name));
 }
 
 double opal_sensors_power_meter::power(void)
@@ -40,7 +39,7 @@ double opal_sensors_power_meter::power(void)
 	int value;
 	double r = 0;
 
-	value = read_sysfs(name, &ok);
+	value = read_sysfs(name.c_str(), &ok);
 
 	if(ok)
 		r = value / 1000000.0;

--- a/src/measurement/opal-sensors.h
+++ b/src/measurement/opal-sensors.h
@@ -29,7 +29,6 @@
 #include <limits.h>
 
 class opal_sensors_power_meter: public power_meter {
-	char name[PATH_MAX];
 public:
 	opal_sensors_power_meter(const char *power_supply_name);
 	virtual void start_measurement(void) {};

--- a/src/measurement/opal-sensors.h
+++ b/src/measurement/opal-sensors.h
@@ -30,7 +30,7 @@
 
 class opal_sensors_power_meter: public power_meter {
 public:
-	opal_sensors_power_meter(const char *power_supply_name);
+	opal_sensors_power_meter(const std::string &power_supply_name);
 	virtual void start_measurement(void) {};
 	virtual void end_measurement(void) {};
 

--- a/src/measurement/sysfs.cpp
+++ b/src/measurement/sysfs.cpp
@@ -29,13 +29,13 @@
 #include <stdio.h>
 #include <limits.h>
 
-sysfs_power_meter::sysfs_power_meter(const char *power_supply_name) : power_meter(power_supply_name)
+sysfs_power_meter::sysfs_power_meter(const string &power_supply_name) : power_meter(power_supply_name)
 {
 	rate = 0.0;
 	capacity = 0.0;
 }
 
-bool sysfs_power_meter::get_sysfs_attr(const char *attribute, int *value)
+bool sysfs_power_meter::get_sysfs_attr(const string &attribute, int *value)
 {
 	std::string filename;
 	bool ok;

--- a/src/measurement/sysfs.cpp
+++ b/src/measurement/sysfs.cpp
@@ -29,11 +29,10 @@
 #include <stdio.h>
 #include <limits.h>
 
-sysfs_power_meter::sysfs_power_meter(const char *power_supply_name)
+sysfs_power_meter::sysfs_power_meter(const char *power_supply_name) : power_meter(power_supply_name)
 {
 	rate = 0.0;
 	capacity = 0.0;
-	pt_strcpy(name, power_supply_name);
 }
 
 bool sysfs_power_meter::get_sysfs_attr(const char *attribute, int *value)
@@ -41,7 +40,7 @@ bool sysfs_power_meter::get_sysfs_attr(const char *attribute, int *value)
 	char filename[PATH_MAX];
 	bool ok;
 
-	snprintf(filename, sizeof(filename), "/sys/class/power_supply/%s/%s", name, attribute);
+	snprintf(filename, sizeof(filename), "/sys/class/power_supply/%s/%s", name.c_str(), attribute);
 	*value = read_sysfs(filename, &ok);
 
 	return ok;
@@ -136,7 +135,7 @@ void sysfs_power_meter::measure()
 	if (!is_present())
 		return;
 	/** do not jump over. we may have discharging battery */
-	if (read_sysfs_string("/sys/class/power_supply/%s/status", name) == "Discharging")
+	if (read_sysfs_string("/sys/class/power_supply/%s/status", name.c_str()) == "Discharging")
 		this->set_discharging(true);
 
 	got_rate = set_rate_from_power();

--- a/src/measurement/sysfs.cpp
+++ b/src/measurement/sysfs.cpp
@@ -37,10 +37,10 @@ sysfs_power_meter::sysfs_power_meter(const char *power_supply_name) : power_mete
 
 bool sysfs_power_meter::get_sysfs_attr(const char *attribute, int *value)
 {
-	char filename[PATH_MAX];
+	std::string filename;
 	bool ok;
 
-	snprintf(filename, sizeof(filename), "/sys/class/power_supply/%s/%s", name.c_str(), attribute);
+	filename = std::format("/sys/class/power_supply/{}/{}", name, attribute);
 	*value = read_sysfs(filename, &ok);
 
 	return ok;

--- a/src/measurement/sysfs.cpp
+++ b/src/measurement/sysfs.cpp
@@ -135,7 +135,7 @@ void sysfs_power_meter::measure()
 	if (!is_present())
 		return;
 	/** do not jump over. we may have discharging battery */
-	if (read_sysfs_string("/sys/class/power_supply/%s/status", name.c_str()) == "Discharging")
+	if (read_sysfs_string(std::format("/sys/class/power_supply/{}/status", name)) == "Discharging")
 		this->set_discharging(true);
 
 	got_rate = set_rate_from_power();

--- a/src/measurement/sysfs.h
+++ b/src/measurement/sysfs.h
@@ -28,8 +28,6 @@
 #include "measurement.h"
 
 class sysfs_power_meter: public power_meter {
-	char name[256];
-
 	double capacity;
 	double rate;
 

--- a/src/measurement/sysfs.h
+++ b/src/measurement/sysfs.h
@@ -31,7 +31,7 @@ class sysfs_power_meter: public power_meter {
 	double capacity;
 	double rate;
 
-	bool get_sysfs_attr(const char *attribute, int *value);
+	bool get_sysfs_attr(const std::string &attribute, int *value);
 	bool is_present();
 	double get_voltage();
 
@@ -42,7 +42,7 @@ class sysfs_power_meter: public power_meter {
 
 	void measure();
 public:
-	sysfs_power_meter(const char *power_supply_name);
+	sysfs_power_meter(const std::string &power_supply_name);
 	virtual void start_measurement(void);
 	virtual void end_measurement(void);
 

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -487,14 +487,14 @@ int global_power_valid(void)
 }
 
 /* find the directory to store powertop results/parameters based on distribution*/
-char* get_param_directory(const char *filename)
+std::string get_param_directory(const char *filename)
 {
-	static char tempfilename[PATH_MAX];
+	std::string tempfilename;
 
 	if (access("/var/cache/powertop", W_OK ) == 0)
-		snprintf(tempfilename, sizeof(tempfilename), "/var/cache/powertop/%s", filename);
+		tempfilename = std::format("/var/cache/powertop/{}", filename);
 	if (access("/data/local/powertop", W_OK ) == 0)
-		snprintf(tempfilename, sizeof(tempfilename), "/data/local/powertop/%s", filename);
+		tempfilename = std::format("/data/local/powertop/{}", filename);
 
 	return tempfilename;
-};
+}

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -43,7 +43,7 @@ static int maxindex = 1;
 map <string, int> result_index;
 static int maxresindex = 1;
 
-int get_param_index(const char *name)
+int get_param_index(const std::string &name)
 {
 	std::map<string, int>::iterator it;
 	int index = 0;
@@ -55,12 +55,15 @@ int get_param_index(const char *name)
 	} else
 		index = it->second;
 
-	if (index == 0)
-		printf("OH BLA\n");
 	return index;
 }
 
-int get_result_index(const char *name)
+int get_param_index(const char *name)
+{
+	return get_param_index(std::string(name));
+}
+
+int get_result_index(const std::string &name)
 {
 	std::map<string, int>::iterator it;
 	int index = 0;
@@ -75,8 +78,13 @@ int get_result_index(const char *name)
 	return index;
 }
 
+int get_result_index(const char *name)
+{
+	return get_result_index(std::string(name));
+}
 
-void register_parameter(const char *name, double default_value, double weight)
+
+void register_parameter(const std::string &name, double default_value, double weight)
 {
 	int index;
 
@@ -93,7 +101,12 @@ void register_parameter(const char *name, double default_value, double weight)
 	all_parameters.weights[index] = weight;
 }
 
-void set_parameter_value(const char *name, double value, struct parameter_bundle *bundle)
+void register_parameter(const char *name, double default_value, double weight)
+{
+	register_parameter(std::string(name), default_value, weight);
+}
+
+void set_parameter_value(const std::string &name, double value, struct parameter_bundle *bundle)
 {
 	int index;
 
@@ -107,11 +120,21 @@ void set_parameter_value(const char *name, double value, struct parameter_bundle
 	bundle->parameters[index] = value;
 }
 
-double get_parameter_value(const char *name, struct parameter_bundle *the_bundle)
+void set_parameter_value(const char *name, double value, struct parameter_bundle *bundle)
+{
+	set_parameter_value(std::string(name), value, bundle);
+}
+
+double get_parameter_value(const std::string &name, struct parameter_bundle *the_bundle)
 {
 	unsigned int index;
 	index = get_param_index(name);
 	return get_parameter_value(index, the_bundle);
+}
+
+double get_parameter_value(const char *name, struct parameter_bundle *the_bundle)
+{
+	return get_parameter_value(std::string(name), the_bundle);
 }
 
 double get_parameter_value(unsigned int index, struct parameter_bundle *the_bundle)
@@ -128,17 +151,27 @@ double get_parameter_weight(int index, struct parameter_bundle *the_bundle)
 	return the_bundle->weights[index];
 }
 
-double get_result_value(const char *name, struct result_bundle *the_bundle)
+double get_result_value(const std::string &name, struct result_bundle *the_bundle)
 {
 	return get_result_value(get_result_index(name), the_bundle);
 }
 
-void set_result_value(const char *name, double value, struct result_bundle *the_bundle)
+double get_result_value(const char *name, struct result_bundle *the_bundle)
+{
+	return get_result_value(std::string(name), the_bundle);
+}
+
+void set_result_value(const std::string &name, double value, struct result_bundle *the_bundle)
 {
 	unsigned int index = get_result_index(name);
 	if (index >= the_bundle->utilization.size())
 		the_bundle->utilization.resize(index+1);
 	the_bundle->utilization[index] = value;
+}
+
+void set_result_value(const char *name, double value, struct result_bundle *the_bundle)
+{
+	set_result_value(std::string(name), value, the_bundle);
 }
 
 void set_result_value(unsigned int index, double value, struct result_bundle *the_bundle)
@@ -168,9 +201,14 @@ int result_device_exists(const char *name)
 	return 0;
 }
 
-void report_utilization(const char *name, double value, struct result_bundle *bundle)
+void report_utilization(const std::string &name, double value, struct result_bundle *bundle)
 {
 	set_result_value(name, value, bundle);
+}
+
+void report_utilization(const char *name, double value, struct result_bundle *bundle)
+{
+	report_utilization(std::string(name), value, bundle);
 }
 void report_utilization(int index, double value, struct result_bundle *bundle)
 {

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -195,7 +195,7 @@ int result_device_exists(const char *name)
 {
 	unsigned int i;
 	for (i = 0; i < all_devices.size(); i++) {
-		if (strcmp(all_devices[i]->device_name(), name) == 0)
+		if (all_devices[i]->device_name() == name)
 			return 1;
 	}
 	return 0;

--- a/src/parameters/parameters.h
+++ b/src/parameters/parameters.h
@@ -55,13 +55,18 @@ extern map <string, int> param_index;
 extern map <string, int> result_index;
 
 extern int get_param_index(const char *param);
+extern int get_param_index(const std::string &param);
 extern int get_result_index(const char *param);
+extern int get_result_index(const std::string &param);
 
 
 extern void register_parameter(const char *name, double default_value = 0.00, double weight = 1.0);
+extern void register_parameter(const std::string &name, double default_value = 0.00, double weight = 1.0);
 extern double get_parameter_value(const char *name, struct parameter_bundle *bundle = &all_parameters);
+extern double get_parameter_value(const std::string &name, struct parameter_bundle *bundle = &all_parameters);
 extern double get_parameter_value(unsigned int index, struct parameter_bundle *bundle = &all_parameters);
 extern void set_parameter_value(const char *name, double value, struct parameter_bundle *bundle = &all_parameters);
+extern void set_parameter_value(const std::string &name, double value, struct parameter_bundle *bundle = &all_parameters);
 
 
 struct result_bundle
@@ -75,14 +80,17 @@ extern struct result_bundle all_results;
 extern vector <struct result_bundle *> past_results;
 
 extern double get_result_value(const char *name, struct result_bundle *bundle = &all_results);
+extern double get_result_value(const std::string &name, struct result_bundle *bundle = &all_results);
 extern double get_result_value(int index, struct result_bundle *bundle = &all_results);
 
 extern void set_result_value(const char *name, double value, struct result_bundle *bundle = &all_results);
+extern void set_result_value(const std::string &name, double value, struct result_bundle *bundle = &all_results);
 
 
 extern int result_device_exists(const char *name);
 
 extern void report_utilization(const char *name, double value, struct result_bundle *bundle = &all_results);
+extern void report_utilization(const std::string &name, double value, struct result_bundle *bundle = &all_results);
 extern void report_utilization(int index, double value, struct result_bundle *bundle = &all_results);
 
 

--- a/src/parameters/parameters.h
+++ b/src/parameters/parameters.h
@@ -107,7 +107,7 @@ extern struct parameter_bundle * clone_parameters(struct parameter_bundle *bundl
 
 extern void store_results(double duration);
 extern void learn_parameters(int iterations, int do_base_power);
-extern char *get_param_directory(const char *filename);
+extern std::string get_param_directory(const char *filename);
 extern void save_all_results(const char *filename = "saved_results.powertop");
 extern void close_results(void);
 extern void load_results(const char *filename);

--- a/src/parameters/persistent.cpp
+++ b/src/parameters/persistent.cpp
@@ -37,11 +37,11 @@ void save_all_results(const char *filename)
 	ofstream file;
 	unsigned int i;
 	struct result_bundle *bundle;
-	char* pathname;
+	std::string pathname;
 
 	pathname = get_param_directory(filename);
 
-	file.open(pathname, ios::out);
+	file.open(pathname.c_str(), ios::out);
 	if (!file) {
 		cout << _("Cannot save to file") << " " << pathname << "\n";
 		return;
@@ -79,12 +79,12 @@ void load_results(const char *filename)
 	struct result_bundle *bundle;
 	int first = 1;
 	unsigned int count = 0;
-	char* pathname;
+	std::string pathname;
 	int bundle_saved = 0;
 
 	pathname = get_param_directory(filename);
 
-	file.open(pathname, ios::in);
+	file.open(pathname.c_str(), ios::in);
 	if (!file) {
 		cout << _("Cannot load from file") << " " << pathname << "\n";
 		return;
@@ -141,7 +141,7 @@ void load_results(const char *filename)
 void save_parameters(const char *filename)
 {
 	ofstream file;
-	char* pathname;
+	std::string pathname;
 
 //	printf("result size is %i, #parameters is %i \n", (int)past_results.size(), (int)all_parameters.parameters.size());
 
@@ -150,7 +150,7 @@ void save_parameters(const char *filename)
 
 	pathname = get_param_directory(filename);
 
-	file.open(pathname, ios::out);
+	file.open(pathname.c_str(), ios::out);
 	if (!file) {
 		cout << _("Cannot save to file") << " " << pathname << "\n";
 		return;
@@ -171,11 +171,11 @@ void load_parameters(const char *filename)
 	ifstream file;
 	char line[4096];
 	char *c1;
-	char* pathname;
+	std::string pathname;
 
 	pathname = get_param_directory(filename);
 
-	file.open(pathname, ios::in);
+	file.open(pathname.c_str(), ios::in);
 	if (!file) {
 		cout << _("Cannot load from file") << " " << pathname << "\n";
 		cout << _("File will be loaded after taking minimum number of measurement(s) with battery only \n");

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -55,7 +55,7 @@ static inline int sys_perf_event_open(struct perf_event_attr *attr,
 			group_fd, flags);
 }
 
-void perf_event::create_perf_event(char *eventname, int _cpu)
+void perf_event::create_perf_event(const string &eventname, int _cpu)
 {
 	struct perf_event_attr attr;
 	int ret;
@@ -133,41 +133,39 @@ void perf_event::create_perf_event(char *eventname, int _cpu)
 
 }
 
-static int parse_event_format(const char *system_name, const char *event_name)
+static int parse_event_format(const string &system_name, const string &event_name)
 {
 	char *buf;
 	int size;
 
-	buf = tracefs_event_file_read(NULL, system_name, event_name, "format", &size);
+	buf = tracefs_event_file_read(NULL, system_name.c_str(), event_name.c_str(), "format", &size);
 	if (!buf)
 		return -1;
 
-	tep_parse_event(perf_event::tep, buf, size, system_name);
+	tep_parse_event(perf_event::tep, buf, size, system_name.c_str());
 	free(buf);
 	return 0;
 }
 
-void perf_event::set_event_name(const char *system_name, const char *event_name)
+void perf_event::set_event_name(const string &system_name, const string &event_name)
 {
 	struct tep_event *event;
 	int ret;
 
-	event = tep_find_event_by_name(perf_event::tep, system_name, event_name);
+	event = tep_find_event_by_name(perf_event::tep, system_name.c_str(), event_name.c_str());
 	if (!event) {
 		ret = parse_event_format(system_name, event_name);
 		if (ret < 0) {
 			trace_type = -1;
 			return;
 		}
-		event = tep_find_event_by_name(perf_event::tep, system_name, event_name);
+		event = tep_find_event_by_name(perf_event::tep, system_name.c_str(), event_name.c_str());
 	}
 	trace_type = event->id;
 }
 
 perf_event::~perf_event(void)
 {
-	free(name);
-
 	if (tep_get_ref(perf_event::tep) == 1) {
 		tep_free(perf_event::tep);
 		perf_event::tep = NULL;
@@ -189,10 +187,9 @@ static void allocate_tep(void)
 		tep_ref(perf_event::tep);
 }
 
-perf_event::perf_event(const char *system_name, const char *event_name, int _cpu, int buffer_size)
+perf_event::perf_event(const string &system_name, const string &event_name, int _cpu, int buffer_size)
 {
 	allocate_tep();
-	name = NULL;
 	perf_fd = -1;
 	bufsize = buffer_size;
 	cpu = _cpu;
@@ -204,7 +201,6 @@ perf_event::perf_event(const char *system_name, const char *event_name, int _cpu
 perf_event::perf_event(void)
 {
 	allocate_tep();
-	name = NULL;
 	perf_fd = -1;
 	bufsize = 128;
 	perf_mmap = NULL;

--- a/src/perf/perf.h
+++ b/src/perf/perf.h
@@ -45,20 +45,20 @@ protected:
 
 
 	int bufsize;
-	char *name;
+	std::string name;
 	int cpu;
-	void create_perf_event(char *eventname, int cpu);
+	void create_perf_event(const std::string &eventname, int cpu);
 
 public:
 	unsigned int trace_type;
 
 	perf_event(void);
-	perf_event(const char *system_name, const char *event_name, int cpu = 0, int buffer_size = 128);
+	perf_event(const std::string &system_name, const std::string &event_name, int cpu = 0, int buffer_size = 128);
 
 	virtual ~perf_event(void);
 
 
-	void set_event_name(const char *system_name, const char *event_name);
+	void set_event_name(const std::string &system_name, const std::string &event_name);
 	void set_cpu(int cpu);
 
 	void start(void);

--- a/src/perf/perf_bundle.cpp
+++ b/src/perf/perf_bundle.cpp
@@ -92,7 +92,7 @@ void perf_bundle::release(void)
 	records.clear();
 }
 
-bool perf_bundle::add_event(const char *system_name, const char *event_name)
+bool perf_bundle::add_event(const string &system_name, const string &event_name)
 {
 	unsigned int i;
 	int event_added = false;

--- a/src/perf/perf_bundle.h
+++ b/src/perf/perf_bundle.h
@@ -43,7 +43,7 @@ public:
 	virtual ~perf_bundle() {};
 
 	virtual void release(void);
-	bool add_event(const char *system_name, const char *event_name);
+	bool add_event(const std::string &system_name, const std::string &event_name);
 
 	void start(void);
 	void stop(void);

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -172,17 +172,17 @@ class perf_process_bundle: public perf_bundle
 	virtual void handle_trace_point(void *trace, int cpu, uint64_t time);
 };
 
-static bool comm_is_xorg(char *comm)
+static bool comm_is_xorg(const std::string &comm)
 {
-	return strcmp(comm, "Xorg") == 0 || strcmp(comm, "X") == 0;
+	return comm == "Xorg" || comm == "X";
 }
 
 /* some processes shouldn't be blamed for the wakeup if they wake a process up... for now this is a hardcoded list */
-int dont_blame_me(char *comm)
+int dont_blame_me(const std::string &comm)
 {
 	if (comm_is_xorg(comm))
 		return 1;
-	if (strcmp(comm, "dbus-daemon") == 0)
+	if (comm == "dbus-daemon")
 		return 1;
 
 	return 0;
@@ -310,9 +310,9 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 			class timer *timer;
 			timer = (class timer *) current_consumer(cpu);
 			if (timer && strcmp(timer->name(), "timer")==0) {
-				if (strcmp(timer->handler, "delayed_work_timer_fn") &&
-				    strcmp(timer->handler, "hrtimer_wakeup") &&
-				    strcmp(timer->handler, "it_real_fn"))
+				if (timer->handler != "delayed_work_timer_fn" &&
+				    timer->handler != "hrtimer_wakeup" &&
+				    timer->handler != "it_real_fn")
 					from = timer;
 			}
 			/* woken from interrupt */
@@ -377,7 +377,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		irq->start_interrupt(time);
 
-		if (strstr(irq->handler, "timer") ==NULL)
+		if (irq->handler.find("timer") == string::npos)
 			change_blame(cpu, irq, LEVEL_HARDIRQ);
 
 	}
@@ -460,7 +460,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		push_consumer(cpu, timer);
 		timer->fire(time, tmr);
 
-		if (strcmp(timer->handler, "delayed_work_timer_fn"))
+		if (timer->handler != "delayed_work_timer_fn")
 			change_blame(cpu, timer, LEVEL_TIMER);
 	}
 	else if (strcmp(event->name, "timer_expire_exit") == 0) {
@@ -505,7 +505,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		push_consumer(cpu, timer);
 		timer->fire(time, tmr);
 
-		if (strcmp(timer->handler, "delayed_work_timer_fn"))
+		if (timer->handler != "delayed_work_timer_fn")
 			change_blame(cpu, timer, LEVEL_TIMER);
 	}
 	else if (strcmp(event->name, "hrtimer_expire_exit") == 0) {
@@ -553,7 +553,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		work->fire(time, wk);
 
 
-		if (strcmp(work->handler, "do_dbs_timer") != 0 && strcmp(work->handler, "vmstat_update") != 0)
+		if (work->handler != "do_dbs_timer" && work->handler != "vmstat_update")
 			change_blame(cpu, work, LEVEL_WORK);
 	}
 	else if (strcmp(event->name, "workqueue_execute_end") == 0) {

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -261,7 +261,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		if (consumer_depth(cpu) == 1)
 			old_proc = (class process *)current_consumer(cpu);
 
-		if (old_proc && strcmp(old_proc->name(), "process"))
+		if (old_proc && old_proc->name() != "process")
 			old_proc = NULL;
 
 		/* retire the old process */
@@ -309,7 +309,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		if ( (flags & TRACE_FLAG_HARDIRQ) || (flags & TRACE_FLAG_SOFTIRQ)) {
 			class timer *timer;
 			timer = (class timer *) current_consumer(cpu);
-			if (timer && strcmp(timer->name(), "timer")==0) {
+			if (timer && timer->name() == "timer") {
 				if (timer->handler != "delayed_work_timer_fn" &&
 				    timer->handler != "hrtimer_wakeup" &&
 				    timer->handler != "it_real_fn")
@@ -336,7 +336,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		dest_proc = find_create_process(comm, pid);
 
-		if (from && strcmp(from->name(), "process")!=0){
+		if (from && from->name() != "process"){
 			/* not a process doing the wakeup */
 			from = NULL;
 			from_proc = NULL;
@@ -388,7 +388,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		/* find interrupt (top of stack) */
 		irq = (class interrupt *)current_consumer(cpu);
-		if (!irq || strcmp(irq->name(), "interrupt"))
+		if (!irq || irq->name() != "interrupt")
 			return;
 		pop_consumer(cpu);
 		/* retire interrupt */
@@ -426,7 +426,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		uint64_t t;
 
 		irq = (class interrupt *) current_consumer(cpu);
-		if (!irq  || strcmp(irq->name(), "interrupt"))
+		if (!irq  || irq->name() != "interrupt")
 			return;
 		pop_consumer(cpu);
 		/* pop irq */
@@ -474,7 +474,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		tmr = (uint64_t)val;
 
 		timer = (class timer *) current_consumer(cpu);
-		if (!timer || strcmp(timer->name(), "timer")) {
+		if (!timer || timer->name() != "timer") {
 			return;
 		}
 		pop_consumer(cpu);
@@ -514,7 +514,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		uint64_t t;
 
 		timer = (class timer *) current_consumer(cpu);
-		if (!timer || strcmp(timer->name(), "timer")) {
+		if (!timer || timer->name() != "timer") {
 			return;
 		}
 
@@ -567,7 +567,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		wk = (uint64_t)val;
 
 		work = (class work *) current_consumer(cpu);
-		if (!work || strcmp(work->name(), "work")) {
+		if (!work || work->name() != "work") {
 			return;
 		}
 		pop_consumer(cpu);
@@ -611,7 +611,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 
 		/* if we are X, and someone just woke us, account the GPU op to the guy waking us */
-		if (consumer && strcmp(consumer->name(), "process")==0) {
+		if (consumer && consumer->name() == "process") {
 			class process *proc = NULL;
 			proc = (class process *) consumer;
 			if (comm_is_xorg(proc->comm) && proc->last_waker) {
@@ -638,8 +638,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 			return;
 		dev = (int)val;
 
-		if (consumer && strcmp(consumer->name(),
-			"process")==0 && dev > 0) {
+		if (consumer && consumer->name() == "process" && dev > 0) {
 
 			consumer->disk_hits++;
 
@@ -865,7 +864,7 @@ void process_update_display(void)
 		if (all_power[i]->events() == 0 && all_power[i]->usage() == 0 && all_power[i]->Witts() == 0)
 			break;
 
-		if (all_power[i]->usage_units()) {
+		if (!all_power[i]->usage_units().empty()) {
 			if (all_power[i]->usage() < 1000)
 				usage = std::format("{:5.1f}{}", all_power[i]->usage(), all_power[i]->usage_units());
 			else
@@ -950,7 +949,7 @@ void report_process_update_display(void)
 				&& all_power[i]->Witts() == 0)
 			break;
 
-		if (all_power[i]->usage_units()) {
+		if (!all_power[i]->usage_units().empty()) {
 			if (all_power[i]->usage() < 1000)
 				usage = std::format("{:5.1f}{}", all_power[i]->usage(), all_power[i]->usage_units());
 			else
@@ -1095,7 +1094,7 @@ void report_summary(void)
 				all_power[i]->Witts() == 0)
 			break;
 
-		if (all_power[i]->usage_units()) {
+		if (!all_power[i]->usage_units().empty()) {
 			if (all_power[i]->usage() < 1000)
 				usage = std::format("{:5.1f}{}", all_power[i]->usage_summary(),
 					all_power[i]->usage_units_summary());

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -827,11 +827,10 @@ void process_update_display(void)
 	tlr = tl % 60;
 
 	if (pw > 0.0001) {
-		char buf[32];
 		wprintw(win, _("The battery reports a discharge rate of %sW\n"),
-				fmt_prefix(pw, buf));
+				fmt_prefix(pw).c_str());
 		wprintw(win, _("The energy consumed was %sJ\n"),
-				fmt_prefix(joules, buf));
+				fmt_prefix(joules).c_str());
 		need_linebreak = 1;
 	}
 	if (tl > 0 && pw > 0.0001) {
@@ -857,10 +856,7 @@ void process_update_display(void)
 		std::string usage;
 		std::string events;
 		char descr[128];
-		char p_buf[16];
-
-		format_watts(all_power[i]->Witts(), p_buf, 10);
-		power = p_buf;
+		power = format_watts(all_power[i]->Witts(), 10);
 
 		if (!show_power)
 			power = "          ";
@@ -941,10 +937,7 @@ void report_process_update_display(void)
 	for (i = 0; i < total; i++) {
 		std::string power, name, usage, wakes, gpus, disks, xwakes;
 		char descr[128];
-		char p_buf[16];
-
-		format_watts(all_power[i]->Witts(), p_buf, 10);
-		power = p_buf;
+		power = format_watts(all_power[i]->Witts(), 10);
 
 		if (!show_power)
 			power = "          ";
@@ -1089,10 +1082,7 @@ void report_summary(void)
 	for (i = 0; i < all_power.size(); i++) {
 		std::string power, name, usage, events;
 		char descr[128];
-		char p_buf[16];
-
-		format_watts(all_power[i]->Witts(), p_buf, 10);
-		power = p_buf;
+		power = format_watts(all_power[i]->Witts(), 10);
 
 		if (!show_power)
 			power = "          ";

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -878,7 +878,11 @@ void process_update_display(void)
 		else if (all_power[i]->events() <= 0.3)
 			events = std::format("{:5.2f}", all_power[i]->events());
 
-		wprintw(win, "%s  %-14s %-12s %-14s %s\n", 
+		align_string(name, 14, 20);
+		align_string(usage, 14, 20);
+		align_string(events, 12, 20);
+
+		wprintw(win, "%s  %s %s %s %s\n", 
 			power.c_str(), 
 			usage.c_str(), 
 			events.c_str(), 

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -852,40 +852,43 @@ void process_update_display(void)
 		wprintw(win, "                %s       %s    %s       %s\n", _("Usage"), _("Events/s"), _("Category"), _("Description"));
 
 	for (i = 0; i < all_power.size(); i++) {
-		char power[16];
-		char name[20];
-		char usage[20];
-		char events[20];
+		std::string power;
+		std::string name;
+		std::string usage;
+		std::string events;
 		char descr[128];
+		char p_buf[16];
 
-		format_watts(all_power[i]->Witts(), power, 10);
+		format_watts(all_power[i]->Witts(), p_buf, 10);
+		power = p_buf;
+
 		if (!show_power)
-			strcpy(power, "          ");
-		snprintf(name, sizeof(name), "%s", all_power[i]->type());
-
-		align_string(name, 14, 20);
+			power = "          ";
+		name = all_power[i]->type();
 
 		if (all_power[i]->events() == 0 && all_power[i]->usage() == 0 && all_power[i]->Witts() == 0)
 			break;
 
-		usage[0] = 0;
 		if (all_power[i]->usage_units()) {
 			if (all_power[i]->usage() < 1000)
-				snprintf(usage, sizeof(usage), "%5.1f%s", all_power[i]->usage(), all_power[i]->usage_units());
+				usage = std::format("{:5.1f}{}", all_power[i]->usage(), all_power[i]->usage_units());
 			else
-				snprintf(usage, sizeof(usage), "%5i%s", (int)all_power[i]->usage(), all_power[i]->usage_units());
+				usage = std::format("{:5d}{}", (int)all_power[i]->usage(), all_power[i]->usage_units());
 		}
 
-		align_string(usage, 14, 20);
 
-		snprintf(events, sizeof(events), "%5.1f", all_power[i]->events());
+		events = std::format("{:5.1f}", all_power[i]->events());
 		if (!all_power[i]->show_events())
-			events[0] = 0;
+			events = "";
 		else if (all_power[i]->events() <= 0.3)
-			snprintf(events, sizeof(events), "%5.2f", all_power[i]->events());
+			events = std::format("{:5.2f}", all_power[i]->events());
 
-		align_string(events, 12, 20);
-		wprintw(win, "%s  %s %s %s %s\n", power, usage, events, name, pretty_print(all_power[i]->description(), descr, 128));
+		wprintw(win, "%s  %-14s %-12s %-14s %s\n", 
+			power.c_str(), 
+			usage.c_str(), 
+			events.c_str(), 
+			name.c_str(), 
+			pretty_print(all_power[i]->description(), descr, 128));
 	}
 }
 
@@ -936,78 +939,80 @@ void report_process_update_display(void)
 
 
 	for (i = 0; i < total; i++) {
-		char power[16];
-		char name[20];
-		char usage[20];
-		char wakes[20];
-		char gpus[20];
-		char disks[20];
-		char xwakes[20];
+		std::string power, name, usage, wakes, gpus, disks, xwakes;
 		char descr[128];
-		format_watts(all_power[i]->Witts(), power, 10);
+		char p_buf[16];
+
+		format_watts(all_power[i]->Witts(), p_buf, 10);
+		power = p_buf;
 
 		if (!show_power)
-			strcpy(power, "          ");
-		snprintf(name, sizeof(name), "%s", all_power[i]->type());
+			power = "          ";
+		name = all_power[i]->type();
 
-		if (strcmp(name, "Device") == 0)
+		if (name == "Device")
 			continue;
 
 		if (all_power[i]->events() == 0 && all_power[i]->usage() == 0
 				&& all_power[i]->Witts() == 0)
 			break;
 
-		usage[0] = 0;
 		if (all_power[i]->usage_units()) {
 			if (all_power[i]->usage() < 1000)
-				snprintf(usage, sizeof(usage), "%5.1f%s", all_power[i]->usage(), all_power[i]->usage_units());
+				usage = std::format("{:5.1f}{}", all_power[i]->usage(), all_power[i]->usage_units());
 			else
-				snprintf(usage, sizeof(usage), "%5i%s", (int)all_power[i]->usage(), all_power[i]->usage_units());
+				usage = std::format("{:5d}{}", (int)all_power[i]->usage(), all_power[i]->usage_units());
 		}
-		snprintf(wakes, sizeof(wakes), "%5.1f", all_power[i]->wake_ups / measurement_time);
+
+		wakes = std::format("{:5.1f}", all_power[i]->wake_ups / measurement_time);
 		if (all_power[i]->wake_ups / measurement_time <= 0.3)
-			snprintf(wakes, sizeof(wakes), "%5.2f", all_power[i]->wake_ups / measurement_time);
-		snprintf(gpus, sizeof(gpus), "%5.1f", all_power[i]->gpu_ops / measurement_time);
-		snprintf(disks, sizeof(disks), "%5.1f (%5.1f)", all_power[i]->hard_disk_hits / measurement_time,
+			wakes = std::format("{:5.2f}", all_power[i]->wake_ups / measurement_time);
+		
+		gpus = std::format("{:5.1f}", all_power[i]->gpu_ops / measurement_time);
+		
+		disks = std::format("{:5.1f} ({:5.1f})", 
+				all_power[i]->hard_disk_hits / measurement_time,
 				all_power[i]->disk_hits / measurement_time);
-		snprintf(xwakes, sizeof(xwakes), "%5.1f", all_power[i]->xwakes / measurement_time);
+		
+		xwakes = std::format("{:5.1f}", all_power[i]->xwakes / measurement_time);
+
 		if (!all_power[i]->show_events()) {
-			wakes[0] = 0;
-			gpus[0] = 0;
-			disks[0] = 0;
+			wakes = "";
+			gpus = "";
+			disks = "";
 		}
 
 		if (all_power[i]->gpu_ops == 0)
-			gpus[0] = 0;
+			gpus = "";
 		if (all_power[i]->wake_ups == 0)
-			wakes[0] = 0;
+			wakes = "";
 		if (all_power[i]->disk_hits == 0)
-			disks[0] = 0;
+			disks = "";
 		if (all_power[i]->xwakes == 0)
-			xwakes[0] = 0;
+			xwakes = "";
 
-		software_data[idx]=string(usage);
+		software_data[idx]=usage;
 		idx+=1;
 
-		software_data[idx]=string(wakes);
+		software_data[idx]=wakes;
 		idx+=1;
 
-		software_data[idx]=string(gpus);
+		software_data[idx]=gpus;
 		idx+=1;
 
-		software_data[idx]=string(disks);
+		software_data[idx]=disks;
 		idx+=1;
 
-		software_data[idx]=string(xwakes);
+		software_data[idx]=xwakes;
 		idx+=1;
 
-		software_data[idx]=string(name);
+		software_data[idx]=name;
 		idx+=1;
 
 		software_data[idx]=pretty_print(all_power[i]->description(), descr, 128);
 		idx+=1;
 		if (show_power) {
-			software_data[idx]=string(power);
+			software_data[idx]=power;
 			idx+=1;
 		}
 	}
@@ -1082,16 +1087,16 @@ void report_summary(void)
 		summary_data[4]=__("PW Estimate");
 
 	for (i = 0; i < all_power.size(); i++) {
-		char power[16];
-		char name[20];
-		char usage[20];
-		char events[20];
+		std::string power, name, usage, events;
 		char descr[128];
-		format_watts(all_power[i]->Witts(), power, 10);
+		char p_buf[16];
+
+		format_watts(all_power[i]->Witts(), p_buf, 10);
+		power = p_buf;
 
 		if (!show_power)
-			strcpy(power, "          ");
-		snprintf(name, sizeof(name), "%s", all_power[i]->type());
+			power = "          ";
+		name = all_power[i]->type();
 
 		if (i > total)
 			break;
@@ -1100,28 +1105,28 @@ void report_summary(void)
 				all_power[i]->Witts() == 0)
 			break;
 
-		usage[0] = 0;
 		if (all_power[i]->usage_units()) {
 			if (all_power[i]->usage() < 1000)
-				snprintf(usage, sizeof(usage), "%5.1f%s", all_power[i]->usage_summary(),
+				usage = std::format("{:5.1f}{}", all_power[i]->usage_summary(),
 					all_power[i]->usage_units_summary());
 			else
-				snprintf(usage, sizeof(usage), "%5i%s", (int)all_power[i]->usage_summary(),
+				usage = std::format("{:5d}{}", (int)all_power[i]->usage_summary(),
 					all_power[i]->usage_units_summary());
 		}
-		snprintf(events, sizeof(events), "%5.1f", all_power[i]->events());
+		
+		events = std::format("{:5.1f}", all_power[i]->events());
 		if (!all_power[i]->show_events())
-			events[0] = 0;
+			events = "";
 		else if (all_power[i]->events() <= 0.3)
-			snprintf(events, sizeof(events), "%5.2f", all_power[i]->events());
+			events = std::format("{:5.2f}", all_power[i]->events());
 
-		summary_data[idx]=string(usage);
+		summary_data[idx]=usage;
 		idx+=1;
 
-		summary_data[idx]=string(events);
+		summary_data[idx]=events;
 		idx+=1;
 
-		summary_data[idx]=string(name);
+		summary_data[idx]=name;
 		idx+=1;
 
 		summary_data[idx]=pretty_print(all_power[i]->description(), descr, 128);

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -885,7 +885,7 @@ void process_update_display(void)
 			snprintf(events, sizeof(events), "%5.2f", all_power[i]->events());
 
 		align_string(events, 12, 20);
-		wprintw(win, "%s  %s %s %s %s\n", power, usage, events, name, pretty_print(all_power[i]->description().c_str(), descr, 128));
+		wprintw(win, "%s  %s %s %s %s\n", power, usage, events, name, pretty_print(all_power[i]->description(), descr, 128));
 	}
 }
 
@@ -1004,7 +1004,7 @@ void report_process_update_display(void)
 		software_data[idx]=string(name);
 		idx+=1;
 
-		software_data[idx]=pretty_print(all_power[i]->description().c_str(), descr, 128);
+		software_data[idx]=pretty_print(all_power[i]->description(), descr, 128);
 		idx+=1;
 		if (show_power) {
 			software_data[idx]=string(power);
@@ -1124,7 +1124,7 @@ void report_summary(void)
 		summary_data[idx]=string(name);
 		idx+=1;
 
-		summary_data[idx]=pretty_print(all_power[i]->description().c_str(), descr, 128);
+		summary_data[idx]=pretty_print(all_power[i]->description(), descr, 128);
 		idx+=1;
 
 		if (show_power){

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -885,7 +885,7 @@ void process_update_display(void)
 			snprintf(events, sizeof(events), "%5.2f", all_power[i]->events());
 
 		align_string(events, 12, 20);
-		wprintw(win, "%s  %s %s %s %s\n", power, usage, events, name, pretty_print(all_power[i]->description(), descr, 128));
+		wprintw(win, "%s  %s %s %s %s\n", power, usage, events, name, pretty_print(all_power[i]->description().c_str(), descr, 128));
 	}
 }
 
@@ -1004,7 +1004,7 @@ void report_process_update_display(void)
 		software_data[idx]=string(name);
 		idx+=1;
 
-		software_data[idx]=string(pretty_print(all_power[i]->description(), descr, 128));
+		software_data[idx]=pretty_print(all_power[i]->description().c_str(), descr, 128);
 		idx+=1;
 		if (show_power) {
 			software_data[idx]=string(power);
@@ -1124,7 +1124,7 @@ void report_summary(void)
 		summary_data[idx]=string(name);
 		idx+=1;
 
-		summary_data[idx]=string(pretty_print(all_power[i]->description(), descr, 128));
+		summary_data[idx]=pretty_print(all_power[i]->description().c_str(), descr, 128);
 		idx+=1;
 
 		if (show_power){

--- a/src/process/interrupt.cpp
+++ b/src/process/interrupt.cpp
@@ -44,7 +44,7 @@ const char* softirqs[] = {
 };
 
 
-interrupt::interrupt(const char *_handler, int _number) : power_consumer()
+interrupt::interrupt(const string &_handler, int _number) : power_consumer()
 {
 	char buf[128];
 	running_since = 0;
@@ -86,7 +86,7 @@ double interrupt::usage_summary(void)
 	return t;
 }
 
-const char * interrupt::usage_units_summary(void)
+std::string interrupt::usage_units_summary(void)
 {
 	return "%";
 }

--- a/src/process/interrupt.cpp
+++ b/src/process/interrupt.cpp
@@ -72,11 +72,11 @@ uint64_t interrupt::end_interrupt(uint64_t time)
 	return delta;
 }
 
-const char * interrupt::description(void)
+std::string interrupt::description(void)
 {
 	if (child_runtime > accumulated_runtime)
 		child_runtime = 0;
-	return desc.c_str();
+	return desc;
 }
 
 double interrupt::usage_summary(void)

--- a/src/process/interrupt.cpp
+++ b/src/process/interrupt.cpp
@@ -51,7 +51,7 @@ interrupt::interrupt(const char *_handler, int _number) : power_consumer()
 	number = _number;
 	handler = _handler;
 	raw_count = 0;
-	desc = std::format("[{}] {}", number, pretty_print(handler.c_str(), buf, 128));
+	desc = std::format("[{}] {}", number, pretty_print(handler, buf, 128));
 }
 
 

--- a/src/process/interrupt.cpp
+++ b/src/process/interrupt.cpp
@@ -49,9 +49,9 @@ interrupt::interrupt(const char *_handler, int _number) : power_consumer()
 	char buf[128];
 	running_since = 0;
 	number = _number;
-	pt_strcpy(handler, _handler);
+	handler = _handler;
 	raw_count = 0;
-	snprintf(desc, sizeof(desc), "[%i] %s", number, pretty_print(handler, buf, 128));
+	desc = std::format("[{}] {}", number, pretty_print(handler.c_str(), buf, 128));
 }
 
 
@@ -76,7 +76,7 @@ const char * interrupt::description(void)
 {
 	if (child_runtime > accumulated_runtime)
 		child_runtime = 0;
-	return desc;
+	return desc.c_str();
 }
 
 double interrupt::usage_summary(void)
@@ -94,21 +94,21 @@ const char * interrupt::usage_units_summary(void)
 
 class interrupt * find_create_interrupt(const char *_handler, int nr, int cpu)
 {
-	char handler[64];
+	std::string handler_s;
 	unsigned int i;
 	class interrupt *new_irq;
 
-	pt_strcpy(handler, _handler);
-	if (strcmp(handler, "timer")==0)
-		sprintf(handler, "timer/%i", cpu);
+	handler_s = _handler;
+	if (handler_s == "timer")
+		handler_s = std::format("timer/{}", cpu);
 
 
 	for (i = 0; i < all_interrupts.size(); i++) {
-		if (all_interrupts[i] && all_interrupts[i]->number == nr && strcmp(handler, all_interrupts[i]->handler) == 0)
+		if (all_interrupts[i] && all_interrupts[i]->number == nr && all_interrupts[i]->handler == handler_s)
 			return all_interrupts[i];
 	}
 
-	new_irq = new class interrupt(handler, nr);
+	new_irq = new class interrupt(handler_s.c_str(), nr);
 	all_interrupts.push_back(new_irq);
 	return new_irq;
 }

--- a/src/process/interrupt.h
+++ b/src/process/interrupt.h
@@ -44,6 +44,7 @@ public:
 	virtual uint64_t end_interrupt(uint64_t time);
 
 	virtual const char * description(void);
+	virtual std::string description_s(void) { return description(); };
 
 	virtual const char * name(void) { return "interrupt"; };
 	virtual const char * type(void) { return "Interrupt"; };

--- a/src/process/interrupt.h
+++ b/src/process/interrupt.h
@@ -43,8 +43,7 @@ public:
 	virtual void start_interrupt(uint64_t time);
 	virtual uint64_t end_interrupt(uint64_t time);
 
-	virtual const char * description(void);
-	virtual std::string description_s(void) { return desc; };
+	virtual std::string description(void);
 
 	virtual const char * name(void) { return "interrupt"; };
 	virtual const char * type(void) { return "Interrupt"; };

--- a/src/process/interrupt.h
+++ b/src/process/interrupt.h
@@ -38,17 +38,17 @@ public:
 
 	int		raw_count;
 
-	interrupt(const char *_handler, int _number);
+	interrupt(const std::string &_handler, int _number);
 
 	virtual void start_interrupt(uint64_t time);
 	virtual uint64_t end_interrupt(uint64_t time);
 
 	virtual std::string description(void);
 
-	virtual const char * name(void) { return "interrupt"; };
-	virtual const char * type(void) { return "Interrupt"; };
+	virtual std::string name(void) { return "interrupt"; };
+	virtual std::string type(void) { return "Interrupt"; };
 	virtual double usage_summary(void);
-	virtual const char * usage_units_summary(void);
+	virtual std::string usage_units_summary(void);
 };
 
 extern vector <class interrupt *> all_interrupts;

--- a/src/process/interrupt.h
+++ b/src/process/interrupt.h
@@ -31,9 +31,9 @@
 
 class interrupt : public power_consumer {
 	uint64_t	running_since;
-	char		desc[256];
+	std::string	desc;
 public:
-	char		handler[32];
+	std::string	handler;
 	int		number;
 
 	int		raw_count;
@@ -44,7 +44,7 @@ public:
 	virtual uint64_t end_interrupt(uint64_t time);
 
 	virtual const char * description(void);
-	virtual std::string description_s(void) { return description(); };
+	virtual std::string description_s(void) { return desc; };
 
 	virtual const char * name(void) { return "interrupt"; };
 	virtual const char * type(void) { return "Interrupt"; };

--- a/src/process/powerconsumer.cpp
+++ b/src/process/powerconsumer.cpp
@@ -86,7 +86,7 @@ double power_consumer::usage(void)
 	return t;
 }
 
-const char * power_consumer::usage_units(void)
+std::string power_consumer::usage_units(void)
 {
 	double t;
 	t = (accumulated_runtime - child_runtime) / 1000000.0 / measurement_time;

--- a/src/process/powerconsumer.h
+++ b/src/process/powerconsumer.h
@@ -57,14 +57,14 @@ public:
 	virtual double Witts(void);
 	virtual std::string description(void) { return ""; };
 
-	virtual const char * name(void) { return "abstract"; };
-	virtual const char * type(void) { return "abstract"; };
+	virtual std::string name(void) { return "abstract"; };
+	virtual std::string type(void) { return "abstract"; };
 
 	virtual double usage(void);
-	virtual const char * usage_units(void);
+	virtual std::string usage_units(void);
 
 	virtual double usage_summary(void) { return usage();};
-	virtual const char * usage_units_summary(void) { return usage_units(); };
+	virtual std::string usage_units_summary(void) { return usage_units(); };
 	virtual double events(void) { return  (wake_ups + gpu_ops + hard_disk_hits) / measurement_time;};
 	virtual int show_events(void) { return 1; };
 };

--- a/src/process/powerconsumer.h
+++ b/src/process/powerconsumer.h
@@ -55,8 +55,7 @@ public:
 	virtual ~power_consumer() {};
 
 	virtual double Witts(void);
-	virtual const char * description(void) { return ""; };
-	virtual std::string description_s(void) { return description(); };
+	virtual std::string description(void) { return ""; };
 
 	virtual const char * name(void) { return "abstract"; };
 	virtual const char * type(void) { return "abstract"; };

--- a/src/process/powerconsumer.h
+++ b/src/process/powerconsumer.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <vector>
 #include <algorithm>
+#include <string>
 
 using namespace std;
 
@@ -55,6 +56,7 @@ public:
 
 	virtual double Witts(void);
 	virtual const char * description(void) { return ""; };
+	virtual std::string description_s(void) { return description(); };
 
 	virtual const char * name(void) { return "abstract"; };
 	virtual const char * type(void) { return "abstract"; };

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -151,19 +151,24 @@ const char * process::usage_units_summary(void)
 	return "%";
 }
 
-class process * find_create_process(const char *_comm, int pid)
+class process * find_create_process(const std::string &comm, int pid)
 {
 	unsigned int i;
 	class process *new_proc;
 
 	for (i = 0; i < all_processes.size(); i++) {
-		if (all_processes[i]->pid == pid && all_processes[i]->comm == _comm)
+		if (all_processes[i]->pid == pid && all_processes[i]->comm == comm)
 			return all_processes[i];
 	}
 
-	new_proc = new class process(_comm, pid);
+	new_proc = new class process(comm.c_str(), pid);
 	all_processes.push_back(new_proc);
 	return new_proc;
+}
+
+class process * find_create_process(const char *_comm, int pid)
+{
+	return find_create_process(string(_comm ? _comm : ""), pid);
 }
 
 class process * find_create_process(char *comm, int pid)

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -81,11 +81,9 @@ static void cmdline_to_string(std::string& str)
 
 process::process(const char *_comm, int _pid, int _tid) : power_consumer()
 {
-	char line[4097];
 	ifstream file;
-	ssize_t pos;
 
-	pt_strcpy(comm, _comm);
+	comm = _comm;
 	pid = _pid;
 	is_idle = 0;
 	running = 0;
@@ -95,9 +93,9 @@ process::process(const char *_comm, int _pid, int _tid) : power_consumer()
 	tgid = _tid;
 
 	if (_tid == 0) {
-		sprintf(line, "/proc/%i/status", _pid);
-		file.open(line);
+		file.open(std::format("/proc/{}/status", _pid));
 		while (file) {
+			char line[4097];
 			file.getline(line, 4096);
 			line[4096] = '\0';
 			if (strstr(line, "Tgid")) {
@@ -113,31 +111,21 @@ process::process(const char *_comm, int _pid, int _tid) : power_consumer()
 		file.close();
 	}
 
-	if (strncmp(_comm, "kondemand/", 10) == 0)
+	if (comm.starts_with("kondemand/"))
 		is_idle = 1;
 
-	pos = snprintf(desc, sizeof(desc), "[PID %d] ", pid);
+	desc = std::format("[PID {}] {}", pid, comm);
 
-	if (pos < 0)
-		pos = 0;
-	if ((size_t)pos > sizeof(desc))
-		return;
-
-	strncpy(desc + pos, comm, sizeof(desc) - pos - 1);
-	desc[sizeof(desc) - 1] = '\0';
-
-	sprintf(line, "/proc/%i/cmdline", _pid);
-	file.open(line, ios::binary);
+	file.open(std::format("/proc/{}/cmdline", _pid), ios::binary);
 	if (file) {
 		std::string cmdline(std::istreambuf_iterator<char>(file), (std::istreambuf_iterator<char>()));
 		file.close();
 		if (cmdline.size() < 1) {
 			is_kernel = 1;
-			snprintf(desc + pos, sizeof(desc) - pos, "[%s]", comm);
+			desc = std::format("[PID {}] [{}]", pid, comm);
 		} else {
 			cmdline_to_string(cmdline);
-			strncpy(desc + pos, cmdline.c_str(), sizeof(desc) - pos - 1);
-			desc[sizeof(desc) - 1] = '\0';
+			desc = std::format("[PID {}] {}", pid, cmdline);
 		}
 	}
 }
@@ -148,7 +136,7 @@ const char * process::description(void)
 	if (child_runtime > accumulated_runtime)
 		child_runtime = 0;
 
-	return desc;
+	return desc.c_str();
 }
 
 double process::usage_summary(void)
@@ -163,17 +151,17 @@ const char * process::usage_units_summary(void)
 	return "%";
 }
 
-class process * find_create_process(const char *comm, int pid)
+class process * find_create_process(const char *_comm, int pid)
 {
 	unsigned int i;
 	class process *new_proc;
 
 	for (i = 0; i < all_processes.size(); i++) {
-		if (all_processes[i]->pid == pid && strcmp(comm, all_processes[i]->comm) == 0)
+		if (all_processes[i]->pid == pid && all_processes[i]->comm == _comm)
 			return all_processes[i];
 	}
 
-	new_proc = new class process(comm, pid);
+	new_proc = new class process(_comm, pid);
 	all_processes.push_back(new_proc);
 	return new_proc;
 }
@@ -215,7 +203,7 @@ void merge_processes(void)
 				continue;
 			}
 			/* find dupes and add up */
-			if (!strcmp(one->desc, two->desc)) {
+			if (one->desc == two->desc) {
 				merge_process(one, two);
 				delete *it2;
 				it2 = all_processes.erase(it2);

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -79,7 +79,7 @@ static void cmdline_to_string(std::string& str)
 }
 
 
-process::process(const char *_comm, int _pid, int _tid) : power_consumer()
+process::process(const string &_comm, int _pid, int _tid) : power_consumer()
 {
 	ifstream file;
 
@@ -146,7 +146,7 @@ double process::usage_summary(void)
 	return t;
 }
 
-const char * process::usage_units_summary(void)
+std::string process::usage_units_summary(void)
 {
 	return "%";
 }

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -130,13 +130,13 @@ process::process(const char *_comm, int _pid, int _tid) : power_consumer()
 	}
 }
 
-const char * process::description(void)
+std::string process::description(void)
 {
 
 	if (child_runtime > accumulated_runtime)
 		child_runtime = 0;
 
-	return desc.c_str();
+	return desc;
 }
 
 double process::usage_summary(void)

--- a/src/process/process.h
+++ b/src/process/process.h
@@ -52,7 +52,7 @@ public:
 	int		running;
 	int		is_kernel; /* kernel thread */
 
-	process(const char *_comm, int _pid, int _tid = 0);
+	process(const std::string &_comm, int _pid, int _tid = 0);
 
 	virtual void schedule_thread(uint64_t time, int thread_id);
 	virtual uint64_t deschedule_thread(uint64_t time, int thread_id = 0);
@@ -60,11 +60,11 @@ public:
 	virtual void account_disk_dirty(void);
 
 	virtual std::string description(void);
-	virtual const char * name(void) { return "process"; };
-	virtual const char * type(void) { return "Process"; };
+	virtual std::string name(void) { return "process"; };
+	virtual std::string type(void) { return "Process"; };
 
 	virtual double usage_summary(void);
-	virtual const char * usage_units_summary(void);
+	virtual std::string usage_units_summary(void);
 
 };
 

--- a/src/process/process.h
+++ b/src/process/process.h
@@ -59,8 +59,7 @@ public:
 
 	virtual void account_disk_dirty(void);
 
-	virtual const char * description(void);
-	virtual std::string description_s(void) { return desc; };
+	virtual std::string description(void);
 	virtual const char * name(void) { return "process"; };
 	virtual const char * type(void) { return "Process"; };
 

--- a/src/process/process.h
+++ b/src/process/process.h
@@ -42,9 +42,9 @@ Need to collect
 class process : public power_consumer {
 	uint64_t	running_since;
 public:
-	char		desc[256];
+	std::string	desc;
 	int		tgid;
-	char		comm[16];
+	std::string	comm;
 	int		pid;
 
 
@@ -60,7 +60,7 @@ public:
 	virtual void account_disk_dirty(void);
 
 	virtual const char * description(void);
-	virtual std::string description_s(void) { return description(); };
+	virtual std::string description_s(void) { return desc; };
 	virtual const char * name(void) { return "process"; };
 	virtual const char * type(void) { return "Process"; };
 

--- a/src/process/process.h
+++ b/src/process/process.h
@@ -60,6 +60,7 @@ public:
 	virtual void account_disk_dirty(void);
 
 	virtual const char * description(void);
+	virtual std::string description_s(void) { return description(); };
 	virtual const char * name(void) { return "process"; };
 	virtual const char * type(void) { return "Process"; };
 

--- a/src/process/process.h
+++ b/src/process/process.h
@@ -82,6 +82,7 @@ extern void clear_process_data(void);
 extern void merge_processes(void);
 
 extern class process * find_create_process(const char *comm, int pid);
+extern class process * find_create_process(const std::string &comm, int pid);
 extern class process * find_create_process(char *comm, int pid);
 extern void all_processes_to_all_power(void);
 

--- a/src/process/processdevice.cpp
+++ b/src/process/processdevice.cpp
@@ -62,7 +62,7 @@ static void add_device(class device *device)
 	for (i = 0; i < all_proc_devices.size(); i++) {
 		class device_consumer *cdev;
 		cdev = all_proc_devices[i];
-		if (device->real_path[0] != 0 && strcmp(cdev->device->real_path, device->real_path) == 0) {
+		if (!device->real_path.empty() && cdev->device->real_path == device->real_path) {
 			/* we have a device with the same underlying object */
 
 			/* aggregate the power */

--- a/src/process/processdevice.cpp
+++ b/src/process/processdevice.cpp
@@ -39,7 +39,7 @@ device_consumer::device_consumer(class device *dev) : power_consumer()
 
 const char * device_consumer::description(void)
 {
-	snprintf(str, sizeof(str), "%s", device->human_name());
+	snprintf(str, sizeof(str), "%s", device->human_name_s().c_str());
 	return str;
 }
 

--- a/src/process/processdevice.cpp
+++ b/src/process/processdevice.cpp
@@ -37,10 +37,9 @@ device_consumer::device_consumer(class device *dev) : power_consumer()
 }
 
 
-const char * device_consumer::description(void)
+std::string device_consumer::description(void)
 {
-	snprintf(str, sizeof(str), "%s", device->human_name_s().c_str());
-	return str;
+	return device->human_name_s();
 }
 
 double device_consumer::Witts(void)

--- a/src/process/processdevice.cpp
+++ b/src/process/processdevice.cpp
@@ -39,7 +39,7 @@ device_consumer::device_consumer(class device *dev) : power_consumer()
 
 std::string device_consumer::description(void)
 {
-	return device->human_name_s();
+	return device->human_name();
 }
 
 double device_consumer::Witts(void)

--- a/src/process/processdevice.h
+++ b/src/process/processdevice.h
@@ -39,6 +39,7 @@ public:
 	device_consumer(class device *dev);
 
 	virtual const char * description(void);
+	virtual std::string description_s(void) { return description(); };
 	virtual const char * name(void) { return "device"; };
 	virtual const char * type(void) { return "Device"; };
 	virtual double Witts(void);

--- a/src/process/processdevice.h
+++ b/src/process/processdevice.h
@@ -38,11 +38,11 @@ public:
 	device_consumer(class device *dev);
 
 	virtual std::string description(void);
-	virtual const char * name(void) { return "device"; };
-	virtual const char * type(void) { return "Device"; };
+	virtual std::string name(void) { return "device"; };
+	virtual std::string type(void) { return "Device"; };
 	virtual double Witts(void);
 	virtual double usage(void) { return device->utilization();};
-	virtual const char * usage_units(void) {return device->util_units();};
+	virtual std::string usage_units(void) {return device->util_units();};
 	virtual int show_events(void) { return 0; };
 };
 

--- a/src/process/processdevice.h
+++ b/src/process/processdevice.h
@@ -31,15 +31,13 @@
 #include "../devices/device.h"
 
 class device_consumer : public power_consumer {
-	char str[4096];
 public:
 	int prio;
 	double power;
 	class device *device;
 	device_consumer(class device *dev);
 
-	virtual const char * description(void);
-	virtual std::string description_s(void) { return description(); };
+	virtual std::string description(void);
 	virtual const char * name(void) { return "device"; };
 	virtual const char * type(void) { return "Device"; };
 	virtual double Witts(void);

--- a/src/process/timer.cpp
+++ b/src/process/timer.cpp
@@ -51,7 +51,7 @@ static bool timer_is_deferred(string_view handler)
 	while (!feof(file)) {
 		if (fgets(line, 4096, file) == NULL)
 			break;
-		if (strstr(line, handler.data())) {
+		if (strstr(line, string(handler).c_str())) {
 			ret = (strstr(line, "D,") != NULL);
 			if (ret == true)
 				break;

--- a/src/process/timer.cpp
+++ b/src/process/timer.cpp
@@ -33,9 +33,11 @@
 #include "../lib.h"
 #include "process.h"
 
+#include <string_view>
+
 using namespace std;
 
-static bool timer_is_deferred(const char *handler)
+static bool timer_is_deferred(string_view handler)
 {
 	FILE    *file;
 	bool    ret = false;
@@ -49,7 +51,7 @@ static bool timer_is_deferred(const char *handler)
 	while (!feof(file)) {
 		if (fgets(line, 4096, file) == NULL)
 			break;
-		if (strstr(line, handler)) {
+		if (strstr(line, handler.data())) {
 			ret = (strstr(line, "D,") != NULL);
 			if (ret == true)
 				break;
@@ -61,7 +63,7 @@ static bool timer_is_deferred(const char *handler)
 
 timer::timer(unsigned long address) : power_consumer()
 {
-	pt_strcpy(handler, kernel_function(address));
+	handler = kernel_function(address);
 	raw_count = 0;
 	deferred = timer_is_deferred(handler);
 }
@@ -125,8 +127,8 @@ const char * timer::description(void)
 	if (child_runtime > accumulated_runtime)
 		child_runtime = 0;
 
-	snprintf(desc, sizeof(desc), "%s", handler);
-	return desc;
+	desc = handler;
+	return desc.c_str();
 }
 
 

--- a/src/process/timer.cpp
+++ b/src/process/timer.cpp
@@ -103,7 +103,7 @@ double timer::usage_summary(void)
 	return t;
 }
 
-const char * timer::usage_units_summary(void)
+std::string timer::usage_units_summary(void)
 {
 	return "%";
 }

--- a/src/process/timer.cpp
+++ b/src/process/timer.cpp
@@ -122,13 +122,13 @@ void all_timers_to_all_power(void)
 }
 
 
-const char * timer::description(void)
+std::string timer::description(void)
 {
 	if (child_runtime > accumulated_runtime)
 		child_runtime = 0;
 
 	desc = handler;
-	return desc.c_str();
+	return desc;
 }
 
 

--- a/src/process/timer.h
+++ b/src/process/timer.h
@@ -43,10 +43,10 @@ public:
 	bool is_deferred(void);
 
 	virtual std::string description(void);
-	virtual const char * name(void) { return "timer"; };
-	virtual const char * type(void) { return "Timer"; };
+	virtual std::string name(void) { return "timer"; };
+	virtual std::string type(void) { return "Timer"; };
 	virtual double usage_summary(void);
-	virtual const char * usage_units_summary(void);
+	virtual std::string usage_units_summary(void);
 
 };
 

--- a/src/process/timer.h
+++ b/src/process/timer.h
@@ -43,6 +43,7 @@ public:
 	bool is_deferred(void);
 
 	virtual const char * description(void);
+	virtual std::string description_s(void) { return description(); };
 	virtual const char * name(void) { return "timer"; };
 	virtual const char * type(void) { return "Timer"; };
 	virtual double usage_summary(void);

--- a/src/process/timer.h
+++ b/src/process/timer.h
@@ -30,9 +30,9 @@
 #include "powerconsumer.h"
 
 class timer : public power_consumer {
-	char desc[256];
+	std::string desc;
 public:
-	char		handler[32];
+	std::string	handler;
 	int		raw_count;
 	bool		deferred;
 
@@ -43,7 +43,7 @@ public:
 	bool is_deferred(void);
 
 	virtual const char * description(void);
-	virtual std::string description_s(void) { return description(); };
+	virtual std::string description_s(void) { return desc; };
 	virtual const char * name(void) { return "timer"; };
 	virtual const char * type(void) { return "Timer"; };
 	virtual double usage_summary(void);

--- a/src/process/timer.h
+++ b/src/process/timer.h
@@ -42,8 +42,7 @@ public:
 	uint64_t done(uint64_t time, uint64_t timer_struct);
 	bool is_deferred(void);
 
-	virtual const char * description(void);
-	virtual std::string description_s(void) { return desc; };
+	virtual std::string description(void);
 	virtual const char * name(void) { return "timer"; };
 	virtual const char * type(void) { return "Timer"; };
 	virtual double usage_summary(void);

--- a/src/process/work.cpp
+++ b/src/process/work.cpp
@@ -109,12 +109,12 @@ void clear_work(void)
 }
 
 
-const char * work::description(void)
+std::string work::description(void)
 {
 	if (child_runtime > accumulated_runtime)
 		child_runtime = 0;
 
-	return desc.c_str();
+	return desc;
 }
 
 

--- a/src/process/work.cpp
+++ b/src/process/work.cpp
@@ -78,7 +78,7 @@ double work::usage_summary(void)
 	return t;
 }
 
-const char * work::usage_units_summary(void)
+std::string work::usage_units_summary(void)
 {
 	return "%";
 }

--- a/src/process/work.cpp
+++ b/src/process/work.cpp
@@ -38,9 +38,9 @@ using namespace std;
 
 work::work(unsigned long address) : power_consumer()
 {
-	pt_strcpy(handler, kernel_function(address));
+	handler = kernel_function(address);
 	raw_count = 0;
-	snprintf(desc, sizeof(desc), "%s", handler);
+	desc = handler;
 }
 
 
@@ -114,7 +114,7 @@ const char * work::description(void)
 	if (child_runtime > accumulated_runtime)
 		child_runtime = 0;
 
-	return desc;
+	return desc.c_str();
 }
 
 

--- a/src/process/work.h
+++ b/src/process/work.h
@@ -40,8 +40,7 @@ public:
 	void fire(uint64_t time, uint64_t work_struct);
 	uint64_t done(uint64_t time, uint64_t work_struct);
 
-	virtual const char * description(void);
-	virtual std::string description_s(void) { return desc; };
+	virtual std::string description(void);
 	virtual const char * name(void) { return "work"; };
 	virtual const char * type(void) { return "kWork"; };
 	virtual double usage_summary(void);

--- a/src/process/work.h
+++ b/src/process/work.h
@@ -30,9 +30,9 @@
 #include "powerconsumer.h"
 
 class work : public power_consumer {
-	char desc[256];
+	std::string desc;
 public:
-	char		handler[32];
+	std::string	handler;
 	int		raw_count;
 
 	work(unsigned long work_func);
@@ -41,7 +41,7 @@ public:
 	uint64_t done(uint64_t time, uint64_t work_struct);
 
 	virtual const char * description(void);
-	virtual std::string description_s(void) { return description(); };
+	virtual std::string description_s(void) { return desc; };
 	virtual const char * name(void) { return "work"; };
 	virtual const char * type(void) { return "kWork"; };
 	virtual double usage_summary(void);

--- a/src/process/work.h
+++ b/src/process/work.h
@@ -41,10 +41,10 @@ public:
 	uint64_t done(uint64_t time, uint64_t work_struct);
 
 	virtual std::string description(void);
-	virtual const char * name(void) { return "work"; };
-	virtual const char * type(void) { return "kWork"; };
+	virtual std::string name(void) { return "work"; };
+	virtual std::string type(void) { return "kWork"; };
 	virtual double usage_summary(void);
-	virtual const char * usage_units_summary(void);
+	virtual std::string usage_units_summary(void);
 
 };
 

--- a/src/process/work.h
+++ b/src/process/work.h
@@ -41,6 +41,7 @@ public:
 	uint64_t done(uint64_t time, uint64_t work_struct);
 
 	virtual const char * description(void);
+	virtual std::string description_s(void) { return description(); };
 	virtual const char * name(void) { return "work"; };
 	virtual const char * type(void) { return "kWork"; };
 	virtual double usage_summary(void);

--- a/src/report/report-formatter-base.cpp
+++ b/src/report/report-formatter-base.cpp
@@ -34,10 +34,10 @@
 
 /* ************************************************************************ */
 
-const char *
+std::string
 report_formatter_string_base::get_result()
 {
-	return result.c_str();
+	return result;
 }
 
 /* ************************************************************************ */
@@ -51,21 +51,17 @@ report_formatter_string_base::clear_result()
 /* ************************************************************************ */
 
 void
-report_formatter_string_base::add(const char *str)
+report_formatter_string_base::add(const string &str)
 {
-	assert(str);
-
 	result += escape_string(str);
 }
 
 /* ************************************************************************ */
 
 void
-report_formatter_string_base::add_exact(const char *str)
+report_formatter_string_base::add_exact(const string &str)
 {
-	assert(str);
-
-	result += std::string(str);
+	result += str;
 }
 
 /* ************************************************************************ */

--- a/src/report/report-formatter-base.h
+++ b/src/report/report-formatter-base.h
@@ -31,20 +31,20 @@
 class report_formatter_string_base: public report_formatter
 {
 public:
-	virtual const char *get_result();
+	virtual std::string get_result();
 	virtual void clear_result();
 
-	virtual void add(const char *str);
+	virtual void add(const std::string &str);
 	virtual void addv(const char *fmt, va_list ap);
 
 protected:
-	void add_exact(const char *str);
+	void add_exact(const std::string &str);
 	void addf(const char *fmt, ...)
 				__attribute__ ((format (printf, 2, 3)));
 	void addf_exact(const char *fmt, ...)
 				__attribute__ ((format (printf, 2, 3)));
 
-	virtual std::string escape_string(const char *str) = 0;
+	virtual std::string escape_string(const std::string &str) = 0;
 
 	std::string result;
 };

--- a/src/report/report-formatter-csv.cpp
+++ b/src/report/report-formatter-csv.cpp
@@ -49,14 +49,12 @@ report_formatter_csv::finish_report()
 
 
 string
-report_formatter_csv::escape_string(const char *str)
+report_formatter_csv::escape_string(const string &str)
 {
 	string res;
 
-	assert(str);
-
-	for (const char *i = str; *i; i++) {
-		switch (*i) {
+	for (size_t i = 0; i < str.length(); i++) {
+		switch (str[i]) {
 			case '"':
 				res += '"';
 #ifdef REPORT_CSV_SPACE_NEED_QUOTES
@@ -68,7 +66,7 @@ report_formatter_csv::escape_string(const char *str)
 				break;
 		}
 
-		res += *i;
+		res += str[i];
 	}
 
 	return res;
@@ -110,10 +108,10 @@ report_formatter_csv::end_div()
 }
 
 void
-report_formatter_csv::add_title(struct tag_attr *title_att, const char *title)
+report_formatter_csv::add_title(struct tag_attr *title_att, const string &title)
 {
 	add_exact("____________________________________________________________________\n");
-	addf_exact(" *  *  *   %s   *  *  *\n", title);
+	addf_exact(" *  *  *   %s   *  *  *\n", title.c_str());
 }
 
 void

--- a/src/report/report-formatter-csv.h
+++ b/src/report/report-formatter-csv.h
@@ -58,14 +58,14 @@ public:
 	void end_header();
 	void add_div(struct tag_attr *div_attr);
 	void end_div();
-	void add_title(struct tag_attr *title_att, const char *title);
+	void add_title(struct tag_attr *title_att, const std::string &title);
 	void add_navigation();
 	void add_summary_list(string *list, int size);
 	void add_table(string *system_data, struct table_attributes *tb_attr);
 
 private:
 	void add_quotes();
-	string escape_string(const char *str);
+	string escape_string(const std::string &str);
 	bool csv_need_quotes;
 	size_t text_start;
 };

--- a/src/report/report-formatter-html.cpp
+++ b/src/report/report-formatter-html.cpp
@@ -99,14 +99,12 @@ report_formatter_html::add_doc_footer()
 
 /* ************************************************************************ */
 string
-report_formatter_html::escape_string(const char *str)
+report_formatter_html::escape_string(const string &str)
 {
 	string res;
 
-	assert(str);
-
-	for (const char *i = str; *i; i++) {
-		switch (*i) {
+	for (size_t i = 0; i < str.length(); i++) {
+		switch (str[i]) {
 			case '<':
 				res += "&lt;";
 				continue;
@@ -126,7 +124,7 @@ report_formatter_html::escape_string(const char *str)
 #endif /* REPORT_HTML_ESCAPE_QUOTES */
 		}
 
-		res += *i;
+		res += str[i];
 	}
 
 	return res;
@@ -302,9 +300,9 @@ report_formatter_html::end_div()
 }
 
 void
-report_formatter_html::add_title(struct tag_attr *title_att, const char *title)
+report_formatter_html::add_title(struct tag_attr *title_att, const string &title)
 {
-	addf_exact("<h2 class=\"%s\"> %s </h2>\n", title_att->css_class, title);
+	addf_exact("<h2 class=\"%s\"> %s </h2>\n", title_att->css_class, title.c_str());
 }
 
 void

--- a/src/report/report-formatter-html.h
+++ b/src/report/report-formatter-html.h
@@ -39,7 +39,7 @@ using namespace std;
 /* ************************************************************************ */
 
 struct html_section {
-	const char *id;
+	std::string id;
 };
 
 /* ************************************************************************ */
@@ -56,7 +56,7 @@ public:
 	void end_header();
 	void add_div(struct tag_attr *div_attr);
 	void end_div();
-	void add_title(struct tag_attr *title_att, const char *title);
+	void add_title(struct tag_attr *title_att, const std::string &title);
 	void add_navigation();
 	void add_summary_list(string *list, int size);
 	void add_table(string *system_data, struct table_attributes *tb_attr);
@@ -66,7 +66,7 @@ private:
 	void init_markup();
 	void add_doc_header();
 	void add_doc_footer();
-	string escape_string(const char *str);
+	string escape_string(const std::string &str);
 
 };
 

--- a/src/report/report-formatter.h
+++ b/src/report/report-formatter.h
@@ -35,10 +35,10 @@ public:
 	virtual ~report_formatter() {}
 
 	virtual void finish_report() {}
-	virtual const char *get_result() {return "Basic report_formatter::get_result() call\n";}
+	virtual std::string get_result() {return "Basic report_formatter::get_result() call\n";}
 	virtual void clear_result() {}
 
-	virtual void add(const char *str) {}
+	virtual void add(const std::string &str) {}
 	virtual void addv(const char *fmt, va_list ap) {}
 
 	/* *** Report Style *** */
@@ -47,7 +47,7 @@ public:
 	virtual void end_header() {}
 	virtual void add_div(struct tag_attr *div_attr) {}
 	virtual void end_div() {}
-	virtual void add_title(struct tag_attr *att_title, const char *title) {}
+	virtual void add_title(struct tag_attr *att_title, const std::string &title) {}
 	virtual void add_navigation() {}
 	virtual void add_summary_list(string *list, int size) {}
 	virtual void add_table(string *system_data,

--- a/src/report/report-maker.cpp
+++ b/src/report/report-maker.cpp
@@ -63,7 +63,9 @@ report_maker::finish_report()
 const char *
 report_maker::get_result()
 {
-	return formatter->get_result();
+	static std::string result;
+	result = formatter->get_result();
+	return result.c_str();
 }
 
 /* ************************************************************************ */
@@ -112,9 +114,8 @@ report_maker::setup_report_formatter()
 /* ************************************************************************ */
 
 void
-report_maker::add(const char *str)
+report_maker::add(const string &str)
 {
-	assert(str);
 	formatter->add(str);
 }
 
@@ -150,7 +151,7 @@ report_maker::end_header()
 }
 
 void
-report_maker::add_title(struct tag_attr *att_title, const char *title)
+report_maker::add_title(struct tag_attr *att_title, const string &title)
 {
 	formatter->add_title(att_title, title);
 }

--- a/src/report/report-maker.h
+++ b/src/report/report-maker.h
@@ -118,7 +118,7 @@ public:
 	const char *get_result();
 	void clear_result();
 
-	void add(const char *str);
+	void add(const std::string &str);
 
 	/* *** Report Style *** */
 	void add_header();
@@ -126,7 +126,7 @@ public:
 	void add_logo();
 	void add_div(struct tag_attr *div_attr);
 	void end_div();
-	void add_title(struct tag_attr *att_title, const char *title);
+	void add_title(struct tag_attr *att_title, const std::string &title);
 	void add_navigation();
 	void add_summary_list(string *list, int size);
 	void add_table(string *system_data, struct table_attributes *tb_attr);

--- a/src/report/report.cpp
+++ b/src/report/report.cpp
@@ -166,7 +166,7 @@ static void system_info(void)
 	delete [] system_data;
 }
 
-void init_report_output(char *filename_str, int iterations)
+void init_report_output(const char *filename_str, int iterations)
 {
 	size_t period;
 	string filename;
@@ -174,7 +174,7 @@ void init_report_output(char *filename_str, int iterations)
 	char datestr[200];
 
 	if (iterations == 1)
-		snprintf(reportout.filename, sizeof(reportout.filename), "%s", filename_str);
+		reportout.filename = filename_str;
 	else
 	{
 		filename = string(filename_str);
@@ -185,15 +185,15 @@ void init_report_output(char *filename_str, int iterations)
 		memset(&stamp, 0, sizeof(time_t));
 		stamp = time(NULL);
 		strftime(datestr, sizeof(datestr), "%Y%m%d-%H%M%S", localtime(&stamp));
-		snprintf(reportout.filename, sizeof(reportout.filename), "%s-%s%s",
-			filename.substr(0, period).c_str(), datestr,
-			filename.substr(period).c_str());
+		reportout.filename = std::format("{}-{}{}",
+			filename.substr(0, period), datestr,
+			filename.substr(period));
 	}
-	
-	reportout.report_file = fopen(reportout.filename, "wm");
+
+	reportout.report_file = fopen(reportout.filename.c_str(), "wm");
 	if (!reportout.report_file) {
 		fprintf(stderr, _("Cannot open output file %s (%s)\n"),
-			reportout.filename, strerror(errno));
+			reportout.filename.c_str(), strerror(errno));
 	}
 
 	report.set_type(reporttype);
@@ -208,7 +208,7 @@ void finish_report_output(void)
 	report.finish_report();
 	if (reportout.report_file)
 	{
-		fprintf(stderr, _("PowerTOP outputting using base filename %s\n"), reportout.filename);
+		fprintf(stderr, _("PowerTOP outputting using base filename %s\n"), reportout.filename.c_str());
 		fputs(report.get_result(), reportout.report_file);
 		fdatasync(fileno(reportout.report_file));
 		fclose(reportout.report_file);

--- a/src/report/report.h
+++ b/src/report/report.h
@@ -35,13 +35,13 @@ using namespace std;
 
 struct reportstream {
 	FILE *report_file;
-	char filename[PATH_MAX];
+	std::string filename;
 };
 
 extern report_type reporttype;
 extern report_maker report;
 extern struct reportstream reportout;
-extern void init_report_output(char *filename_str, int iterations);
+extern void init_report_output(const char *filename_str, int iterations);
 extern void finish_report_output(void);
 
 #endif

--- a/src/tuning/bluetooth.cpp
+++ b/src/tuning/bluetooth.cpp
@@ -45,7 +45,9 @@
 
 bt_tunable::bt_tunable(void) : tunable("", 1.0, _("Good"), _("Bad"), _("Unknown"))
 {
-	sprintf(desc, _("Bluetooth device interface status"));
+	char buffer[4096];
+	snprintf(buffer, sizeof(buffer), _("Bluetooth device interface status"));
+	desc = buffer;
 	pt_strcpy(toggle_bad, "/usr/sbin/hciconfig hci0 up &> /dev/null &");
 	pt_strcpy(toggle_good, "/usr/sbin/hciconfig hci0 down &> /dev/null");
 }

--- a/src/tuning/bluetooth.cpp
+++ b/src/tuning/bluetooth.cpp
@@ -47,8 +47,8 @@
 bt_tunable::bt_tunable(void) : tunable("", 1.0, _("Good"), _("Bad"), _("Unknown"))
 {
 	desc = std::format(_("Bluetooth device interface status"));
-	pt_strcpy(toggle_bad, "/usr/sbin/hciconfig hci0 up &> /dev/null &");
-	pt_strcpy(toggle_good, "/usr/sbin/hciconfig hci0 down &> /dev/null");
+	toggle_bad = "/usr/sbin/hciconfig hci0 up &> /dev/null &";
+	toggle_good = "/usr/sbin/hciconfig hci0 down &> /dev/null";
 }
 
 
@@ -191,9 +191,9 @@ const char *bt_tunable::toggle_script(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		return toggle_bad;
+		return toggle_bad.c_str();
 	}
-	return toggle_good;
+	return toggle_good.c_str();
 }
 
 

--- a/src/tuning/bluetooth.cpp
+++ b/src/tuning/bluetooth.cpp
@@ -39,15 +39,14 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <errno.h>
+#include <format>
 
 #include "../lib.h"
 #include "bluetooth.h"
 
 bt_tunable::bt_tunable(void) : tunable("", 1.0, _("Good"), _("Bad"), _("Unknown"))
 {
-	char buffer[4096];
-	snprintf(buffer, sizeof(buffer), _("Bluetooth device interface status"));
-	desc = buffer;
+	desc = std::format(_("Bluetooth device interface status"));
 	pt_strcpy(toggle_bad, "/usr/sbin/hciconfig hci0 up &> /dev/null &");
 	pt_strcpy(toggle_good, "/usr/sbin/hciconfig hci0 down &> /dev/null");
 }

--- a/src/tuning/bluetooth.cpp
+++ b/src/tuning/bluetooth.cpp
@@ -46,7 +46,7 @@
 
 bt_tunable::bt_tunable(void) : tunable("", 1.0, _("Good"), _("Bad"), _("Unknown"))
 {
-	desc = std::format(_("Bluetooth device interface status"));
+	desc = _("Bluetooth device interface status");
 	toggle_bad = "/usr/sbin/hciconfig hci0 up &> /dev/null &";
 	toggle_good = "/usr/sbin/hciconfig hci0 down &> /dev/null";
 }

--- a/src/tuning/bluetooth.cpp
+++ b/src/tuning/bluetooth.cpp
@@ -185,17 +185,6 @@ void bt_tunable::toggle(void)
 		printf("System is not available\n");
 }
 
-const char *bt_tunable::toggle_script(void)
-{
-	int good;
-	good = good_bad();
-
-	if (good == TUNE_GOOD) {
-		return toggle_bad.c_str();
-	}
-	return toggle_good.c_str();
-}
-
 
 void add_bt_tunable(void)
 {

--- a/src/tuning/bluetooth.h
+++ b/src/tuning/bluetooth.h
@@ -39,8 +39,6 @@ public:
 
 	virtual void toggle(void);
 
-	virtual const char *toggle_script(void);
-
 };
 
 extern void add_bt_tunable(void);

--- a/src/tuning/ethernet.cpp
+++ b/src/tuning/ethernet.cpp
@@ -49,9 +49,11 @@ extern void create_all_nics(callback fn);
 
 ethernet_tunable::ethernet_tunable(const char *iface) : tunable("", 0.3, _("Good"), _("Bad"), _("Unknown"))
 {
+	char buffer[4096];
 	memset(interf, 0, sizeof(interf));
 	pt_strcpy(interf, iface);
-	sprintf(desc, _("Wake-on-lan status for device %s"), iface);
+	snprintf(buffer, sizeof(buffer), _("Wake-on-lan status for device %s"), iface);
+	desc = buffer;
 	snprintf(toggle_good, sizeof(toggle_good), "ethtool -s %s wol d;", iface);
 
 }

--- a/src/tuning/ethernet.cpp
+++ b/src/tuning/ethernet.cpp
@@ -52,7 +52,7 @@ ethernet_tunable::ethernet_tunable(const char *iface) : tunable("", 0.3, _("Good
 {
 	memset(interf, 0, sizeof(interf));
 	pt_strcpy(interf, iface);
-	desc = std::format(_("Wake-on-lan status for device {}"), iface);
+	desc = pt_format(_("Wake-on-lan status for device {}"), iface);
 	toggle_good = std::format("ethtool -s {} wol d;", iface);
 
 }

--- a/src/tuning/ethernet.cpp
+++ b/src/tuning/ethernet.cpp
@@ -1,4 +1,4 @@
-;/*
+/*
  * Copyright 2010, Intel Corporation
  *
  * This file is part of PowerTOP
@@ -39,6 +39,7 @@
 #include <net/if.h>
 #include <linux/sockios.h>
 #include <sys/ioctl.h>
+#include <format>
 
 #include <linux/ethtool.h>
 
@@ -49,11 +50,9 @@ extern void create_all_nics(callback fn);
 
 ethernet_tunable::ethernet_tunable(const char *iface) : tunable("", 0.3, _("Good"), _("Bad"), _("Unknown"))
 {
-	char buffer[4096];
 	memset(interf, 0, sizeof(interf));
 	pt_strcpy(interf, iface);
-	snprintf(buffer, sizeof(buffer), _("Wake-on-lan status for device %s"), iface);
-	desc = buffer;
+	desc = std::format(_("Wake-on-lan status for device {}"), iface);
 	snprintf(toggle_good, sizeof(toggle_good), "ethtool -s %s wol d;", iface);
 
 }

--- a/src/tuning/ethernet.cpp
+++ b/src/tuning/ethernet.cpp
@@ -48,7 +48,7 @@
 
 extern void create_all_nics(callback fn);
 
-ethernet_tunable::ethernet_tunable(const char *iface) : tunable("", 0.3, _("Good"), _("Bad"), _("Unknown"))
+ethernet_tunable::ethernet_tunable(const string &iface) : tunable("", 0.3, _("Good"), _("Bad"), _("Unknown"))
 {
 	interf = iface;
 	desc = pt_format(_("Wake-on-lan status for device {}"), iface);

--- a/src/tuning/ethernet.cpp
+++ b/src/tuning/ethernet.cpp
@@ -129,18 +129,6 @@ void ethernet_tunable::toggle(void)
 	close(sock);
 }
 
-const char *ethernet_tunable::toggle_script(void)
-{
-	int good;
-	good = good_bad();
-
-	if (good != TUNE_GOOD) {
-		return toggle_good.c_str();
-	}
-
-	return NULL;
-}
-
 
 void ethtunable_callback(const char *d_name)
 {

--- a/src/tuning/ethernet.cpp
+++ b/src/tuning/ethernet.cpp
@@ -53,7 +53,7 @@ ethernet_tunable::ethernet_tunable(const char *iface) : tunable("", 0.3, _("Good
 	memset(interf, 0, sizeof(interf));
 	pt_strcpy(interf, iface);
 	desc = std::format(_("Wake-on-lan status for device {}"), iface);
-	snprintf(toggle_good, sizeof(toggle_good), "ethtool -s %s wol d;", iface);
+	toggle_good = std::format("ethtool -s {} wol d;", iface);
 
 }
 
@@ -135,7 +135,7 @@ const char *ethernet_tunable::toggle_script(void)
 	good = good_bad();
 
 	if (good != TUNE_GOOD) {
-		return toggle_good;
+		return toggle_good.c_str();
 	}
 
 	return NULL;

--- a/src/tuning/ethernet.cpp
+++ b/src/tuning/ethernet.cpp
@@ -50,8 +50,7 @@ extern void create_all_nics(callback fn);
 
 ethernet_tunable::ethernet_tunable(const char *iface) : tunable("", 0.3, _("Good"), _("Bad"), _("Unknown"))
 {
-	memset(interf, 0, sizeof(interf));
-	pt_strcpy(interf, iface);
+	interf = iface;
 	desc = pt_format(_("Wake-on-lan status for device {}"), iface);
 	toggle_good = std::format("ethtool -s {} wol d;", iface);
 
@@ -72,7 +71,7 @@ int ethernet_tunable::good_bad(void)
 	if (sock<0)
 		return result;
 
-	pt_strcpy(ifr.ifr_name, interf);
+	strncpy(ifr.ifr_name, interf.c_str(), IFNAMSIZ - 1);
 
 	/* Check if the interf is up */
 	ret = ioctl(sock, SIOCGIFFLAGS, &ifr);
@@ -108,7 +107,7 @@ void ethernet_tunable::toggle(void)
 	if (sock<0)
 		return;
 
-	pt_strcpy(ifr.ifr_name, interf);
+	strncpy(ifr.ifr_name, interf.c_str(), IFNAMSIZ - 1);
 
 	/* Check if the interface is up */
 	ret = ioctl(sock, SIOCGIFFLAGS, &ifr);

--- a/src/tuning/ethernet.h
+++ b/src/tuning/ethernet.h
@@ -33,7 +33,7 @@ using namespace std;
 
 class ethernet_tunable : public tunable {
 public:
-	char interf[4096];
+	std::string interf;
 	ethernet_tunable(const char *iface);
 
 	virtual int good_bad(void);

--- a/src/tuning/ethernet.h
+++ b/src/tuning/ethernet.h
@@ -40,8 +40,6 @@ public:
 
 	virtual void toggle(void);
 
-	virtual const char *toggle_script(void);
-
 };
 
 extern void add_ethernet_tunable(void);

--- a/src/tuning/ethernet.h
+++ b/src/tuning/ethernet.h
@@ -34,7 +34,7 @@ using namespace std;
 class ethernet_tunable : public tunable {
 public:
 	std::string interf;
-	ethernet_tunable(const char *iface);
+	ethernet_tunable(const std::string &iface);
 
 	virtual int good_bad(void);
 

--- a/src/tuning/iw.h
+++ b/src/tuning/iw.h
@@ -63,7 +63,15 @@ enum id_input {
 	II_PHY_IDX,
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int get_wifi_power_saving(const char *iface);
 int set_wifi_power_saving(const char *iface, int state);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __IW_H */

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -57,35 +57,37 @@ runtime_tunable::runtime_tunable(const string &path, const string &bus, const st
 	}
 
 	if (bus == "pci") {
-		char filename[PATH_MAX];
+		std::string filename;
 		uint16_t vendor = 0, device = 0;
 
-		snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/vendor", bus.c_str(), dev.c_str());
+		filename = std::format("/sys/bus/{}/devices/{}/vendor", bus, dev);
 
-		file.open(filename, ios::in);
+		file.open(filename.c_str(), ios::in);
 		if (file) {
 			file >> hex >> vendor;
 			file.close();
 		}
 
 
-		snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/device", bus.c_str(), dev.c_str());
-		file.open(filename, ios::in);
+		filename = std::format("/sys/bus/{}/devices/{}/device", bus, dev);
+		file.open(filename.c_str(), ios::in);
 		if (file) {
 			file >> hex >> device;
 			file.close();
 		}
 
 		if (vendor && device) {
+			std::string pci_name;
 			if (!device_has_runtime_pm(path)) {
-				desc = pt_format(_("PCI Device {} has no runtime power management"), pci_id_to_name(vendor, device, filename, 4095));
+				desc = pt_format(_("PCI Device {} has no runtime power management"), pci_id_to_name(vendor, device, pci_name, 4095));
 			} else {
-				desc = pt_format(_("Runtime PM for PCI Device {}"), pci_id_to_name(vendor, device, filename, 4095));
+				desc = pt_format(_("Runtime PM for PCI Device {}"), pci_id_to_name(vendor, device, pci_name, 4095));
 			}
 		}
 
 		if (path.find("ata") != string::npos) {
-			desc = pt_format(_("Runtime PM for port {} of PCI device: {}"), port, pci_id_to_name(vendor, device, filename, 4095));
+			std::string pci_name;
+			desc = pt_format(_("Runtime PM for port {} of PCI device: {}"), port, pci_id_to_name(vendor, device, pci_name, 4095));
 		}
 
 		if (path.find("block") != string::npos) {

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -46,9 +46,9 @@ runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *
 	runtime_path = std::format("{}/power/control", path);
 
 
-	desc = std::format(_("Runtime PM for {} device {}"), bus, dev);
+	desc = pt_format(_("Runtime PM for {} device {}"), bus, dev);
 	if (!device_has_runtime_pm(path)) {
-		desc = std::format(_("{} device {} has no runtime power management"), bus, dev);
+		desc = pt_format(_("{} device {} has no runtime power management"), bus, dev);
 	}
 
 	if (strcmp(bus, "pci") == 0) {
@@ -73,18 +73,18 @@ runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *
 
 		if (vendor && device) {
 			if (!device_has_runtime_pm(path)) {
-				desc = std::format(_("PCI Device {} has no runtime power management"), pci_id_to_name(vendor, device, filename, 4095));
+				desc = pt_format(_("PCI Device {} has no runtime power management"), pci_id_to_name(vendor, device, filename, 4095));
 			} else {
-				desc = std::format(_("Runtime PM for PCI Device {}"), pci_id_to_name(vendor, device, filename, 4095));
+				desc = pt_format(_("Runtime PM for PCI Device {}"), pci_id_to_name(vendor, device, filename, 4095));
 			}
 		}
 
 		if (string(path).find("ata") != string::npos) {
-			desc = std::format(_("Runtime PM for port {} of PCI device: {}"), port, pci_id_to_name(vendor, device, filename, 4095));
+			desc = pt_format(_("Runtime PM for port {} of PCI device: {}"), port, pci_id_to_name(vendor, device, filename, 4095));
 		}
 
 		if (string(path).find("block") != string::npos) {
-			desc = std::format(_("Runtime PM for disk {}"), port);
+			desc = pt_format(_("Runtime PM for disk {}"), port);
 		}
 
 	}

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -43,7 +43,7 @@
 runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *dev, const char *port) : tunable("", 0.4, _("Good"), _("Bad"), _("Unknown"))
 {
 	ifstream file;
-	sprintf(runtime_path, "%s/power/control", path);
+	runtime_path = std::format("{}/power/control", path);
 
 
 	desc = std::format(_("Runtime PM for {} device {}"), bus, dev);
@@ -88,15 +88,15 @@ runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *
 		}
 
 	}
-	snprintf(toggle_good, sizeof(toggle_good), "echo 'auto' > '%s';", runtime_path);
-	snprintf(toggle_bad, sizeof(toggle_bad), "echo 'on' > '%s';", runtime_path);
+	toggle_good = std::format("echo 'auto' > '{}';", runtime_path);
+	toggle_bad = std::format("echo 'on' > '{}';", runtime_path);
 }
 
 int runtime_tunable::good_bad(void)
 {
 	std::string content;
 
-	content = read_sysfs_string(runtime_path);
+	content = read_sysfs_string(runtime_path.c_str());
 
 	if (content == "auto")
 		return TUNE_GOOD;
@@ -112,11 +112,11 @@ void runtime_tunable::toggle(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		write_sysfs(runtime_path, "on");
+		write_sysfs(runtime_path.c_str(), "on");
 		return;
 	}
 
-	write_sysfs(runtime_path, "auto");
+	write_sysfs(runtime_path.c_str(), "auto");
 }
 
 const char *runtime_tunable::toggle_script(void)
@@ -125,10 +125,10 @@ const char *runtime_tunable::toggle_script(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		return toggle_bad;
+		return toggle_bad.c_str();
 	}
 
-	return toggle_good;
+	return toggle_good.c_str();
 }
 
 

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -42,12 +42,16 @@
 runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *dev, const char *port) : tunable("", 0.4, _("Good"), _("Bad"), _("Unknown"))
 {
 	ifstream file;
+	char buffer[4096];
 	sprintf(runtime_path, "%s/power/control", path);
 
 
-	sprintf(desc, _("Runtime PM for %s device %s"), bus, dev);
-	if (!device_has_runtime_pm(path))
-		sprintf(desc, _("%s device %s has no runtime power management"), bus, dev);
+	snprintf(buffer, sizeof(buffer), _("Runtime PM for %s device %s"), bus, dev);
+	desc = buffer;
+	if (!device_has_runtime_pm(path)) {
+		snprintf(buffer, sizeof(buffer), _("%s device %s has no runtime power management"), bus, dev);
+		desc = buffer;
+	}
 
 	if (strcmp(bus, "pci") == 0) {
 		char filename[PATH_MAX];
@@ -70,17 +74,24 @@ runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *
 		}
 
 		if (vendor && device) {
-			if (!device_has_runtime_pm(path))
-				sprintf(desc, _("PCI Device %s has no runtime power management"), pci_id_to_name(vendor, device, filename, 4095));
-			else
-				sprintf(desc, _("Runtime PM for PCI Device %s"), pci_id_to_name(vendor, device, filename, 4095));
+			if (!device_has_runtime_pm(path)) {
+				snprintf(buffer, sizeof(buffer), _("PCI Device %s has no runtime power management"), pci_id_to_name(vendor, device, filename, 4095));
+				desc = buffer;
+			} else {
+				snprintf(buffer, sizeof(buffer), _("Runtime PM for PCI Device %s"), pci_id_to_name(vendor, device, filename, 4095));
+				desc = buffer;
+			}
 		}
 
-		if (string(path).find("ata") != string::npos)
-			sprintf(desc, _("Runtime PM for port %s of PCI device: %s"), port, pci_id_to_name(vendor, device, filename, 4095));
+		if (string(path).find("ata") != string::npos) {
+			snprintf(buffer, sizeof(buffer), _("Runtime PM for port %s of PCI device: %s"), port, pci_id_to_name(vendor, device, filename, 4095));
+			desc = buffer;
+		}
 
-		if (string(path).find("block") != string::npos)
-			sprintf(desc, _("Runtime PM for disk %s"), port);
+		if (string(path).find("block") != string::npos) {
+			snprintf(buffer, sizeof(buffer), _("Runtime PM for disk %s"), port);
+			desc = buffer;
+		}
 
 	}
 	snprintf(toggle_good, sizeof(toggle_good), "echo 'auto' > '%s';", runtime_path);

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -98,9 +98,9 @@ int runtime_tunable::good_bad(void)
 
 	content = read_sysfs_string(runtime_path);
 
-	if (strcmp(content.c_str(), "auto") == 0)
+	if (content == "auto")
 		return TUNE_GOOD;
-	if (strcmp(content.c_str(), "on") == 0)
+	if (content == "on")
 		return TUNE_GOOD;
 
 	return TUNE_BAD;

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -35,6 +35,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <limits.h>
+#include <format>
 
 #include "../lib.h"
 #include "../devices/runtime_pm.h"
@@ -42,15 +43,12 @@
 runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *dev, const char *port) : tunable("", 0.4, _("Good"), _("Bad"), _("Unknown"))
 {
 	ifstream file;
-	char buffer[4096];
 	sprintf(runtime_path, "%s/power/control", path);
 
 
-	snprintf(buffer, sizeof(buffer), _("Runtime PM for %s device %s"), bus, dev);
-	desc = buffer;
+	desc = std::format(_("Runtime PM for {} device {}"), bus, dev);
 	if (!device_has_runtime_pm(path)) {
-		snprintf(buffer, sizeof(buffer), _("%s device %s has no runtime power management"), bus, dev);
-		desc = buffer;
+		desc = std::format(_("{} device {} has no runtime power management"), bus, dev);
 	}
 
 	if (strcmp(bus, "pci") == 0) {
@@ -75,22 +73,18 @@ runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *
 
 		if (vendor && device) {
 			if (!device_has_runtime_pm(path)) {
-				snprintf(buffer, sizeof(buffer), _("PCI Device %s has no runtime power management"), pci_id_to_name(vendor, device, filename, 4095));
-				desc = buffer;
+				desc = std::format(_("PCI Device {} has no runtime power management"), pci_id_to_name(vendor, device, filename, 4095));
 			} else {
-				snprintf(buffer, sizeof(buffer), _("Runtime PM for PCI Device %s"), pci_id_to_name(vendor, device, filename, 4095));
-				desc = buffer;
+				desc = std::format(_("Runtime PM for PCI Device {}"), pci_id_to_name(vendor, device, filename, 4095));
 			}
 		}
 
 		if (string(path).find("ata") != string::npos) {
-			snprintf(buffer, sizeof(buffer), _("Runtime PM for port %s of PCI device: %s"), port, pci_id_to_name(vendor, device, filename, 4095));
-			desc = buffer;
+			desc = std::format(_("Runtime PM for port {} of PCI device: {}"), port, pci_id_to_name(vendor, device, filename, 4095));
 		}
 
 		if (string(path).find("block") != string::npos) {
-			snprintf(buffer, sizeof(buffer), _("Runtime PM for disk %s"), port);
-			desc = buffer;
+			desc = std::format(_("Runtime PM for disk {}"), port);
 		}
 
 	}
@@ -100,7 +94,7 @@ runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *
 
 int runtime_tunable::good_bad(void)
 {
-	string content;
+	std::string content;
 
 	content = read_sysfs_string(runtime_path);
 

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -101,7 +101,7 @@ int runtime_tunable::good_bad(void)
 {
 	std::string content;
 
-	content = read_sysfs_string(runtime_path.c_str());
+	content = read_sysfs_string(runtime_path);
 
 	if (content == "auto")
 		return TUNE_GOOD;

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -119,18 +119,6 @@ void runtime_tunable::toggle(void)
 	write_sysfs(runtime_path.c_str(), "auto");
 }
 
-const char *runtime_tunable::toggle_script(void)
-{
-	int good;
-	good = good_bad();
-
-	if (good == TUNE_GOOD) {
-		return toggle_bad.c_str();
-	}
-
-	return toggle_good.c_str();
-}
-
 
 void add_runtime_tunables(const char *bus)
 {

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -40,22 +40,27 @@
 #include "../lib.h"
 #include "../devices/runtime_pm.h"
 
-runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *dev, const char *port) : tunable("", 0.4, _("Good"), _("Bad"), _("Unknown"))
+runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *dev, const char *port)
+	: runtime_tunable(string(path ? path : ""), string(bus ? bus : ""), string(dev ? dev : ""), string(port ? port : ""))
+{
+}
+
+runtime_tunable::runtime_tunable(const string &path, const string &bus, const string &dev, const string &port) : tunable("", 0.4, _("Good"), _("Bad"), _("Unknown"))
 {
 	ifstream file;
 	runtime_path = std::format("{}/power/control", path);
 
 
 	desc = pt_format(_("Runtime PM for {} device {}"), bus, dev);
-	if (!device_has_runtime_pm(path)) {
+	if (!device_has_runtime_pm(path.c_str())) {
 		desc = pt_format(_("{} device {} has no runtime power management"), bus, dev);
 	}
 
-	if (strcmp(bus, "pci") == 0) {
+	if (bus == "pci") {
 		char filename[PATH_MAX];
 		uint16_t vendor = 0, device = 0;
 
-		snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/vendor", bus, dev);
+		snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/vendor", bus.c_str(), dev.c_str());
 
 		file.open(filename, ios::in);
 		if (file) {
@@ -64,7 +69,7 @@ runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *
 		}
 
 
-		snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/device", bus, dev);
+		snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/device", bus.c_str(), dev.c_str());
 		file.open(filename, ios::in);
 		if (file) {
 			file >> hex >> device;
@@ -72,18 +77,18 @@ runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *
 		}
 
 		if (vendor && device) {
-			if (!device_has_runtime_pm(path)) {
+			if (!device_has_runtime_pm(path.c_str())) {
 				desc = pt_format(_("PCI Device {} has no runtime power management"), pci_id_to_name(vendor, device, filename, 4095));
 			} else {
 				desc = pt_format(_("Runtime PM for PCI Device {}"), pci_id_to_name(vendor, device, filename, 4095));
 			}
 		}
 
-		if (string(path).find("ata") != string::npos) {
+		if (path.find("ata") != string::npos) {
 			desc = pt_format(_("Runtime PM for port {} of PCI device: {}"), port, pci_id_to_name(vendor, device, filename, 4095));
 		}
 
-		if (string(path).find("block") != string::npos) {
+		if (path.find("block") != string::npos) {
 			desc = pt_format(_("Runtime PM for disk {}"), port);
 		}
 
@@ -124,11 +129,11 @@ void add_runtime_tunables(const char *bus)
 {
 	struct dirent *entry;
 	DIR *dir;
-	char filename[PATH_MAX], port[PATH_MAX];
+	std::string filename, port;
 	int max_ports = 32, count=0;
 
-	snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/", bus);
-	dir = opendir(filename);
+	filename = std::format("/sys/bus/{}/devices/", bus);
+	dir = opendir(filename.c_str());
 	if (!dir)
 		return;
 	while (1) {
@@ -141,32 +146,32 @@ void add_runtime_tunables(const char *bus)
 		if (entry->d_name[0] == '.')
 			continue;
 
-		snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/power/control", bus, entry->d_name);
+		filename = std::format("/sys/bus/{}/devices/{}/power/control", bus, entry->d_name);
 
-		if (access(filename, R_OK) != 0)
+		if (access(filename.c_str(), R_OK) != 0)
 			continue;
 
 
-		snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s", bus, entry->d_name);
+		filename = std::format("/sys/bus/{}/devices/{}", bus, entry->d_name);
 
-		runtime = new class runtime_tunable(filename, bus, entry->d_name, NULL);
+		runtime = new class runtime_tunable(filename, bus, entry->d_name, "");
 
-		if (!device_has_runtime_pm(filename))
+		if (!device_has_runtime_pm(filename.c_str()))
 			all_untunables.push_back(runtime);
 		else
 			all_tunables.push_back(runtime);
 
 		for (int i=0; i < max_ports; i++) {
-			snprintf(port, sizeof(port), "ata%d", i);
-			snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/%s/power/control", bus, entry->d_name, port);
+			port = std::format("ata{}", i);
+			filename = std::format("/sys/bus/{}/devices/{}/{}/power/control", bus, entry->d_name, port);
 
-			if (access(filename, R_OK) != 0)
+			if (access(filename.c_str(), R_OK) != 0)
 				continue;
 
-			snprintf(filename, sizeof(filename), "/sys/bus/%s/devices/%s/%s", bus, entry->d_name, port);
+			filename = std::format("/sys/bus/{}/devices/{}/{}", bus, entry->d_name, port);
 			runtime_ahci_port = new class runtime_tunable(filename, bus, entry->d_name, port);
 
-			if (!device_has_runtime_pm(filename))
+			if (!device_has_runtime_pm(filename.c_str()))
 				all_untunables.push_back(runtime_ahci_port);
 			else
 				all_tunables.push_back(runtime_ahci_port);
@@ -177,15 +182,15 @@ void add_runtime_tunables(const char *bus)
 			if (count != 0)
 				break;
 
-			snprintf(filename, sizeof(filename), "/sys/block/sd%c/device/power/control", blk);
+			filename = std::format("/sys/block/sd{}/device/power/control", blk);
 
-			if (access(filename, R_OK) != 0)
+			if (access(filename.c_str(), R_OK) != 0)
 				continue;
 
-			snprintf(port, sizeof(port), "sd%c", blk);
-			snprintf(filename, sizeof(filename), "/sys/block/%s/device", port);
+			port = std::format("sd{}", blk);
+			filename = std::format("/sys/block/{}/device", port);
 			runtime_ahci_disk = new class runtime_tunable(filename, bus, entry->d_name, port);
-			if (!device_has_runtime_pm(filename))
+			if (!device_has_runtime_pm(filename.c_str()))
 				all_untunables.push_back(runtime_ahci_disk);
 			else
 				all_tunables.push_back(runtime_ahci_disk);

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -40,11 +40,6 @@
 #include "../lib.h"
 #include "../devices/runtime_pm.h"
 
-runtime_tunable::runtime_tunable(const char *path, const char *bus, const char *dev, const char *port)
-	: runtime_tunable(string(path ? path : ""), string(bus ? bus : ""), string(dev ? dev : ""), string(port ? port : ""))
-{
-}
-
 runtime_tunable::runtime_tunable(const string &path, const string &bus, const string &dev, const string &port) : tunable("", 0.4, _("Good"), _("Bad"), _("Unknown"))
 {
 	ifstream file;

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -52,7 +52,7 @@ runtime_tunable::runtime_tunable(const string &path, const string &bus, const st
 
 
 	desc = pt_format(_("Runtime PM for {} device {}"), bus, dev);
-	if (!device_has_runtime_pm(path.c_str())) {
+	if (!device_has_runtime_pm(path)) {
 		desc = pt_format(_("{} device {} has no runtime power management"), bus, dev);
 	}
 
@@ -77,7 +77,7 @@ runtime_tunable::runtime_tunable(const string &path, const string &bus, const st
 		}
 
 		if (vendor && device) {
-			if (!device_has_runtime_pm(path.c_str())) {
+			if (!device_has_runtime_pm(path)) {
 				desc = pt_format(_("PCI Device {} has no runtime power management"), pci_id_to_name(vendor, device, filename, 4095));
 			} else {
 				desc = pt_format(_("Runtime PM for PCI Device {}"), pci_id_to_name(vendor, device, filename, 4095));
@@ -156,7 +156,7 @@ void add_runtime_tunables(const char *bus)
 
 		runtime = new class runtime_tunable(filename, bus, entry->d_name, "");
 
-		if (!device_has_runtime_pm(filename.c_str()))
+		if (!device_has_runtime_pm(filename))
 			all_untunables.push_back(runtime);
 		else
 			all_tunables.push_back(runtime);
@@ -171,7 +171,7 @@ void add_runtime_tunables(const char *bus)
 			filename = std::format("/sys/bus/{}/devices/{}/{}", bus, entry->d_name, port);
 			runtime_ahci_port = new class runtime_tunable(filename, bus, entry->d_name, port);
 
-			if (!device_has_runtime_pm(filename.c_str()))
+			if (!device_has_runtime_pm(filename))
 				all_untunables.push_back(runtime_ahci_port);
 			else
 				all_tunables.push_back(runtime_ahci_port);
@@ -190,7 +190,7 @@ void add_runtime_tunables(const char *bus)
 			port = std::format("sd{}", blk);
 			filename = std::format("/sys/block/{}/device", port);
 			runtime_ahci_disk = new class runtime_tunable(filename, bus, entry->d_name, port);
-			if (!device_has_runtime_pm(filename.c_str()))
+			if (!device_has_runtime_pm(filename))
 				all_untunables.push_back(runtime_ahci_disk);
 			else
 				all_tunables.push_back(runtime_ahci_disk);

--- a/src/tuning/runtime.h
+++ b/src/tuning/runtime.h
@@ -35,6 +35,7 @@ class runtime_tunable : public tunable {
 	std::string runtime_path;
 public:
 	runtime_tunable(const char *runtime_path, const char *bus, const char *dev, const char *port);
+	runtime_tunable(const std::string &runtime_path, const std::string &bus, const std::string &dev, const std::string &port);
 
 	virtual int good_bad(void);
 

--- a/src/tuning/runtime.h
+++ b/src/tuning/runtime.h
@@ -32,7 +32,7 @@
 using namespace std;
 
 class runtime_tunable : public tunable {
-	char runtime_path[PATH_MAX];
+	std::string runtime_path;
 public:
 	runtime_tunable(const char *runtime_path, const char *bus, const char *dev, const char *port);
 

--- a/src/tuning/runtime.h
+++ b/src/tuning/runtime.h
@@ -34,7 +34,6 @@ using namespace std;
 class runtime_tunable : public tunable {
 	std::string runtime_path;
 public:
-	runtime_tunable(const char *runtime_path, const char *bus, const char *dev, const char *port);
 	runtime_tunable(const std::string &runtime_path, const std::string &bus, const std::string &dev, const std::string &port);
 
 	virtual int good_bad(void);

--- a/src/tuning/runtime.h
+++ b/src/tuning/runtime.h
@@ -40,8 +40,6 @@ public:
 
 	virtual void toggle(void);
 
-	virtual const char *toggle_script(void);
-
 };
 
 extern void add_runtime_tunables(const char *bus);

--- a/src/tuning/tunable.cpp
+++ b/src/tuning/tunable.cpp
@@ -28,14 +28,14 @@
 #include <string.h>
 #include "../lib.h"
 
-vector<class tunable *> all_tunables;
-vector<class tunable *> all_untunables;
+std::vector<class tunable *> all_tunables;
+std::vector<class tunable *> all_untunables;
 
 
 tunable::tunable(const char *str, double _score, const char *good, const char *bad, const char *neutral)
 {
 	score = _score;
-	pt_strcpy(desc, str);
+	desc = str;
 	pt_strcpy(good_string, good);
 	pt_strcpy(bad_string, bad);
 	pt_strcpy(neutral_string, neutral);
@@ -45,7 +45,7 @@ tunable::tunable(const char *str, double _score, const char *good, const char *b
 tunable::tunable(void)
 {
 	score = 0;
-	desc[0] = 0;
+	desc = "";
 	pt_strcpy(good_string, _("Good"));
 	pt_strcpy(bad_string, _("Bad"));
 	pt_strcpy(neutral_string, _("Unknown"));

--- a/src/tuning/tunable.cpp
+++ b/src/tuning/tunable.cpp
@@ -32,10 +32,10 @@ std::vector<class tunable *> all_tunables;
 std::vector<class tunable *> all_untunables;
 
 
-tunable::tunable(const char *str, double _score, const char *good, const char *bad, const char *neutral)
+tunable::tunable(const string &str, double _score, const string &good, const string &bad, const string &neutral)
 {
-	score = _score;
 	desc = str;
+	score = _score;
 	good_string = good;
 	bad_string = bad;
 	neutral_string = neutral;

--- a/src/tuning/tunable.cpp
+++ b/src/tuning/tunable.cpp
@@ -36,9 +36,9 @@ tunable::tunable(const char *str, double _score, const char *good, const char *b
 {
 	score = _score;
 	desc = str;
-	pt_strcpy(good_string, good);
-	pt_strcpy(bad_string, bad);
-	pt_strcpy(neutral_string, neutral);
+	good_string = good;
+	bad_string = bad;
+	neutral_string = neutral;
 }
 
 
@@ -46,7 +46,7 @@ tunable::tunable(void)
 {
 	score = 0;
 	desc = "";
-	pt_strcpy(good_string, _("Good"));
-	pt_strcpy(bad_string, _("Bad"));
-	pt_strcpy(neutral_string, _("Unknown"));
+	good_string = _("Good");
+	bad_string = _("Bad");
+	neutral_string = _("Unknown");
 }

--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -62,19 +62,7 @@ public:
 
 	virtual int good_bad(void) { return TUNE_NEUTRAL; }
 
-	virtual const char *result_string(void)
-	{
-		switch (good_bad()) {
-		case TUNE_GOOD:
-			return good_string.c_str();
-		case TUNE_BAD:
-		case TUNE_UNFIXABLE:
-			return bad_string.c_str();
-		}
-		return neutral_string.c_str();
-	}
-
-	virtual std::string result_string_s(void)
+	virtual std::string result_string(void)
 	{
 		switch (good_bad()) {
 		case TUNE_GOOD:

--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -41,12 +41,12 @@ using namespace std;
 
 class tunable {
 
-	char good_string[128];
-	char bad_string[128];
-	char neutral_string[128];
+	std::string good_string;
+	std::string bad_string;
+	std::string neutral_string;
 protected:
-	char toggle_good[4096];
-	char toggle_bad[4096];
+	std::string toggle_good;
+	std::string toggle_bad;
 public:
 	std::string desc;
 	double score;
@@ -55,14 +55,26 @@ public:
 	tunable(const char *str, double _score, const char *good = "", const char *bad = "", const char *neutral ="");
 
 	void dump_cmd_good(FILE *fp) {
-		(void) fprintf(fp, "\n### %s\n# %s\n", desc.c_str(), toggle_good);
+		(void) fprintf(fp, "\n### %s\n# %s\n", desc.c_str(), toggle_good.c_str());
 	}
 
 	virtual ~tunable() {};
 
 	virtual int good_bad(void) { return TUNE_NEUTRAL; }
 
-	virtual char *result_string(void)
+	virtual const char *result_string(void)
+	{
+		switch (good_bad()) {
+		case TUNE_GOOD:
+			return good_string.c_str();
+		case TUNE_BAD:
+		case TUNE_UNFIXABLE:
+			return bad_string.c_str();
+		}
+		return neutral_string.c_str();
+	}
+
+	virtual std::string result_string_s(void)
 	{
 		switch (good_bad()) {
 		case TUNE_GOOD:
@@ -81,6 +93,12 @@ public:
 	virtual void toggle(void) { };
 
 	virtual const char *toggle_script(void) { return NULL; }
+	virtual std::string toggle_script_s(void) {
+		const char *c = toggle_script();
+		if (c)
+			return c;
+		return "";
+	}
 };
 
 extern std::vector<class tunable *> all_tunables;

--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -52,7 +52,7 @@ public:
 	double score;
 
 	tunable(void);
-	tunable(const char *str, double _score, const char *good = "", const char *bad = "", const char *neutral ="");
+	tunable(const std::string &str, double _score, const std::string &good = "", const std::string &bad = "", const std::string &neutral ="");
 
 	void dump_cmd_good(FILE *fp) {
 		(void) fprintf(fp, "\n### %s\n# %s\n", desc.c_str(), toggle_good.c_str());
@@ -83,15 +83,6 @@ public:
 		if (good_bad() == TUNE_GOOD)
 			return toggle_bad;
 		return toggle_good;
-	}
-
-	virtual const char *toggle_script_c(void) {
-		std::string s = toggle_script();
-		if (s.empty())
-			return NULL;
-		if (good_bad() == TUNE_GOOD)
-			return toggle_bad.c_str();
-		return toggle_good.c_str();
 	}
 };
 

--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -92,12 +92,19 @@ public:
 
 	virtual void toggle(void) { };
 
-	virtual const char *toggle_script(void) { return NULL; }
-	virtual std::string toggle_script_s(void) {
-		const char *c = toggle_script();
-		if (c)
-			return c;
-		return "";
+	virtual std::string toggle_script(void) {
+		if (good_bad() == TUNE_GOOD)
+			return toggle_bad;
+		return toggle_good;
+	}
+
+	virtual const char *toggle_script_c(void) {
+		std::string s = toggle_script();
+		if (s.empty())
+			return NULL;
+		if (good_bad() == TUNE_GOOD)
+			return toggle_bad.c_str();
+		return toggle_good.c_str();
 	}
 };
 

--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -87,8 +87,7 @@ public:
 	}
 
 
-	virtual const char *description(void) { return desc.c_str(); };
-	virtual std::string description_s(void) { return desc; };
+	virtual std::string description(void) { return desc; };
 
 	virtual void toggle(void) { };
 

--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -29,6 +29,8 @@
 
 #include "../lib.h"
 
+#include <string>
+
 using namespace std;
 
 #define TUNE_GOOD    1
@@ -46,14 +48,14 @@ protected:
 	char toggle_good[4096];
 	char toggle_bad[4096];
 public:
-	char desc[4096];
+	std::string desc;
 	double score;
 
 	tunable(void);
 	tunable(const char *str, double _score, const char *good = "", const char *bad = "", const char *neutral ="");
 
 	void dump_cmd_good(FILE *fp) {
-		(void) fprintf(fp, "\n### %s\n# %s\n", desc, toggle_good);
+		(void) fprintf(fp, "\n### %s\n# %s\n", desc.c_str(), toggle_good);
 	}
 
 	virtual ~tunable() {};
@@ -73,14 +75,15 @@ public:
 	}
 
 
-	virtual const char *description(void) { return desc; };
+	virtual const char *description(void) { return desc.c_str(); };
+	virtual std::string description_s(void) { return desc; };
 
 	virtual void toggle(void) { };
 
 	virtual const char *toggle_script(void) { return NULL; }
 };
 
-extern vector<class tunable *> all_tunables;
-extern vector<class tunable *> all_untunables;
+extern std::vector<class tunable *> all_tunables;
+extern std::vector<class tunable *> all_untunables;
 
 #endif

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -110,11 +110,8 @@ static void __tuning_update_display(int cursor_pos)
 	wmove(win, 2,0);
 
 	for (i = 0; i < all_tunables.size(); i++) {
-		char res[128];
+		std::string res = all_tunables[i]->result_string();
 		std::string desc = all_tunables[i]->description();
-		pt_strcpy(res, all_tunables[i]->result_string());
-		while (strlen(res) < 12)
-			strcat(res, " ");
 
 		if ((int)i != cursor_pos) {
 			wattrset(win, A_NORMAL);
@@ -123,7 +120,7 @@ static void __tuning_update_display(int cursor_pos)
 			wattrset(win, A_REVERSE);
 			wprintw(win, ">> ");
 		}
-		wprintw(win, "%s  %-103s\n", _(res), _(desc.c_str()));
+		wprintw(win, "%-12s  %-103s\n", _(res.c_str()), _(desc.c_str()));
 	}
 }
 

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -110,8 +110,11 @@ static void __tuning_update_display(int cursor_pos)
 	wmove(win, 2,0);
 
 	for (i = 0; i < all_tunables.size(); i++) {
-		std::string res = all_tunables[i]->result_string();
-		std::string desc = all_tunables[i]->description();
+		std::string res = _(all_tunables[i]->result_string().c_str());
+		std::string desc = _(all_tunables[i]->description().c_str());
+
+		align_string(res, 12, 12);
+		align_string(desc, 103, 103);
 
 		if ((int)i != cursor_pos) {
 			wattrset(win, A_NORMAL);
@@ -120,7 +123,7 @@ static void __tuning_update_display(int cursor_pos)
 			wattrset(win, A_REVERSE);
 			wprintw(win, ">> ");
 		}
-		wprintw(win, "%-12s  %-103s\n", _(res.c_str()), _(desc.c_str()));
+		wprintw(win, "%s  %s\n", res.c_str(), desc.c_str());
 	}
 }
 

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -154,7 +154,7 @@ void tuning_window::cursor_enter(void)
 		return;
 	/** device will change its state so need to store toggle script before
 	 * we toggle()*/
-	toggle_script = tun->toggle_script();
+	toggle_script = tun->toggle_script_c();
 	tun->toggle();
 	ui_notify_user(">> %s\n", toggle_script);
 }

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -142,15 +142,16 @@ void tuning_window::repaint(void)
 void tuning_window::cursor_enter(void)
 {
 	class tunable *tun;
-	const char *toggle_script;
+	std::string toggle_script;
 	tun = all_tunables[cursor_pos];
 	if (!tun)
 		return;
 	/** device will change its state so need to store toggle script before
 	 * we toggle()*/
-	toggle_script = tun->toggle_script_c();
+	toggle_script = tun->toggle_script();
 	tun->toggle();
-	ui_notify_user(">> %s\n", toggle_script);
+	if (!toggle_script.empty())
+		ui_notify_user(">> %s\n", toggle_script.c_str());
 }
 
 static bool tunables_sort(class tunable * i, class tunable * j)

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -111,14 +111,11 @@ static void __tuning_update_display(int cursor_pos)
 
 	for (i = 0; i < all_tunables.size(); i++) {
 		char res[128];
-		char desc[4096];
+		std::string desc = all_tunables[i]->description();
 		pt_strcpy(res, all_tunables[i]->result_string());
-		pt_strcpy(desc, all_tunables[i]->description());
 		while (strlen(res) < 12)
 			strcat(res, " ");
 
-		while (strlen(desc) < 103)
-			strcat(desc, " ");
 		if ((int)i != cursor_pos) {
 			wattrset(win, A_NORMAL);
 			wprintw(win, "   ");
@@ -126,7 +123,7 @@ static void __tuning_update_display(int cursor_pos)
 			wattrset(win, A_REVERSE);
 			wprintw(win, ">> ");
 		}
-		wprintw(win, "%s  %s\n", _(res), _(desc));
+		wprintw(win, "%s  %-103s\n", _(res), _(desc.c_str()));
 	}
 }
 
@@ -176,10 +173,7 @@ static bool tunables_sort(class tunable * i, class tunable * j)
 	if (d > 0.0001)
 		return i->score > j->score;
 
-	if (strcasecmp(i->description(), j->description()) == -1)
-		return true;
-
-	return false;
+	return i->description() < j->description();
 }
 
 void tuning_window::window_refresh()
@@ -247,7 +241,7 @@ void report_show_tunables(void)
 			gb = all_tunables[i]->good_bad();
 			if (gb != TUNE_BAD)
 				continue;
-			tunable_data[idx]=string(all_tunables[i]->description());
+			tunable_data[idx]=all_tunables[i]->description();
 			idx+=1;
 			tunable_data[idx]=string(all_tunables[i]->toggle_script());
 			idx+=1;
@@ -269,9 +263,9 @@ void report_show_tunables(void)
 	string *untunable_data = new string[rows];
 	untunable_data[0]=__("Description");
 
-	for (i = 0; i < all_untunables.size(); i++)
-		untunable_data[i+1]= string(all_untunables[i]->description());
-
+	for (i = 0; i < all_untunables.size(); i++) {
+		untunable_data[i+1]= all_untunables[i]->description();
+	}
 	/* Report Output */
 	report.add_title(&title_attr,__("Untunable Software Issues"));
 	report.add_table(untunable_data, &tune_table_css);
@@ -300,7 +294,7 @@ void report_show_tunables(void)
 		if (gb != TUNE_GOOD)
 			continue;
 
-		tuned_data[idx]=string(all_tunables[i]->description());
+		tuned_data[idx]=all_tunables[i]->description();
 		idx+=1;
         }
 	/* Report Output */

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -54,7 +54,7 @@ i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : 
 		filename = std::format("{}/device", path);
 	}
 
-	if (device_has_runtime_pm(filename.c_str())) {
+	if (device_has_runtime_pm(filename)) {
 		desc = pt_format(_("Runtime PM for I2C {} {} ({})"), (is_adapter ? _("Adapter") : _("Device")), name, devname);
 	} else {
 		desc = pt_format(_("I2C {} {} has no runtime power management"), (is_adapter ? _("Adapter") : _("Device")), name);
@@ -107,7 +107,7 @@ static void add_i2c_callback(const char *d_name)
 	else
 		filename = std::format("/sys/bus/i2c/devices/{}", d_name);
 
-	if (device_has_runtime_pm(filename.c_str()))
+	if (device_has_runtime_pm(filename))
 		all_tunables.push_back(i2c);
 	else
 		all_untunables.push_back(i2c);

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -89,18 +89,6 @@ void i2c_tunable::toggle(void)
 	write_sysfs(i2c_path.c_str(), "auto");
 }
 
-const char *i2c_tunable::toggle_script(void)
-{
-	int good;
-	good = good_bad();
-
-	if (good == TUNE_GOOD) {
-		return toggle_bad.c_str();
-	}
-
-	return toggle_good.c_str();
-}
-
 static void add_i2c_callback(const char *d_name)
 {
 	class i2c_tunable *i2c;

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -36,11 +36,11 @@
 i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : tunable("", 0.9, _("Good"), _("Bad"), _("Unknown"))
 {
 	ifstream file;
-	char filename[PATH_MAX];
+	std::string filename;
 	std::string devname;
 
-	snprintf(filename, sizeof(filename), "%s/name", path);
-	file.open(filename, ios::in);
+	filename = std::format("{}/name", path);
+	file.open(filename.c_str(), ios::in);
 	if (file) {
 		getline(file, devname);
 		file.close();
@@ -48,13 +48,13 @@ i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : 
 
 	if (is_adapter) {
 		i2c_path = std::format("{}/device/power/control", path);
-		snprintf(filename, sizeof(filename), "%s/device", path);
+		filename = std::format("{}/device", path);
 	} else {
 		i2c_path = std::format("{}/power/control", path);
-		snprintf(filename, sizeof(filename), "%s/device", path);
+		filename = std::format("{}/device", path);
 	}
 
-	if (device_has_runtime_pm(filename)) {
+	if (device_has_runtime_pm(filename.c_str())) {
 		desc = pt_format(_("Runtime PM for I2C {} {} ({})"), (is_adapter ? _("Adapter") : _("Device")), name, devname);
 	} else {
 		desc = pt_format(_("I2C {} {} has no runtime power management"), (is_adapter ? _("Adapter") : _("Device")), name);
@@ -92,22 +92,22 @@ void i2c_tunable::toggle(void)
 static void add_i2c_callback(const char *d_name)
 {
 	class i2c_tunable *i2c;
-	char filename[PATH_MAX];
+	std::string filename;
 	bool is_adapter = false;
 
-	snprintf(filename, PATH_MAX, "/sys/bus/i2c/devices/%s/new_device", d_name);
-	if (access(filename, W_OK) == 0)
+	filename = std::format("/sys/bus/i2c/devices/{}/new_device", d_name);
+	if (access(filename.c_str(), W_OK) == 0)
 		is_adapter = true;
 
-	snprintf(filename, PATH_MAX, "/sys/bus/i2c/devices/%s", d_name);
-	i2c = new class i2c_tunable(filename, d_name, is_adapter);
+	filename = std::format("/sys/bus/i2c/devices/{}", d_name);
+	i2c = new class i2c_tunable(filename.c_str(), d_name, is_adapter);
 
 	if (is_adapter)
-		snprintf(filename, PATH_MAX, "/sys/bus/i2c/devices/%s/device", d_name);
+		filename = std::format("/sys/bus/i2c/devices/{}/device", d_name);
 	else
-		snprintf(filename, PATH_MAX, "/sys/bus/i2c/devices/%s", d_name);
+		filename = std::format("/sys/bus/i2c/devices/{}", d_name);
 
-	if (device_has_runtime_pm(filename))
+	if (device_has_runtime_pm(filename.c_str()))
 		all_tunables.push_back(i2c);
 	else
 		all_untunables.push_back(i2c);

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -28,6 +28,7 @@
 #include <fstream>
 #include <ctype.h>
 #include <limits.h>
+#include <format>
 
 #include "../lib.h"
 #include "../devices/runtime_pm.h"
@@ -37,7 +38,6 @@ i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : 
 	ifstream file;
 	char filename[PATH_MAX];
 	std::string devname;
-	char buffer[4096];
 
 	snprintf(filename, sizeof(filename), "%s/name", path);
 	file.open(filename, ios::in);
@@ -55,11 +55,9 @@ i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : 
 	}
 
 	if (device_has_runtime_pm(filename)) {
-		snprintf(buffer, sizeof(buffer), _("Runtime PM for I2C %s %s (%s)"), (is_adapter ? _("Adapter") : _("Device")), name, (devname.empty() ? "" : devname.c_str()));
-		desc = buffer;
+		desc = std::format(_("Runtime PM for I2C {} {} ({})"), (is_adapter ? _("Adapter") : _("Device")), name, devname);
 	} else {
-		snprintf(buffer, sizeof(buffer), _("I2C %s %s has no runtime power management"), (is_adapter ? _("Adapter") : _("Device")), name);
-		desc = buffer;
+		desc = std::format(_("I2C {} {} has no runtime power management"), (is_adapter ? _("Adapter") : _("Device")), name);
 	}
 
 	snprintf(toggle_good, sizeof(toggle_good), "echo 'auto' > '%s';", i2c_path);

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -68,7 +68,7 @@ int i2c_tunable::good_bad(void)
 {
 	std::string content;
 
-	content = read_sysfs_string(i2c_path.c_str());
+	content = read_sysfs_string(i2c_path);
 
 	if (content == "auto")
 		return TUNE_GOOD;

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -33,7 +33,7 @@
 #include "../lib.h"
 #include "../devices/runtime_pm.h"
 
-i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : tunable("", 0.9, _("Good"), _("Bad"), _("Unknown"))
+i2c_tunable::i2c_tunable(const string &path, const string &name, bool is_adapter) : tunable("", 0.9, _("Good"), _("Bad"), _("Unknown"))
 {
 	ifstream file;
 	std::string filename;

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -70,7 +70,7 @@ int i2c_tunable::good_bad(void)
 
 	content = read_sysfs_string(i2c_path);
 
-	if (strcmp(content.c_str(), "auto") == 0)
+	if (content == "auto")
 		return TUNE_GOOD;
 
 	return TUNE_BAD;

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -47,10 +47,10 @@ i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : 
 	}
 
 	if (is_adapter) {
-		snprintf(i2c_path, sizeof(i2c_path), "%s/device/power/control", path);
+		i2c_path = std::format("{}/device/power/control", path);
 		snprintf(filename, sizeof(filename), "%s/device", path);
 	} else {
-		snprintf(i2c_path, sizeof(i2c_path),  "%s/power/control", path);
+		i2c_path = std::format("{}/power/control", path);
 		snprintf(filename, sizeof(filename), "%s/device", path);
 	}
 
@@ -60,15 +60,15 @@ i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : 
 		desc = std::format(_("I2C {} {} has no runtime power management"), (is_adapter ? _("Adapter") : _("Device")), name);
 	}
 
-	snprintf(toggle_good, sizeof(toggle_good), "echo 'auto' > '%s';", i2c_path);
-	snprintf(toggle_bad, sizeof(toggle_bad), "echo 'on' > '%s';", i2c_path);
+	toggle_good = std::format("echo 'auto' > '{}';", i2c_path);
+	toggle_bad = std::format("echo 'on' > '{}';", i2c_path);
 }
 
 int i2c_tunable::good_bad(void)
 {
 	std::string content;
 
-	content = read_sysfs_string(i2c_path);
+	content = read_sysfs_string(i2c_path.c_str());
 
 	if (content == "auto")
 		return TUNE_GOOD;
@@ -82,11 +82,11 @@ void i2c_tunable::toggle(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		write_sysfs(i2c_path, "on");
+		write_sysfs(i2c_path.c_str(), "on");
 		return;
 	}
 
-	write_sysfs(i2c_path, "auto");
+	write_sysfs(i2c_path.c_str(), "auto");
 }
 
 const char *i2c_tunable::toggle_script(void)
@@ -95,10 +95,10 @@ const char *i2c_tunable::toggle_script(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		return toggle_bad;
+		return toggle_bad.c_str();
 	}
 
-	return toggle_good;
+	return toggle_good.c_str();
 }
 
 static void add_i2c_callback(const char *d_name)

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -55,9 +55,9 @@ i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : 
 	}
 
 	if (device_has_runtime_pm(filename)) {
-		desc = std::format(_("Runtime PM for I2C {} {} ({})"), (is_adapter ? _("Adapter") : _("Device")), name, devname);
+		desc = pt_format(_("Runtime PM for I2C {} {} ({})"), (is_adapter ? _("Adapter") : _("Device")), name, devname);
 	} else {
-		desc = std::format(_("I2C {} {} has no runtime power management"), (is_adapter ? _("Adapter") : _("Device")), name);
+		desc = pt_format(_("I2C {} {} has no runtime power management"), (is_adapter ? _("Adapter") : _("Device")), name);
 	}
 
 	toggle_good = std::format("echo 'auto' > '{}';", i2c_path);

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -36,7 +36,8 @@ i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : 
 {
 	ifstream file;
 	char filename[PATH_MAX];
-	string devname;
+	std::string devname;
+	char buffer[4096];
 
 	snprintf(filename, sizeof(filename), "%s/name", path);
 	file.open(filename, ios::in);
@@ -53,10 +54,13 @@ i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : 
 		snprintf(filename, sizeof(filename), "%s/device", path);
 	}
 
-	if (device_has_runtime_pm(filename))
-		snprintf(desc, sizeof(desc), _("Runtime PM for I2C %s %s (%s)"), (is_adapter ? _("Adapter") : _("Device")), name, (devname.empty() ? "" : devname.c_str()));
-	else
-		snprintf(desc, sizeof(desc), _("I2C %s %s has no runtime power management"), (is_adapter ? _("Adapter") : _("Device")), name);
+	if (device_has_runtime_pm(filename)) {
+		snprintf(buffer, sizeof(buffer), _("Runtime PM for I2C %s %s (%s)"), (is_adapter ? _("Adapter") : _("Device")), name, (devname.empty() ? "" : devname.c_str()));
+		desc = buffer;
+	} else {
+		snprintf(buffer, sizeof(buffer), _("I2C %s %s has no runtime power management"), (is_adapter ? _("Adapter") : _("Device")), name);
+		desc = buffer;
+	}
 
 	snprintf(toggle_good, sizeof(toggle_good), "echo 'auto' > '%s';", i2c_path);
 	snprintf(toggle_bad, sizeof(toggle_bad), "echo 'on' > '%s';", i2c_path);
@@ -64,7 +68,7 @@ i2c_tunable::i2c_tunable(const char *path, const char *name, bool is_adapter) : 
 
 int i2c_tunable::good_bad(void)
 {
-	string content;
+	std::string content;
 
 	content = read_sysfs_string(i2c_path);
 

--- a/src/tuning/tuningi2c.h
+++ b/src/tuning/tuningi2c.h
@@ -36,8 +36,6 @@ public:
 
 	virtual void toggle(void);
 
-	virtual const char *toggle_script(void);
-
 };
 
 extern void add_i2c_tunables(void);

--- a/src/tuning/tuningi2c.h
+++ b/src/tuning/tuningi2c.h
@@ -30,7 +30,7 @@ using namespace std;
 class i2c_tunable : public tunable {
 	std::string i2c_path;
 public:
-	i2c_tunable(const char *path, const char *name, bool is_adapter);
+	i2c_tunable(const std::string &path, const std::string &name, bool is_adapter);
 
 	virtual int good_bad(void);
 

--- a/src/tuning/tuningi2c.h
+++ b/src/tuning/tuningi2c.h
@@ -28,7 +28,7 @@
 using namespace std;
 
 class i2c_tunable : public tunable {
-	char i2c_path[PATH_MAX];
+	std::string i2c_path;
 public:
 	i2c_tunable(const char *path, const char *name, bool is_adapter);
 

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -25,51 +25,37 @@
 
 #include "tuning.h"
 #include "tunable.h"
-#include "unistd.h"
+#include <unistd.h>
 #include "tuningsysfs.h"
 #include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
+#include <dirent.h>
 #include <utility>
 #include <iostream>
 #include <fstream>
-#include <unistd.h>
-#include <sys/types.h>
-#include <dirent.h>
 #include <limits.h>
-
+#include <format>
 
 #include "../lib.h"
 
-sysfs_tunable::sysfs_tunable(const char *str, const char *_sysfs_path, const char *_target_content) : tunable(str, 1.0, _("Good"), _("Bad"), _("Unknown"))
+sysfs_tunable::sysfs_tunable(const char *str, const char *_sysfs_path, const char *_target_content) : tunable(str, 1.5, _("Good"), _("Bad"), _("Unknown"))
 {
-	pt_strcpy(sysfs_path, _sysfs_path);
-	pt_strcpy(target_value, _target_content);
-	bad_value[0] = 0;
-	snprintf(toggle_good, sizeof(toggle_good), "echo '%s' > '%s';", target_value, sysfs_path);
-	snprintf(toggle_bad, sizeof(toggle_bad), "echo '%s' > '%s';", bad_value, sysfs_path);
+	sysfs_path = _sysfs_path;
+	target_value = _target_content;
+	bad_value = read_sysfs_string(_sysfs_path);
+
+	toggle_good = std::format("echo '{}' > '{}';", target_value, sysfs_path);
+	toggle_bad = std::format("echo '{}' > '{}';", bad_value, sysfs_path);
 }
 
 int sysfs_tunable::good_bad(void)
 {
-	char current_value[4096], *c;
-	ifstream file;
+	std::string content;
 
-	file.open(sysfs_path, ios::in);
-	if (!file)
-		return TUNE_NEUTRAL;
-	file.getline(current_value, 4096);
-	file.close();
+	content = read_sysfs_string(sysfs_path.c_str());
 
-	c = strchr(current_value, '\n');
-	if (c)
-		*c = 0;
-
-	if (strcmp(current_value, target_value) == 0)
+	if (content == target_value)
 		return TUNE_GOOD;
 
-	pt_strcpy(bad_value, current_value);
 	return TUNE_BAD;
 }
 
@@ -79,52 +65,45 @@ void sysfs_tunable::toggle(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		if (strlen(bad_value) > 0)
-			write_sysfs(sysfs_path, bad_value);
+		write_sysfs(sysfs_path.c_str(), bad_value.c_str());
 		return;
 	}
 
-	write_sysfs(sysfs_path, target_value);
+	write_sysfs(sysfs_path.c_str(), target_value.c_str());
 }
 
-const char *sysfs_tunable::toggle_script(void) {
+const char *sysfs_tunable::toggle_script(void)
+{
 	int good;
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		if (strlen(bad_value) > 0)
-			return toggle_bad;
-		return NULL;
+		return toggle_bad.c_str();
 	}
 
-	return toggle_good;
+	return toggle_good.c_str();
 }
 
 
 void add_sysfs_tunable(const char *str, const char *_sysfs_path, const char *_target_content)
 {
-	class sysfs_tunable *tunable;
+	class sysfs_tunable *st;
 
-	if (access(_sysfs_path, R_OK) != 0)
-		return;
-
-	tunable = new class sysfs_tunable(str, _sysfs_path, _target_content);
-
-
-	all_tunables.push_back(tunable);
+	st = new class sysfs_tunable(str, _sysfs_path, _target_content);
+	all_tunables.push_back(st);
 }
 
-static void add_sata_tunables_callback(const char *d_name)
+static void add_sata_callback(const char *d_name)
 {
 	char filename[PATH_MAX];
-	char msg[4096];
-
 	snprintf(filename, sizeof(filename), "/sys/class/scsi_host/%s/link_power_management_policy", d_name);
-	snprintf(msg, sizeof(msg), _("Enable SATA link power management for %s"), d_name);
-	add_sysfs_tunable(msg, filename, "med_power_with_dipm");
+	if (access(filename, R_OK) != 0)
+		return;
+
+	add_sysfs_tunable(_("SATA link power management for host"), filename, "min_power");
 }
 
 void add_sata_tunables(void)
 {
-	process_directory("/sys/class/scsi_host", add_sata_tunables_callback);
+	process_directory("/sys/class/scsi_host/", add_sata_callback);
 }

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -83,12 +83,12 @@ void add_sysfs_tunable(const char *str, const char *_sysfs_path, const char *_ta
 
 static void add_sata_callback(const char *d_name)
 {
-	char filename[PATH_MAX];
-	snprintf(filename, sizeof(filename), "/sys/class/scsi_host/%s/link_power_management_policy", d_name);
-	if (access(filename, R_OK) != 0)
+	std::string filename;
+	filename = std::format("/sys/class/scsi_host/{}/link_power_management_policy", d_name);
+	if (access(filename.c_str(), R_OK) != 0)
 		return;
 
-	add_sysfs_tunable(_("SATA link power management for host"), filename, "min_power");
+	add_sysfs_tunable(_("SATA link power management for host"), filename.c_str(), "min_power");
 }
 
 void add_sata_tunables(void)

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -51,7 +51,7 @@ int sysfs_tunable::good_bad(void)
 {
 	std::string content;
 
-	content = read_sysfs_string(sysfs_path.c_str());
+	content = read_sysfs_string(sysfs_path);
 
 	if (content == target_value)
 		return TUNE_GOOD;

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -72,18 +72,6 @@ void sysfs_tunable::toggle(void)
 	write_sysfs(sysfs_path.c_str(), target_value.c_str());
 }
 
-const char *sysfs_tunable::toggle_script(void)
-{
-	int good;
-	good = good_bad();
-
-	if (good == TUNE_GOOD) {
-		return toggle_bad.c_str();
-	}
-
-	return toggle_good.c_str();
-}
-
 
 void add_sysfs_tunable(const char *str, const char *_sysfs_path, const char *_target_content)
 {

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -36,11 +36,10 @@
 #include <format>
 
 #include "../lib.h"
-
-sysfs_tunable::sysfs_tunable(const char *str, const char *_sysfs_path, const char *_target_content) : tunable(str, 1.5, _("Good"), _("Bad"), _("Unknown"))
+sysfs_tunable::sysfs_tunable(const string &str, const string &_sysfs_path, const string &target_content) : tunable(str, 1.0, _("Good"), _("Bad"), _("Unknown"))
 {
 	sysfs_path = _sysfs_path;
-	target_value = _target_content;
+	target_value = target_content;
 	bad_value = read_sysfs_string(_sysfs_path);
 
 	toggle_good = std::format("echo '{}' > '{}';", target_value, sysfs_path);

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -40,10 +40,8 @@ sysfs_tunable::sysfs_tunable(const string &str, const string &_sysfs_path, const
 {
 	sysfs_path = _sysfs_path;
 	target_value = target_content;
-	bad_value = read_sysfs_string(_sysfs_path);
 
 	toggle_good = std::format("echo '{}' > '{}';", target_value, sysfs_path);
-	toggle_bad = std::format("echo '{}' > '{}';", bad_value, sysfs_path);
 }
 
 int sysfs_tunable::good_bad(void)
@@ -55,6 +53,8 @@ int sysfs_tunable::good_bad(void)
 	if (content == target_value)
 		return TUNE_GOOD;
 
+	bad_value = content;
+	toggle_bad = std::format("echo '{}' > '{}';", bad_value, sysfs_path);
 	return TUNE_BAD;
 }
 
@@ -64,7 +64,8 @@ void sysfs_tunable::toggle(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		write_sysfs(sysfs_path.c_str(), bad_value.c_str());
+		if (bad_value.length() > 0)
+			write_sysfs(sysfs_path.c_str(), bad_value.c_str());
 		return;
 	}
 
@@ -87,7 +88,7 @@ static void add_sata_callback(const char *d_name)
 	if (access(filename.c_str(), R_OK) != 0)
 		return;
 
-	add_sysfs_tunable(_("SATA link power management for host"), filename.c_str(), "min_power");
+	add_sysfs_tunable(pt_format(_("Enable SATA link power management for {}"), d_name).c_str(), filename.c_str(), "med_power_with_dipm");
 }
 
 void add_sata_tunables(void)

--- a/src/tuning/tuningsysfs.h
+++ b/src/tuning/tuningsysfs.h
@@ -33,9 +33,9 @@
 using namespace std;
 
 class sysfs_tunable : public tunable {
-	char sysfs_path[PATH_MAX];
-	char target_value[4096];
-	char bad_value[4096];
+	std::string sysfs_path;
+	std::string target_value;
+	std::string bad_value;
 public:
 	sysfs_tunable(const char *str, const char *sysfs_path, const char *target_content);
 

--- a/src/tuning/tuningsysfs.h
+++ b/src/tuning/tuningsysfs.h
@@ -43,8 +43,6 @@ public:
 
 	virtual void toggle(void);
 
-	virtual const char *toggle_script(void);
-
 };
 
 extern void add_sysfs_tunable(const char *str, const char *_sysfs_path, const char *_target_content);

--- a/src/tuning/tuningsysfs.h
+++ b/src/tuning/tuningsysfs.h
@@ -37,7 +37,7 @@ class sysfs_tunable : public tunable {
 	std::string target_value;
 	std::string bad_value;
 public:
-	sysfs_tunable(const char *str, const char *sysfs_path, const char *target_content);
+	sysfs_tunable(const std::string &str, const std::string &sysfs_path, const std::string &target_content);
 
 	virtual int good_bad(void);
 

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -50,7 +50,7 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 	str1 = read_sysfs_string("%s/idVendor", path);
 	str2 = read_sysfs_string("%s/idProduct", path);
 
-	desc = std::format(_("Autosuspend for unknown USB device {} ({}:{})"), name, str1, str2);
+	desc = pt_format(_("Autosuspend for unknown USB device {} ({}:{})"), name, str1, str2);
 
 	snprintf(filename, sizeof(filename), "%s/manufacturer", path);
 	file.open(filename, ios::in);
@@ -67,11 +67,11 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 		file.close();
 	};
 	if (strlen(vendor) && strlen(product)) {
-		desc = std::format(_("Autosuspend for USB device {} [{}]"), product, vendor);
+		desc = pt_format(_("Autosuspend for USB device {} [{}]"), product, vendor);
 	} else if (strlen(product)) {
-		desc = std::format(_("Autosuspend for USB device {} [{}]"), product, name);
+		desc = pt_format(_("Autosuspend for USB device {} [{}]"), product, name);
 	} else if (strlen(vendor)) {
-		desc = std::format(_("Autosuspend for USB device {} [{}]"), vendor, name);
+		desc = pt_format(_("Autosuspend for USB device {} [{}]"), vendor, name);
 	}
 
 	toggle_good = std::format("echo 'auto' > '{}';", usb_path);

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -40,9 +40,8 @@
 usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, _("Good"), _("Bad"), _("Unknown"))
 {
 	ifstream file;
-	char filename[PATH_MAX];
-	char vendor[2048];
-	char product[2048];
+	std::string vendor;
+	std::string product;
 	std::string str1, str2;
 
 	usb_path = std::format("{}/power/control", path);
@@ -52,25 +51,23 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 
 	desc = pt_format(_("Autosuspend for unknown USB device {} ({}:{})"), name, str1, str2);
 
-	snprintf(filename, sizeof(filename), "%s/manufacturer", path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/manufacturer", path), ios::in);
 	if (file) {
-		file.getline(vendor, 2047);
-		if (strstr(vendor, "Linux "))
-			vendor[0] = 0;
+		getline(file, vendor);
+		if (vendor.starts_with("Linux "))
+			vendor = "";
 		file.close();
 	};
-	snprintf(filename, sizeof(filename), "%s/product", path);
-	file.open(filename, ios::in);
+	file.open(std::format("{}/product", path), ios::in);
 	if (file) {
-		file.getline(product, 2040);
+		getline(file, product);
 		file.close();
 	};
-	if (strlen(vendor) && strlen(product)) {
+	if (!vendor.empty() && !product.empty()) {
 		desc = pt_format(_("Autosuspend for USB device {} [{}]"), product, vendor);
-	} else if (strlen(product)) {
+	} else if (!product.empty()) {
 		desc = pt_format(_("Autosuspend for USB device {} [{}]"), product, name);
-	} else if (strlen(vendor)) {
+	} else if (!vendor.empty()) {
 		desc = pt_format(_("Autosuspend for USB device {} [{}]"), vendor, name);
 	}
 
@@ -106,27 +103,27 @@ void usb_tunable::toggle(void)
 static void add_usb_callback(const char *d_name)
 {
 	class usb_tunable *usb;
-	char filename[PATH_MAX];
+	std::string filename;
 	DIR *dir;
 
-	snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s/power/control", d_name);
-	if (access(filename, R_OK) != 0)
+	filename = std::format("/sys/bus/usb/devices/{}/power/control", d_name);
+	if (access(filename.c_str(), R_OK) != 0)
 		return;
 
-	snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s/power/active_duration", d_name);
-	if (access(filename, R_OK)!=0)
+	filename = std::format("/sys/bus/usb/devices/{}/power/active_duration", d_name);
+	if (access(filename.c_str(), R_OK)!=0)
 		return;
 
 	/* every interface of this device should support autosuspend */
-	snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s", d_name);
-	if ((dir = opendir(filename))) {
+	filename = std::format("/sys/bus/usb/devices/{}", d_name);
+	if ((dir = opendir(filename.c_str()))) {
 		struct dirent *entry;
 		while ((entry = readdir(dir))) {
 			/* dirname: <busnum>-<devnum>...:<config num>-<interface num> */
 			if (!isdigit(entry->d_name[0]))
 				continue;
-			snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s/%s/supports_autosuspend", d_name, entry->d_name);
-			if (access(filename, R_OK) == 0 && read_sysfs(filename) == 0)
+			filename = std::format("/sys/bus/usb/devices/{}/{}/supports_autosuspend", d_name, entry->d_name);
+			if (access(filename.c_str(), R_OK) == 0 && read_sysfs(filename.c_str()) == 0)
 				break;
 		}
 		closedir(dir);
@@ -134,8 +131,8 @@ static void add_usb_callback(const char *d_name)
 			return;
 	}
 
-	snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s", d_name);
-	usb = new class usb_tunable(filename, d_name);
+	filename = std::format("/sys/bus/usb/devices/{}", d_name);
+	usb = new class usb_tunable(filename.c_str(), d_name);
 	all_tunables.push_back(usb);
 }
 

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <fstream>
 #include <limits.h>
+#include <format>
 
 #include "../lib.h"
 
@@ -43,7 +44,6 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 	char vendor[2048];
 	char product[2048];
 	std::string str1, str2;
-	char buffer[4096];
 	snprintf(usb_path, sizeof(usb_path), "%s/power/control", path);
 
 	vendor[0] = 0;
@@ -52,8 +52,7 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 	str1 = read_sysfs_string("%s/idVendor", path);
 	str2 = read_sysfs_string("%s/idProduct", path);
 
-	snprintf(buffer, sizeof(buffer), _("Autosuspend for unknown USB device %s (%s:%s)"), name, str1.c_str(), str2.c_str());
-	desc = buffer;
+	desc = std::format(_("Autosuspend for unknown USB device {} ({}:{})"), name, str1, str2);
 
 	snprintf(filename, sizeof(filename), "%s/manufacturer", path);
 	file.open(filename, ios::in);
@@ -70,14 +69,11 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 		file.close();
 	};
 	if (strlen(vendor) && strlen(product)) {
-		snprintf(buffer, sizeof(buffer), _("Autosuspend for USB device %s [%s]"), product, vendor);
-		desc = buffer;
+		desc = std::format(_("Autosuspend for USB device {} [{}]"), product, vendor);
 	} else if (strlen(product)) {
-		snprintf(buffer, sizeof(buffer), _("Autosuspend for USB device %s [%s]"), product, name);
-		desc = buffer;
+		desc = std::format(_("Autosuspend for USB device {} [{}]"), product, name);
 	} else if (strlen(vendor)) {
-		snprintf(buffer, sizeof(buffer), _("Autosuspend for USB device %s [%s]"), vendor, name);
-		desc = buffer;
+		desc = std::format(_("Autosuspend for USB device {} [{}]"), vendor, name);
 	}
 
 	snprintf(toggle_good, sizeof(toggle_good), "echo 'auto' > '%s';", usb_path);

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -103,18 +103,6 @@ void usb_tunable::toggle(void)
 	write_sysfs(usb_path.c_str(), "auto");
 }
 
-const char *usb_tunable::toggle_script(void)
-{
-	int good;
-	good = good_bad();
-
-	if (good == TUNE_GOOD) {
-		return toggle_bad.c_str();
-	}
-
-	return toggle_good.c_str();
-}
-
 static void add_usb_callback(const char *d_name)
 {
 	class usb_tunable *usb;

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -86,7 +86,7 @@ int usb_tunable::good_bad(void)
 
 	content = read_sysfs_string(usb_path);
 
-	if (strcmp(content.c_str(), "auto") == 0)
+	if (content == "auto")
 		return TUNE_GOOD;
 
 	return TUNE_BAD;

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -37,7 +37,7 @@
 
 #include "../lib.h"
 
-usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, _("Good"), _("Bad"), _("Unknown"))
+usb_tunable::usb_tunable(const string &path, const string &name) : tunable("", 0.9, _("Good"), _("Bad"), _("Unknown"))
 {
 	ifstream file;
 	std::string vendor;

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -47,8 +47,8 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 
 	usb_path = std::format("{}/power/control", path);
 
-	str1 = read_sysfs_string("%s/idVendor", path);
-	str2 = read_sysfs_string("%s/idProduct", path);
+	str1 = read_sysfs_string(std::format("{}/idVendor", path));
+	str2 = read_sysfs_string(std::format("{}/idProduct", path));
 
 	desc = pt_format(_("Autosuspend for unknown USB device {} ({}:{})"), name, str1, str2);
 
@@ -82,7 +82,7 @@ int usb_tunable::good_bad(void)
 {
 	string content;
 
-	content = read_sysfs_string(usb_path.c_str());
+	content = read_sysfs_string(usb_path);
 
 	if (content == "auto")
 		return TUNE_GOOD;

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -44,10 +44,8 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 	char vendor[2048];
 	char product[2048];
 	std::string str1, str2;
-	snprintf(usb_path, sizeof(usb_path), "%s/power/control", path);
 
-	vendor[0] = 0;
-	product[0] = 0;
+	usb_path = std::format("{}/power/control", path);
 
 	str1 = read_sysfs_string("%s/idVendor", path);
 	str2 = read_sysfs_string("%s/idProduct", path);
@@ -76,15 +74,15 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 		desc = std::format(_("Autosuspend for USB device {} [{}]"), vendor, name);
 	}
 
-	snprintf(toggle_good, sizeof(toggle_good), "echo 'auto' > '%s';", usb_path);
-	snprintf(toggle_bad, sizeof(toggle_bad), "echo 'on' > '%s';", usb_path);
+	toggle_good = std::format("echo 'auto' > '{}';", usb_path);
+	toggle_bad = std::format("echo 'on' > '{}';", usb_path);
 }
 
 int usb_tunable::good_bad(void)
 {
 	string content;
 
-	content = read_sysfs_string(usb_path);
+	content = read_sysfs_string(usb_path.c_str());
 
 	if (content == "auto")
 		return TUNE_GOOD;
@@ -98,11 +96,11 @@ void usb_tunable::toggle(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		write_sysfs(usb_path, "on");
+		write_sysfs(usb_path.c_str(), "on");
 		return;
 	}
 
-	write_sysfs(usb_path, "auto");
+	write_sysfs(usb_path.c_str(), "auto");
 }
 
 const char *usb_tunable::toggle_script(void)
@@ -111,10 +109,10 @@ const char *usb_tunable::toggle_script(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		return toggle_bad;
+		return toggle_bad.c_str();
 	}
 
-	return toggle_good;
+	return toggle_good.c_str();
 }
 
 static void add_usb_callback(const char *d_name)

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -42,7 +42,8 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 	char filename[PATH_MAX];
 	char vendor[2048];
 	char product[2048];
-	string str1, str2;
+	std::string str1, str2;
+	char buffer[4096];
 	snprintf(usb_path, sizeof(usb_path), "%s/power/control", path);
 
 	vendor[0] = 0;
@@ -51,7 +52,8 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 	str1 = read_sysfs_string("%s/idVendor", path);
 	str2 = read_sysfs_string("%s/idProduct", path);
 
-	snprintf(desc, sizeof(desc), _("Autosuspend for unknown USB device %s (%s:%s)"), name, str1.c_str(), str2.c_str());
+	snprintf(buffer, sizeof(buffer), _("Autosuspend for unknown USB device %s (%s:%s)"), name, str1.c_str(), str2.c_str());
+	desc = buffer;
 
 	snprintf(filename, sizeof(filename), "%s/manufacturer", path);
 	file.open(filename, ios::in);
@@ -67,12 +69,16 @@ usb_tunable::usb_tunable(const char *path, const char *name) : tunable("", 0.9, 
 		file.getline(product, 2040);
 		file.close();
 	};
-	if (strlen(vendor) && strlen(product))
-		snprintf(desc, sizeof(desc), _("Autosuspend for USB device %s [%s]"), product, vendor);
-	else if (strlen(product))
-		snprintf(desc, sizeof(desc), _("Autosuspend for USB device %s [%s]"), product, name);
-	else if (strlen(vendor))
-		snprintf(desc, sizeof(desc), _("Autosuspend for USB device %s [%s]"), vendor, name);
+	if (strlen(vendor) && strlen(product)) {
+		snprintf(buffer, sizeof(buffer), _("Autosuspend for USB device %s [%s]"), product, vendor);
+		desc = buffer;
+	} else if (strlen(product)) {
+		snprintf(buffer, sizeof(buffer), _("Autosuspend for USB device %s [%s]"), product, name);
+		desc = buffer;
+	} else if (strlen(vendor)) {
+		snprintf(buffer, sizeof(buffer), _("Autosuspend for USB device %s [%s]"), vendor, name);
+		desc = buffer;
+	}
 
 	snprintf(toggle_good, sizeof(toggle_good), "echo 'auto' > '%s';", usb_path);
 	snprintf(toggle_bad, sizeof(toggle_bad), "echo 'on' > '%s';", usb_path);

--- a/src/tuning/tuningusb.h
+++ b/src/tuning/tuningusb.h
@@ -41,8 +41,6 @@ public:
 
 	virtual void toggle(void);
 
-	virtual const char *toggle_script(void);
-
 };
 
 extern void add_usb_tunables(void);

--- a/src/tuning/tuningusb.h
+++ b/src/tuning/tuningusb.h
@@ -33,7 +33,7 @@
 using namespace std;
 
 class usb_tunable : public tunable {
-	char usb_path[PATH_MAX];
+	std::string usb_path;
 public:
 	usb_tunable(const char *usb_path, const char *path);
 

--- a/src/tuning/tuningusb.h
+++ b/src/tuning/tuningusb.h
@@ -35,7 +35,7 @@ using namespace std;
 class usb_tunable : public tunable {
 	std::string usb_path;
 public:
-	usb_tunable(const char *usb_path, const char *path);
+	usb_tunable(const std::string &usb_path, const std::string &path);
 
 	virtual int good_bad(void);
 

--- a/src/tuning/wifi.cpp
+++ b/src/tuning/wifi.cpp
@@ -46,7 +46,7 @@ extern "C" {
 wifi_tunable::wifi_tunable(const char *_iface) : tunable("", 1.5, _("Good"), _("Bad"), _("Unknown"))
 {
 	iface = _iface;
-	desc = std::format(_("Wireless Power Saving for interface {}"), iface);
+	desc = pt_format(_("Wireless Power Saving for interface {}"), iface);
 
 	toggle_good = std::format("iw dev {} set power_save on", iface);
 	toggle_bad = std::format("iw dev {} set power_save off", iface);

--- a/src/tuning/wifi.cpp
+++ b/src/tuning/wifi.cpp
@@ -73,18 +73,6 @@ void wifi_tunable::toggle(void)
 	set_wifi_power_saving(iface, 1);
 }
 
-const char *wifi_tunable::toggle_script(void)
-{
-	int good;
-	good = good_bad();
-
-	if (good == TUNE_GOOD) {
-		return toggle_bad.c_str();
-	}
-
-	return toggle_good.c_str();
-}
-
 void add_wifi_tunables(void)
 {
 	struct dirent *entry;

--- a/src/tuning/wifi.cpp
+++ b/src/tuning/wifi.cpp
@@ -45,11 +45,11 @@ extern "C" {
 
 wifi_tunable::wifi_tunable(const char *_iface) : tunable("", 1.5, _("Good"), _("Bad"), _("Unknown"))
 {
-	pt_strcpy(iface, _iface);
+	iface = _iface;
 	desc = std::format(_("Wireless Power Saving for interface {}"), iface);
 
-	snprintf(toggle_good, sizeof(toggle_good), "iw dev %s set power_save on", iface);
-	snprintf(toggle_bad, sizeof(toggle_bad), "iw dev %s set power_save off", iface);
+	pt_strcpy(toggle_good, std::format("iw dev {} set power_save on", iface).c_str());
+	pt_strcpy(toggle_bad, std::format("iw dev {} set power_save off", iface).c_str());
 }
 
 int wifi_tunable::good_bad(void)
@@ -110,4 +110,14 @@ void add_wifi_tunables(void)
 
 	closedir(dir);
 
+}
+
+int get_wifi_power_saving(const std::string &iface)
+{
+	return get_wifi_power_saving(iface.c_str());
+}
+
+int set_wifi_power_saving(const std::string &iface, int state)
+{
+	return set_wifi_power_saving(iface.c_str(), state);
 }

--- a/src/tuning/wifi.cpp
+++ b/src/tuning/wifi.cpp
@@ -44,8 +44,10 @@ extern "C" {
 
 wifi_tunable::wifi_tunable(const char *_iface) : tunable("", 1.5, _("Good"), _("Bad"), _("Unknown"))
 {
+	char buffer[4096];
 	pt_strcpy(iface, _iface);
-	sprintf(desc, _("Wireless Power Saving for interface %s"), iface);
+	snprintf(buffer, sizeof(buffer), _("Wireless Power Saving for interface %s"), iface);
+	desc = buffer;
 
 	snprintf(toggle_good, sizeof(toggle_good), "iw dev %s set power_save on", iface);
 	snprintf(toggle_bad, sizeof(toggle_bad), "iw dev %s set power_save off", iface);

--- a/src/tuning/wifi.cpp
+++ b/src/tuning/wifi.cpp
@@ -43,7 +43,7 @@ extern "C" {
 }
 
 
-wifi_tunable::wifi_tunable(const char *_iface) : tunable("", 1.5, _("Good"), _("Bad"), _("Unknown"))
+wifi_tunable::wifi_tunable(const string &_iface) : tunable("", 1.5, _("Good"), _("Bad"), _("Unknown"))
 {
 	iface = _iface;
 	desc = pt_format(_("Wireless Power Saving for interface {}"), iface);
@@ -54,7 +54,7 @@ wifi_tunable::wifi_tunable(const char *_iface) : tunable("", 1.5, _("Good"), _("
 
 int wifi_tunable::good_bad(void)
 {
-	if (get_wifi_power_saving(iface))
+	if (get_wifi_power_saving(iface.c_str()))
 		return TUNE_GOOD;
 
 	return TUNE_BAD;
@@ -66,18 +66,17 @@ void wifi_tunable::toggle(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		set_wifi_power_saving(iface, 0);
+		set_wifi_power_saving(iface.c_str(), 0);
 		return;
 	}
 
-	set_wifi_power_saving(iface, 1);
+	set_wifi_power_saving(iface.c_str(), 1);
 }
 
 void add_wifi_tunables(void)
 {
 	struct dirent *entry;
 	DIR *dir;
-	char* wlan_name;
 	class wifi_tunable *wifi;
 
 
@@ -88,9 +87,8 @@ void add_wifi_tunables(void)
 		entry = readdir(dir);
 		if (!entry)
 			break;
-		wlan_name = strstr(entry->d_name, "wlan");
-		if (wlan_name) {
-			wifi = new class wifi_tunable(wlan_name);
+		if (strstr(entry->d_name, "wlan")) {
+			wifi = new class wifi_tunable(entry->d_name);
 			all_tunables.push_back(wifi);
 		}
 	
@@ -98,14 +96,4 @@ void add_wifi_tunables(void)
 
 	closedir(dir);
 
-}
-
-int get_wifi_power_saving(const std::string &iface)
-{
-	return get_wifi_power_saving(iface.c_str());
-}
-
-int set_wifi_power_saving(const std::string &iface, int state)
-{
-	return set_wifi_power_saving(iface.c_str(), state);
 }

--- a/src/tuning/wifi.cpp
+++ b/src/tuning/wifi.cpp
@@ -48,8 +48,8 @@ wifi_tunable::wifi_tunable(const char *_iface) : tunable("", 1.5, _("Good"), _("
 	iface = _iface;
 	desc = std::format(_("Wireless Power Saving for interface {}"), iface);
 
-	pt_strcpy(toggle_good, std::format("iw dev {} set power_save on", iface).c_str());
-	pt_strcpy(toggle_bad, std::format("iw dev {} set power_save off", iface).c_str());
+	toggle_good = std::format("iw dev {} set power_save on", iface);
+	toggle_bad = std::format("iw dev {} set power_save off", iface);
 }
 
 int wifi_tunable::good_bad(void)
@@ -79,10 +79,10 @@ const char *wifi_tunable::toggle_script(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		return toggle_bad;
+		return toggle_bad.c_str();
 	}
 
-	return toggle_good;
+	return toggle_good.c_str();
 }
 
 void add_wifi_tunables(void)

--- a/src/tuning/wifi.cpp
+++ b/src/tuning/wifi.cpp
@@ -34,6 +34,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <dirent.h>
+#include <format>
 
 #include "../lib.h"
 
@@ -44,10 +45,8 @@ extern "C" {
 
 wifi_tunable::wifi_tunable(const char *_iface) : tunable("", 1.5, _("Good"), _("Bad"), _("Unknown"))
 {
-	char buffer[4096];
 	pt_strcpy(iface, _iface);
-	snprintf(buffer, sizeof(buffer), _("Wireless Power Saving for interface %s"), iface);
-	desc = buffer;
+	desc = std::format(_("Wireless Power Saving for interface {}"), iface);
 
 	snprintf(toggle_good, sizeof(toggle_good), "iw dev %s set power_save on", iface);
 	snprintf(toggle_bad, sizeof(toggle_bad), "iw dev %s set power_save off", iface);

--- a/src/tuning/wifi.h
+++ b/src/tuning/wifi.h
@@ -29,10 +29,12 @@
 
 #include "tunable.h"
 
+#include <string>
+
 using namespace std;
 
 class wifi_tunable : public tunable {
-	char iface[4096];
+	std::string iface;
 public:
 	wifi_tunable(const char *_iface);
 
@@ -45,6 +47,9 @@ public:
 };
 
 extern void add_wifi_tunables(void);
+
+int get_wifi_power_saving(const std::string &iface);
+int set_wifi_power_saving(const std::string &iface, int state);
 
 
 #endif

--- a/src/tuning/wifi.h
+++ b/src/tuning/wifi.h
@@ -42,8 +42,6 @@ public:
 
 	virtual void toggle(void);
 
-	virtual const char *toggle_script(void);
-
 };
 
 extern void add_wifi_tunables(void);

--- a/src/tuning/wifi.h
+++ b/src/tuning/wifi.h
@@ -36,7 +36,7 @@ using namespace std;
 class wifi_tunable : public tunable {
 	std::string iface;
 public:
-	wifi_tunable(const char *_iface);
+	wifi_tunable(const std::string &_iface);
 
 	virtual int good_bad(void);
 

--- a/src/wakeup/waketab.cpp
+++ b/src/wakeup/waketab.cpp
@@ -153,7 +153,7 @@ void report_show_wakeup(void)
 			gb = wakeup_all[i]->wakeup_value();
 			if (gb != WAKEUP_DISABLE)
 				continue;
-			wakeup_data[idx]=string(wakeup_all[i]->description());
+			wakeup_data[idx]=wakeup_all[i]->description();
 			idx+=1;
 			wakeup_data[idx]=string(wakeup_all[i]->wakeup_toggle_script());
 			idx+=1;

--- a/src/wakeup/waketab.cpp
+++ b/src/wakeup/waketab.cpp
@@ -108,13 +108,13 @@ void wakeup_window::repaint(void)
 void wakeup_window::cursor_enter(void)
 {
 	class wakeup *wake;
-	const char *wakeup_toggle_script;
+	std::string wakeup_toggle_script;
 	wake = wakeup_all[cursor_pos];
 	if (!wake)
 		return;
 	wakeup_toggle_script = wake->wakeup_toggle_script();
 	wake->wakeup_toggle();
-	ui_notify_user(">> %s\n", wakeup_toggle_script);
+	ui_notify_user(">> %s\n", wakeup_toggle_script.c_str());
 }
 
 void report_show_wakeup(void)

--- a/src/wakeup/waketab.cpp
+++ b/src/wakeup/waketab.cpp
@@ -69,15 +69,8 @@ static void __wakeup_update_display(int cursor_pos)
 	wmove(win, 1,0);
 
 	for (i = 0; i < wakeup_all.size(); i++) {
-		char res[128];
-		char desc[4096];
-		pt_strcpy(res, wakeup_all[i]->wakeup_string());
-		pt_strcpy(desc, wakeup_all[i]->description());
-		while (strlen(res) < 12)
-			strcat(res, " ");
-
-		while (strlen(desc) < 103)
-			strcat(desc, " ");
+		std::string res = wakeup_all[i]->wakeup_string();
+		std::string desc = wakeup_all[i]->description();
 
 		if ((int)i != cursor_pos) {
 			wattrset(win, A_NORMAL);
@@ -86,7 +79,7 @@ static void __wakeup_update_display(int cursor_pos)
 			wattrset(win, A_REVERSE);
 			wprintw(win, ">> ");
 		}
-	wprintw(win, "%s  %s\n", _(res), _(desc));
+		wprintw(win, "%-12s  %-103s\n", _(res.c_str()), _(desc.c_str()));
 	}
 }
 

--- a/src/wakeup/wakeup.cpp
+++ b/src/wakeup/wakeup.cpp
@@ -33,7 +33,7 @@ using namespace std;
 
 std::vector<class wakeup *> wakeup_all;
 
-wakeup::wakeup(const char *str, double _score, const char *enable, const char *disable)
+wakeup::wakeup(const string &str, double _score, const string &enable, const string &disable)
 {
 	score = _score;
         desc = str;

--- a/src/wakeup/wakeup.cpp
+++ b/src/wakeup/wakeup.cpp
@@ -31,12 +31,12 @@
 
 using namespace std;
 
-vector<class wakeup *> wakeup_all;
+std::vector<class wakeup *> wakeup_all;
 
 wakeup::wakeup(const char *str, double _score, const char *enable, const char *disable)
 {
 	score = _score;
-        pt_strcpy(desc, str);
+        desc = str;
         pt_strcpy(wakeup_enable, enable);
         pt_strcpy(wakeup_disable, disable);
 }
@@ -44,7 +44,7 @@ wakeup::wakeup(const char *str, double _score, const char *enable, const char *d
 wakeup::wakeup(void)
 {
 	score = 0;
-        desc[0] = 0;
+        desc = "";
         pt_strcpy(wakeup_enable, _("Enabled"));
         pt_strcpy(wakeup_disable, _("Disabled"));
 	pt_strcpy(wakeup_idle, _("Unknown"));

--- a/src/wakeup/wakeup.cpp
+++ b/src/wakeup/wakeup.cpp
@@ -37,16 +37,16 @@ wakeup::wakeup(const char *str, double _score, const char *enable, const char *d
 {
 	score = _score;
         desc = str;
-        pt_strcpy(wakeup_enable, enable);
-        pt_strcpy(wakeup_disable, disable);
+        wakeup_enable = enable;
+        wakeup_disable = disable;
 }
 
 wakeup::wakeup(void)
 {
 	score = 0;
         desc = "";
-        pt_strcpy(wakeup_enable, _("Enabled"));
-        pt_strcpy(wakeup_disable, _("Disabled"));
-	pt_strcpy(wakeup_idle, _("Unknown"));
+        wakeup_enable = _("Enabled");
+        wakeup_disable = _("Disabled");
+	wakeup_idle = _("Unknown");
 }
 

--- a/src/wakeup/wakeup.h
+++ b/src/wakeup/wakeup.h
@@ -65,8 +65,7 @@ public:
 	}
 
 
-	virtual const char *description(void) { return desc.c_str(); };
-	virtual std::string description_s(void) { return desc; };
+	virtual std::string description(void) { return desc; };
 
 	virtual void wakeup_toggle(void) { };
 

--- a/src/wakeup/wakeup.h
+++ b/src/wakeup/wakeup.h
@@ -28,6 +28,8 @@
 #include<vector>
 #include <limits.h>
 
+#include <string>
+
 using namespace std;
 
 #define WAKEUP_ENABLE 1
@@ -41,7 +43,7 @@ protected:
 	char toggle_enable[4096];
 	char toggle_disable[4096];
 public:
-	char desc[4096];
+	std::string desc;
 	double score;
 
 	wakeup(const char *str, double _score, const char *enable = "", const char *disable = "");
@@ -63,7 +65,8 @@ public:
 	}
 
 
-	virtual const char *description(void) { return desc; };
+	virtual const char *description(void) { return desc.c_str(); };
+	virtual std::string description_s(void) { return desc; };
 
 	virtual void wakeup_toggle(void) { };
 
@@ -71,7 +74,7 @@ public:
 
 };
 
-extern vector<class wakeup *> wakeup_all;
+extern std::vector<class wakeup *> wakeup_all;
 
 extern void initialize_wakeup(void);
 extern void wakeup_update_display(void);

--- a/src/wakeup/wakeup.h
+++ b/src/wakeup/wakeup.h
@@ -46,7 +46,7 @@ public:
 	std::string desc;
 	double score;
 
-	wakeup(const char *str, double _score, const char *enable = "", const char *disable = "");
+	wakeup(const std::string &str, double _score, const std::string &enable = "", const std::string &disable = "");
 	wakeup(void);
 
 	virtual ~wakeup () {};

--- a/src/wakeup/wakeup.h
+++ b/src/wakeup/wakeup.h
@@ -36,9 +36,9 @@ using namespace std;
 #define WAKEUP_DISABLE 0
 
 class wakeup {
-	char wakeup_enable[128];
-	char wakeup_disable[128];
-	char wakeup_idle[128];
+	std::string wakeup_enable;
+	std::string wakeup_disable;
+	std::string wakeup_idle;
 protected:
 	std::string toggle_enable;
 	std::string toggle_disable;
@@ -53,7 +53,7 @@ public:
 
 	virtual int wakeup_value(void) { return WAKEUP_DISABLE; }
 
-	virtual char *wakeup_string(void)
+	virtual const std::string& wakeup_string(void)
 	{
 		switch (wakeup_value()) {
 		case WAKEUP_ENABLE:

--- a/src/wakeup/wakeup.h
+++ b/src/wakeup/wakeup.h
@@ -40,8 +40,8 @@ class wakeup {
 	char wakeup_disable[128];
 	char wakeup_idle[128];
 protected:
-	char toggle_enable[4096];
-	char toggle_disable[4096];
+	std::string toggle_enable;
+	std::string toggle_disable;
 public:
 	std::string desc;
 	double score;
@@ -70,7 +70,7 @@ public:
 
 	virtual void wakeup_toggle(void) { };
 
-	virtual const char *wakeup_toggle_script(void) { return toggle_enable; }
+	virtual std::string wakeup_toggle_script(void) { return toggle_enable; }
 
 };
 

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -51,8 +51,8 @@ ethernet_wakeup::ethernet_wakeup(const char *path, const char *iface) : wakeup("
 	pt_strcpy(interf, iface);
 	desc = pt_format(_("Wake-on-lan status for device {}"), iface);
 	snprintf(eth_path, sizeof(eth_path), "/sys/class/net/%s/device/power/wakeup", iface);
-	snprintf(toggle_enable, sizeof(toggle_enable), "echo 'enabled' > '%s';", eth_path);
-	snprintf(toggle_disable, sizeof(toggle_disable), "echo 'disabled' > '%s';", eth_path);
+	toggle_enable = std::format("echo 'enabled' > '{}';", eth_path);
+	toggle_disable = std::format("echo 'disabled' > '{}';", eth_path);
 }
 
 int ethernet_wakeup::wakeup_value(void)
@@ -80,7 +80,7 @@ void ethernet_wakeup::wakeup_toggle(void)
 	write_sysfs(eth_path, "enabled");
 }
 
-const char *ethernet_wakeup::wakeup_toggle_script(void)
+std::string ethernet_wakeup::wakeup_toggle_script(void)
 {
 	int enable;
 	enable = wakeup_value();

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -45,7 +45,7 @@
 #include "../lib.h"
 #include "wakeup_ethernet.h"
 
-ethernet_wakeup::ethernet_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
+ethernet_wakeup::ethernet_wakeup(const string &path, const string &iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
 	interf = iface;
 	desc = pt_format(_("Wake-on-lan status for device {}"), iface);

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -49,7 +49,7 @@ ethernet_wakeup::ethernet_wakeup(const char *path, const char *iface) : wakeup("
 {
 	memset(interf, 0, sizeof(interf));
 	pt_strcpy(interf, iface);
-	desc = std::format(_("Wake-on-lan status for device {}"), iface);
+	desc = pt_format(_("Wake-on-lan status for device {}"), iface);
 	snprintf(eth_path, sizeof(eth_path), "/sys/class/net/%s/device/power/wakeup", iface);
 	snprintf(toggle_enable, sizeof(toggle_enable), "echo 'enabled' > '%s';", eth_path);
 	snprintf(toggle_disable, sizeof(toggle_disable), "echo 'disabled' > '%s';", eth_path);

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -47,8 +47,7 @@
 
 ethernet_wakeup::ethernet_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
-	memset(interf, 0, sizeof(interf));
-	pt_strcpy(interf, iface);
+	interf = iface;
 	desc = pt_format(_("Wake-on-lan status for device {}"), iface);
 	snprintf(eth_path, sizeof(eth_path), "/sys/class/net/%s/device/power/wakeup", iface);
 	toggle_enable = std::format("echo 'enabled' > '{}';", eth_path);

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -46,9 +46,11 @@
 
 ethernet_wakeup::ethernet_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
+	char buffer[4096];
 	memset(interf, 0, sizeof(interf));
 	pt_strcpy(interf, iface);
-	sprintf(desc, _("Wake-on-lan status for device %s"), iface);
+	snprintf(buffer, sizeof(buffer), _("Wake-on-lan status for device %s"), iface);
+	desc = buffer;
 	snprintf(eth_path, sizeof(eth_path), "/sys/class/net/%s/device/power/wakeup", iface);
 	snprintf(toggle_enable, sizeof(toggle_enable), "echo 'enabled' > '%s';", eth_path);
 	snprintf(toggle_disable, sizeof(toggle_disable), "echo 'disabled' > '%s';", eth_path);

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -91,17 +91,17 @@ std::string ethernet_wakeup::wakeup_toggle_script(void)
 	return toggle_enable;
 }
 
-void wakeup_eth_callback(const char *d_name)
+static void wakeup_eth_callback(const char *d_name)
 {
 	class ethernet_wakeup *eth;
-	char filename[PATH_MAX];
+	std::string filename;
 
-	snprintf(filename, sizeof(filename), "/sys/class/net/%s/device/power/wakeup", d_name);
-	if (access(filename, R_OK) != 0)
+	filename = std::format("/sys/class/net/{}/device/power/wakeup", d_name);
+	if (access(filename.c_str(), R_OK) != 0)
 		return;
 
-	snprintf(filename, sizeof(filename), "/sys/class/net/%s/device/power/wakeup", d_name);
-	eth = new class ethernet_wakeup(filename, d_name);
+	filename = std::format("/sys/class/net/{}/device/power/wakeup", d_name);
+	eth = new class ethernet_wakeup(filename.c_str(), d_name);
 	wakeup_all.push_back(eth);
 }
 

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -38,6 +38,7 @@
 #include <net/if.h>
 #include <linux/sockios.h>
 #include <sys/ioctl.h>
+#include <format>
 
 #include <linux/ethtool.h>
 
@@ -46,11 +47,9 @@
 
 ethernet_wakeup::ethernet_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
-	char buffer[4096];
 	memset(interf, 0, sizeof(interf));
 	pt_strcpy(interf, iface);
-	snprintf(buffer, sizeof(buffer), _("Wake-on-lan status for device %s"), iface);
-	desc = buffer;
+	desc = std::format(_("Wake-on-lan status for device {}"), iface);
 	snprintf(eth_path, sizeof(eth_path), "/sys/class/net/%s/device/power/wakeup", iface);
 	snprintf(toggle_enable, sizeof(toggle_enable), "echo 'enabled' > '%s';", eth_path);
 	snprintf(toggle_disable, sizeof(toggle_disable), "echo 'disabled' > '%s';", eth_path);

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -61,7 +61,7 @@ int ethernet_wakeup::wakeup_value(void)
 
 	content = read_sysfs_string(eth_path);
 
-	if (strcmp(content.c_str(), "enabled") == 0)
+	if (content == "enabled")
 		return WAKEUP_ENABLE;
 
 	return WAKEUP_DISABLE;

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -49,7 +49,7 @@ ethernet_wakeup::ethernet_wakeup(const char *path, const char *iface) : wakeup("
 {
 	interf = iface;
 	desc = pt_format(_("Wake-on-lan status for device {}"), iface);
-	snprintf(eth_path, sizeof(eth_path), "/sys/class/net/%s/device/power/wakeup", iface);
+	eth_path = std::format("/sys/class/net/{}/device/power/wakeup", iface);
 	toggle_enable = std::format("echo 'enabled' > '{}';", eth_path);
 	toggle_disable = std::format("echo 'disabled' > '{}';", eth_path);
 }

--- a/src/wakeup/wakeup_ethernet.h
+++ b/src/wakeup/wakeup_ethernet.h
@@ -41,7 +41,7 @@ public:
 
 	virtual void wakeup_toggle(void);
 
-	virtual const char *wakeup_toggle_script(void);
+	virtual std::string wakeup_toggle_script(void);
 
 };
 

--- a/src/wakeup/wakeup_ethernet.h
+++ b/src/wakeup/wakeup_ethernet.h
@@ -34,7 +34,7 @@ using namespace std;
 class ethernet_wakeup : public wakeup {
 	char eth_path[PATH_MAX];
 public:
-	char interf[4096];
+	std::string interf;
 	ethernet_wakeup(const char *eth_path, const char *iface);
 
 	virtual int wakeup_value(void);

--- a/src/wakeup/wakeup_ethernet.h
+++ b/src/wakeup/wakeup_ethernet.h
@@ -32,7 +32,7 @@
 using namespace std;
 
 class ethernet_wakeup : public wakeup {
-	char eth_path[PATH_MAX];
+	std::string eth_path;
 public:
 	std::string interf;
 	ethernet_wakeup(const char *eth_path, const char *iface);

--- a/src/wakeup/wakeup_ethernet.h
+++ b/src/wakeup/wakeup_ethernet.h
@@ -35,7 +35,7 @@ class ethernet_wakeup : public wakeup {
 	std::string eth_path;
 public:
 	std::string interf;
-	ethernet_wakeup(const char *eth_path, const char *iface);
+	ethernet_wakeup(const std::string &eth_path, const std::string &iface);
 
 	virtual int wakeup_value(void);
 

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -51,8 +51,8 @@ usb_wakeup::usb_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _(
 	pt_strcpy(interf, iface);
 	desc = pt_format(_("Wake status for USB device {}"), iface);
 	snprintf(usb_path, sizeof(usb_path), "/sys/bus/usb/devices/%s/power/wakeup", iface);
-	snprintf(toggle_enable, sizeof(toggle_enable), "echo 'enabled' > '%s';", usb_path);
-	snprintf(toggle_disable, sizeof(toggle_disable), "echo 'disabled' > '%s';", usb_path);
+	toggle_enable = std::format("echo 'enabled' > '{}';", usb_path);
+	toggle_disable = std::format("echo 'disabled' > '{}';", usb_path);
 }
 
 int usb_wakeup::wakeup_value(void)
@@ -80,7 +80,7 @@ void usb_wakeup::wakeup_toggle(void)
 	write_sysfs(usb_path, "enabled");
 }
 
-const char *usb_wakeup::wakeup_toggle_script(void)
+std::string usb_wakeup::wakeup_toggle_script(void)
 {
 	int enable;
 	enable = wakeup_value();

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -61,7 +61,7 @@ int usb_wakeup::wakeup_value(void)
 
 	content = read_sysfs_string(usb_path);
 
-	if (strcmp(content.c_str(), "enabled") == 0)
+	if (content == "enabled")
 		return WAKEUP_ENABLE;
 
 	return WAKEUP_DISABLE;

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -91,17 +91,17 @@ std::string usb_wakeup::wakeup_toggle_script(void)
 	return toggle_enable;
 }
 
-void wakeup_usb_callback(const char *d_name)
+static void wakeup_usb_callback(const char *d_name)
 {
 	class usb_wakeup *usb;
-	char filename[PATH_MAX];
+	std::string filename;
 
-	snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s/power/wakeup", d_name);
-	if (access(filename, R_OK) != 0)
+	filename = std::format("/sys/bus/usb/devices/{}/power/wakeup", d_name);
+	if (access(filename.c_str(), R_OK) != 0)
 		return;
 
-	snprintf(filename, sizeof(filename), "/sys/bus/usb/devices/%s/power/wakeup", d_name);
-	usb = new class usb_wakeup(filename, d_name);
+	filename = std::format("/sys/bus/usb/devices/{}/power/wakeup", d_name);
+	usb = new class usb_wakeup(filename.c_str(), d_name);
 	wakeup_all.push_back(usb);
 }
 

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -49,7 +49,7 @@ usb_wakeup::usb_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _(
 {
 	memset(interf, 0, sizeof(interf));
 	pt_strcpy(interf, iface);
-	desc = std::format(_("Wake status for USB device {}"), iface);
+	desc = pt_format(_("Wake status for USB device {}"), iface);
 	snprintf(usb_path, sizeof(usb_path), "/sys/bus/usb/devices/%s/power/wakeup", iface);
 	snprintf(toggle_enable, sizeof(toggle_enable), "echo 'enabled' > '%s';", usb_path);
 	snprintf(toggle_disable, sizeof(toggle_disable), "echo 'disabled' > '%s';", usb_path);

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -1,4 +1,4 @@
-;/*
+/*
  * Copyright 2018, Intel Corporation
  *
  * This file is part of PowerTOP
@@ -38,6 +38,7 @@
 #include <net/if.h>
 #include <linux/sockios.h>
 #include <sys/ioctl.h>
+#include <format>
 
 #include <linux/ethtool.h>
 
@@ -46,11 +47,9 @@
 
 usb_wakeup::usb_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
-	char buffer[4096];
 	memset(interf, 0, sizeof(interf));
 	pt_strcpy(interf, iface);
-	snprintf(buffer, sizeof(buffer), _("Wake status for USB device %s"), iface);
-	desc = buffer;
+	desc = std::format(_("Wake status for USB device {}"), iface);
 	snprintf(usb_path, sizeof(usb_path), "/sys/bus/usb/devices/%s/power/wakeup", iface);
 	snprintf(toggle_enable, sizeof(toggle_enable), "echo 'enabled' > '%s';", usb_path);
 	snprintf(toggle_disable, sizeof(toggle_disable), "echo 'disabled' > '%s';", usb_path);

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -45,7 +45,7 @@
 #include "../lib.h"
 #include "wakeup_usb.h"
 
-usb_wakeup::usb_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
+usb_wakeup::usb_wakeup(const string &path, const string &iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
 	interf = iface;
 	desc = pt_format(_("Wake status for USB device {}"), iface);

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -47,8 +47,7 @@
 
 usb_wakeup::usb_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
-	memset(interf, 0, sizeof(interf));
-	pt_strcpy(interf, iface);
+	interf = iface;
 	desc = pt_format(_("Wake status for USB device {}"), iface);
 	snprintf(usb_path, sizeof(usb_path), "/sys/bus/usb/devices/%s/power/wakeup", iface);
 	toggle_enable = std::format("echo 'enabled' > '{}';", usb_path);

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -49,7 +49,7 @@ usb_wakeup::usb_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _(
 {
 	interf = iface;
 	desc = pt_format(_("Wake status for USB device {}"), iface);
-	snprintf(usb_path, sizeof(usb_path), "/sys/bus/usb/devices/%s/power/wakeup", iface);
+	usb_path = std::format("/sys/bus/usb/devices/{}/power/wakeup", iface);
 	toggle_enable = std::format("echo 'enabled' > '{}';", usb_path);
 	toggle_disable = std::format("echo 'disabled' > '{}';", usb_path);
 }

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -46,9 +46,11 @@
 
 usb_wakeup::usb_wakeup(const char *path, const char *iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
+	char buffer[4096];
 	memset(interf, 0, sizeof(interf));
 	pt_strcpy(interf, iface);
-	sprintf(desc, _("Wake status for USB device %s"), iface);
+	snprintf(buffer, sizeof(buffer), _("Wake status for USB device %s"), iface);
+	desc = buffer;
 	snprintf(usb_path, sizeof(usb_path), "/sys/bus/usb/devices/%s/power/wakeup", iface);
 	snprintf(toggle_enable, sizeof(toggle_enable), "echo 'enabled' > '%s';", usb_path);
 	snprintf(toggle_disable, sizeof(toggle_disable), "echo 'disabled' > '%s';", usb_path);

--- a/src/wakeup/wakeup_usb.h
+++ b/src/wakeup/wakeup_usb.h
@@ -41,7 +41,7 @@ public:
 
 	virtual void wakeup_toggle(void);
 
-	virtual const char *wakeup_toggle_script(void);
+	virtual std::string wakeup_toggle_script(void);
 
 };
 

--- a/src/wakeup/wakeup_usb.h
+++ b/src/wakeup/wakeup_usb.h
@@ -35,7 +35,7 @@ class usb_wakeup : public wakeup {
 	std::string usb_path;
 public:
 	std::string interf;
-	usb_wakeup(const char *usb_path, const char *iface);
+	usb_wakeup(const std::string &usb_path, const std::string &iface);
 
 	virtual int wakeup_value(void);
 

--- a/src/wakeup/wakeup_usb.h
+++ b/src/wakeup/wakeup_usb.h
@@ -34,7 +34,7 @@ using namespace std;
 class usb_wakeup : public wakeup {
 	char usb_path[PATH_MAX];
 public:
-	char interf[4096];
+	std::string interf;
 	usb_wakeup(const char *usb_path, const char *iface);
 
 	virtual int wakeup_value(void);

--- a/src/wakeup/wakeup_usb.h
+++ b/src/wakeup/wakeup_usb.h
@@ -32,7 +32,7 @@
 using namespace std;
 
 class usb_wakeup : public wakeup {
-	char usb_path[PATH_MAX];
+	std::string usb_path;
 public:
 	std::string interf;
 	usb_wakeup(const char *usb_path, const char *iface);


### PR DESCRIPTION
- **Refactor: Convert tunable and wakeup desc to std::string and add _s() string methods**
- **Build: Update to C++20 standard**
- **Refactor: Use std::format in wifi_tunable**
- **Refactor: Use std::format in usb_wakeup**
- **Refactor: Use std::format in ethernet_wakeup**
- **Refactor: Use std::format in runtime_tunable**
- **Refactor: Use std::format in bt_tunable**
- **Refactor: Use std::format in ethernet_tunable**
- **Refactor: Use std::format in usb_tunable**
- **Refactor: Use std::format in i2c_tunable**
- **Refactor: Convert device::guilty to std::string and use std::format in alsa::human_name**
- **Cleanup: Remove redundant length checks for std::string guilty**
- **Refactor: Convert alsa::humanname to std::string and use std::format**
- **Refactor: Convert network::humanname to std::string and use std::format**
- **Refactor: Convert usbdevice humanname and devname to std::string and use std::format**
- **Refactor: Convert runtime_pmdevice humanname and name to std::string and use std::format**
- **Refactor: Convert ahci humanname and name to std::string and use std::format**
- **Refactor: Convert rfkill humanname and name to std::string and use std::format**
- **Refactor: Convert alsa humanname and name to std::string and use std::format**
- **Refactor: Convert backlight name to std::string and use std::format**
- **Refactor: Convert devfreq dir_name to std::string and use std::format**
- **Refactor: Add _s() string methods to thinkpad_fan**
- **Refactor: Add _s() string methods to thinkpad_light**
- **Refactor: Use std::string and std::format in device reporting methods**
- **Refactor: Add std::string variants for parameter/result access methods**
- **Cleanup: Remove redundant .c_str() calls in runtime_pm.cpp**
- **Cleanup: Remove redundant .c_str() calls in ahci.cpp**
- **Cleanup: Remove redundant .c_str() calls in rfkill.cpp**
- **Cleanup: Remove redundant .c_str() calls in backlight.cpp**
- **Refactor: Add std::string variants for register_devpower and parameter/result methods, and cleanup .c_str() calls**
- **Refactor: Convert usbdevice name to std::string**
- **Refactor: Convert network name to std::string and use std::format**
- **Refactor: Add _s() string methods to i915gpu and incorporate naming logic**
- **Refactor: Add _s() string methods to gpu_rapl_device**
- **Refactor: Convert cpudevice naming members to std::string**
- **Refactor: Add _s() string methods to cpu_rapl_device**
- **Refactor: Add _s() string methods to dram_rapl_device**
- **Refactor: Add std::string variants for wifi power saving and cleanup .c_str() calls**
- **update review rules to use const when possible**
- **Cleanup: Use direct std::string comparison in usb_wakeup**
- **Cleanup: Use direct std::string comparison in ethernet_wakeup**
- **Cleanup: Use direct std::string comparison in usb_tunable**
- **Cleanup: Use direct std::string comparison in i2c_tunable**
- **Cleanup: Use direct std::string comparison in runtime_tunable**
- **Refactor: Convert cpudevice naming members to std::string and implement naming methods**
- **Refactor: Convert device::real_path to std::string**
- **Refactor: Convert alsa::sysfs_path to std::string and use std::format**
- **Refactor: Convert backlight::sysfs_path to std::string and use std::format**
- **Refactor: Convert runtime_pmdevice::sysfs_path to std::string and use std::format**
- **Refactor: Convert rfkill::sysfs_path to std::string and use std::format**
- **Refactor: Convert network::sysfs_path to std::string and use std::format**
- **Refactor: Convert ahci::sysfs_path to std::string and use std::format**
- **Refactor: Convert usbdevice::sysfs_path to std::string and use std::format**
- **Refactor: Convert tunable members to std::string and use std::format in derived classes**
- **Doc: Update class description with recent string refactors**
- **Refactor: Convert toggle_script to std::string and remove redundant overrides**
- **a lot more buffer conversions**
- **cpu: Finalize buffer and string conversions**
- **lib: Add pt_format helper and refactor translated strings**
- **wakeup: Modernize toggle scripts to std::string**
- **wakeup: Complete modernization of class wakeup and subclasses**
- **devices: Modernize register_sysfs_path**
- **tuning: Modernize runtime_tunable and add_runtime_tunables**
- **measurement: Modernize power_meter hierarchy with std::string for names**
- **lib: Modernize read_sysfs_string and unify on std::string**
- **process: Modernize process hierarchy with std::string**
- **devlist: Modernize devuser and devpower structs with std::string**
- **process: Modernize find_create_process to use std::string**
- **devices: Rename human_name to human_name_cstr and prefer human_name_s**
- **tuning: Modernize ethernet_tunable with std::string**
- **modernize: Convert description() to return std::string**
- **lib: Modernize pretty_print with std::string overload**
- **devices: Complete modernization of human_name method**
- **wakeup: Finalize modernization of wakeup subclasses**
- **report: Modernize reportstream and output initialization**
- **modernize: Eliminate pt_strcpy in tuning.cpp and modernize result_string()**
- **modernize: Eliminate more pt_strcpy usages by converting targets to std::string**
- **cpu: Modernize CPU header formatting and eliminate snprintf into local buffers**
- **cpu: Modernize path construction and eliminate filename buffers**
- **process: Modernize UI formatting and eliminate snprintf into local buffers**
- **tuning: Modernize path construction and eliminate local char buffers**
- **modernize: Convert device_has_runtime_pm to take std::string**
- **modernize: Comprehensive modernization of path construction and local buffers**
- **modernize: Systematic refactor of object hierarchy to prefer std::string**
- **modernize: Modernize lib.h and lib.cpp to prefer std::string**
- **rapl: Modernize c_rapl_interface constructor to use std::string**
- **modernize: Batch commit of hierarchy and class modernization fixes**
- **perf: Modernize perf_event and perf_bundle to use std::string**
- **modernize: Complete modernization of remaining classes**
- **fix: Resolve regressions introduced during C++20 modernization**
