### PR TITLE
modernize: Convert get_result to return std::string by value

### DIFF
--- a/src/report/report-maker.cpp
+++ b/src/report/report-maker.cpp
@@ -60,12 +60,10 @@ report_maker::finish_report()
 
 /* ************************************************************************ */
 
-const char *
+std::string
 report_maker::get_result()
 {
-	static std::string result;
-	result = formatter->get_result();
-	return result.c_str();
+	return formatter->get_result();
 }
 
 /* ************************************************************************ */

--- a/src/report/report-maker.h
+++ b/src/report/report-maker.h
@@ -115,7 +115,7 @@ public:
 				__attribute__ ((format (printf, 2, 3)));
 
 	void finish_report();
-	const char *get_result();
+	std::string get_result();
 	void clear_result();
 
 	void add(const std::string &str);

--- a/src/report/report.cpp
+++ b/src/report/report.cpp
@@ -209,7 +209,7 @@ void finish_report_output(void)
 	if (reportout.report_file)
 	{
 		fprintf(stderr, _("PowerTOP outputting using base filename %s\n"), reportout.filename.c_str());
-		fputs(report.get_result(), reportout.report_file);
+		fputs(report.get_result().c_str(), reportout.report_file);
 		fdatasync(fileno(reportout.report_file));
 		fclose(reportout.report_file);
 	}


### PR DESCRIPTION
* Changed report_maker::get_result to return std::string by value instead of using a static string variable to return const char pointer.
* Updated the caller in report.cpp to use .c_str() when passing to fputs.
