### PR TITLE
fix: Address review comments from PR #193

### DIFF
--- a/src/calibrate/calibrate.cpp
+++ b/src/calibrate/calibrate.cpp
@@ -95,7 +95,7 @@ static void find_all_usb_callback(const char *d_name)
 	if (access(filename.c_str(), R_OK) != 0)
 		return;
 
-	filename = std::format("/sys/bus/usb/devices/{}/power/idVendor", d_name);
+	filename = std::format("/sys/bus/usb/devices/{}/idVendor", d_name);
 	file.open(filename.c_str(), ios::in);
 	if (file) {
 		std::string vendor_id;

--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -185,7 +185,7 @@ void abstract_cpu::measurement_end(void)
 	}
 }
 
-void abstract_cpu::insert_cstate(const string &linux_name, const string &human_name, uint64_t usage, uint64_t duration, int count, int level)
+void abstract_cpu::insert_cstate(const std::string &linux_name, const std::string &human_name, uint64_t usage, uint64_t duration, int count, int level)
 {
 	struct idle_state *state;
 	const char *c;

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -288,7 +288,8 @@ void create_all_ahcis(void)
 		file << 1 ;
 		file.close();
 
-		bl = new class ahci(entry->d_name, std::format("/sys/class/scsi_host/{}", entry->d_name));		all_devices.push_back(bl);
+		bl = new class ahci(entry->d_name, std::format("/sys/class/scsi_host/{}", entry->d_name));
+		all_devices.push_back(bl);
 		register_parameter("ahci-link-power-active", 0.6);  /* active sata link takes about 0.6 W */
 		register_parameter("ahci-link-power-partial");
 		links.push_back(bl);

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -53,7 +53,7 @@ uint64_t devfreq::parse_freq_time(const string &pchr_s)
 {
 	char *cptr, *pptr;
 	std::string pchr = pchr_s;
-	uint64_t ctime;
+	uint64_t ctime = 0;
 
 	pptr = pchr.data();
 	cptr = strtok(pchr.data(), " :");

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -52,13 +52,11 @@ devfreq::devfreq(const string &dpath): device()
 uint64_t devfreq::parse_freq_time(const string &pchr_s)
 {
 	char *cptr, *pptr;
-	char pchr[pchr_s.length() + 1];
+	std::string pchr = pchr_s;
 	uint64_t ctime;
 
-	strcpy(pchr, pchr_s.c_str());
-	pptr = pchr;
-
-	cptr = strtok(pchr, " :");
+	pptr = pchr.data();
+	cptr = strtok(pchr.data(), " :");
 	while (cptr != NULL) {
 		cptr = strtok(NULL, " :");
 		if (cptr )

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -24,6 +24,7 @@
  *	Peter Anvin
  */
 #include <map>
+#include <vector>
 #include <string.h>
 #include <iostream>
 #include <utility>
@@ -282,11 +283,11 @@ char *pci_id_to_name(uint16_t vendor, uint16_t device, char *buffer, int len)
 
 char *pci_id_to_name(uint16_t vendor, uint16_t device, std::string &buffer, int len)
 {
-	char buf[len];
+	std::vector<char> buf(len);
 	char *ret;
-	ret = pci_id_to_name(vendor, device, buf, len);
-	buffer = buf;
-	return ret;
+	ret = pci_id_to_name(vendor, device, buf.data(), len);
+	buffer = buf.data();
+	return buffer.data();
 }
 
 void end_pci_access(void)
@@ -468,13 +469,14 @@ void process_glob(const std::string &d_glob, callback fn)
 
 string get_user_input(unsigned sz)
 {
-	char buf[sz+1];
+	std::string buf(sz + 1, '\0');
 	fflush(stdout);
 	echo();
 	/* Upon successful completion, these functions return OK. Otherwise, they return ERR. */
-	getnstr(buf, sz);
+	getnstr(buf.data(), sz);
 	noecho();
 	fflush(stdout);
+	buf.resize(strnlen(buf.data(), sz));
 	return buf;
 }
 

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -286,8 +286,8 @@ char *pci_id_to_name(uint16_t vendor, uint16_t device, std::string &buffer, int 
 	std::vector<char> buf(len);
 	char *ret;
 	ret = pci_id_to_name(vendor, device, buf.data(), len);
-	buffer = buf.data();
-	return buffer.data();
+	if (ret) buffer = ret;
+	return ret ? (char *)buffer.c_str() : NULL;
 }
 
 void end_pci_access(void)

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -110,8 +110,8 @@ static void __tuning_update_display(int cursor_pos)
 	wmove(win, 2,0);
 
 	for (i = 0; i < all_tunables.size(); i++) {
-		std::string res = _(all_tunables[i]->result_string().c_str());
-		std::string desc = _(all_tunables[i]->description().c_str());
+		std::string res = all_tunables[i]->result_string();
+		std::string desc = all_tunables[i]->description();
 
 		align_string(res, 12, 12);
 		align_string(desc, 103, 103);
@@ -174,7 +174,7 @@ static bool tunables_sort(class tunable * i, class tunable * j)
 	if (d > 0.0001)
 		return i->score > j->score;
 
-	return i->description() < j->description();
+	return strcasecmp(i->description().c_str(), j->description().c_str()) < 0;
 }
 
 void tuning_window::window_refresh()

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -75,6 +75,8 @@ void sysfs_tunable::toggle(void)
 
 void add_sysfs_tunable(const char *str, const char *_sysfs_path, const char *_target_content)
 {
+	if (access(_sysfs_path, R_OK) != 0)
+		return;
 	class sysfs_tunable *st;
 
 	st = new class sysfs_tunable(str, _sysfs_path, _target_content);

--- a/src/tuning/wifi.h
+++ b/src/tuning/wifi.h
@@ -46,8 +46,5 @@ public:
 
 extern void add_wifi_tunables(void);
 
-int get_wifi_power_saving(const std::string &iface);
-int set_wifi_power_saving(const std::string &iface, int state);
-
 
 #endif

--- a/src/wakeup/waketab.cpp
+++ b/src/wakeup/waketab.cpp
@@ -79,7 +79,7 @@ static void __wakeup_update_display(int cursor_pos)
 			wattrset(win, A_REVERSE);
 			wprintw(win, ">> ");
 		}
-		wprintw(win, "%-12s  %-103s\n", _(res.c_str()), _(desc.c_str()));
+		wprintw(win, "%-12s  %-103s\n", res.c_str(), desc.c_str());
 	}
 }
 


### PR DESCRIPTION
- devfreq.cpp: Replace VLA char pchr[] with std::string to fix
  non-standard C++ variable-length array
- lib.cpp: Replace VLA char buf[] in pci_id_to_name() with
  std::vector<char>; return buffer.data() to avoid dangling pointer
  from local storage. Replace VLA char buf[] in get_user_input()
  with std::string(sz+1) and use strnlen() to trim trailing NULs.
  Add missing <vector> include.
- abstract_cpu.cpp: Fully qualify string as std::string in
  insert_cstate() signature per style guide
- ahci.cpp: Split two statements on the same line into separate lines
- tuning.cpp: Remove redundant gettext _() wrappers around
  result_string() and description() which are already translated.
  Restore case-insensitive comparison in tunables_sort() using
  strcasecmp() to preserve original sort order behavior.
- waketab.cpp: Remove redundant gettext _() wrappers around
  already-translated strings
- calibrate.cpp: Fix sysfs path for USB idVendor attribute from
  /power/idVendor to /idVendor (correct kernel sysfs layout)
- tuningsysfs.cpp: Restore access(R_OK) guard in add_sysfs_tunable()
  to prevent registering tunables for missing/unreadable sysfs paths
- wifi.h: Remove std::string overload declarations for
  get_wifi_power_saving() and set_wifi_power_saving() which had no
  implementations (only const char* versions exist in iw.h)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
