### PR TITLE
pci_id_to_name: single std::string implementation, remove char* overloads

### DIFF
--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -192,7 +192,6 @@ static void do_bus(const char *bus)
 
 		if (strcmp(bus, "pci") == 0) {
 			uint16_t vendor = 0, device = 0;
-			std::string pci_name;
 
 			file.open(std::format("/sys/bus/{}/devices/{}/vendor", bus, entry->d_name), ios::in);
 			if (file) {
@@ -209,7 +208,7 @@ static void do_bus(const char *bus)
 
 			if (vendor && device) {
 				dev->set_human_name(pt_format(_("PCI Device: {}"),
-					pci_id_to_name(vendor, device, pci_name, 4095)));
+					pci_id_to_name(vendor, device)));
 			}
 		}
 		all_devices.push_back(dev);

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -265,29 +265,18 @@ std::string format_watts(double W, unsigned int len)
 #ifndef HAVE_NO_PCI
 static struct pci_access *pci_access;
 
-char *pci_id_to_name(uint16_t vendor, uint16_t device, char *buffer, int len)
+std::string pci_id_to_name(uint16_t vendor, uint16_t device)
 {
-	char *ret;
-
-	buffer[0] = 0;
+	const int len = 4096;
+	std::vector<char> buf(len);
 
 	if (!pci_access) {
 		pci_access = pci_alloc();
 		pci_init(pci_access);
 	}
 
-	ret = pci_lookup_name(pci_access, buffer, len, PCI_LOOKUP_VENDOR | PCI_LOOKUP_DEVICE, vendor, device);
-
-	return ret;
-}
-
-char *pci_id_to_name(uint16_t vendor, uint16_t device, std::string &buffer, int len)
-{
-	std::vector<char> buf(len);
-	char *ret;
-	ret = pci_id_to_name(vendor, device, buf.data(), len);
-	if (ret) buffer = ret;
-	return ret ? (char *)buffer.c_str() : NULL;
+	char *ret = pci_lookup_name(pci_access, buf.data(), len, PCI_LOOKUP_VENDOR | PCI_LOOKUP_DEVICE, vendor, device);
+	return ret ? std::string(ret) : std::string();
 }
 
 void end_pci_access(void)
@@ -298,14 +287,9 @@ void end_pci_access(void)
 
 #else
 
-char *pci_id_to_name(uint16_t vendor, uint16_t device, char *buffer, int len)
+std::string pci_id_to_name(uint16_t vendor, uint16_t device)
 {
-	return NULL;
-}
-
-char *pci_id_to_name(uint16_t vendor, uint16_t device, std::string &buffer, int len)
-{
-	return NULL;
+	return std::string();
 }
 
 void end_pci_access(void)

--- a/src/lib.h
+++ b/src/lib.h
@@ -74,7 +74,7 @@ extern string read_sysfs_string(const string &filename);
 
 extern std::string format_watts(double W, unsigned int len);
 
-extern char *pci_id_to_name(uint16_t vendor, uint16_t device, std::string &buffer, int len);
+extern std::string pci_id_to_name(uint16_t vendor, uint16_t device);
 extern void end_pci_access(void);
 
 

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -72,17 +72,15 @@ runtime_tunable::runtime_tunable(const string &path, const string &bus, const st
 		}
 
 		if (vendor && device) {
-			std::string pci_name;
 			if (!device_has_runtime_pm(path)) {
-				desc = pt_format(_("PCI Device {} has no runtime power management"), pci_id_to_name(vendor, device, pci_name, 4095));
+				desc = pt_format(_("PCI Device {} has no runtime power management"), pci_id_to_name(vendor, device));
 			} else {
-				desc = pt_format(_("Runtime PM for PCI Device {}"), pci_id_to_name(vendor, device, pci_name, 4095));
+				desc = pt_format(_("Runtime PM for PCI Device {}"), pci_id_to_name(vendor, device));
 			}
 		}
 
 		if (path.find("ata") != string::npos) {
-			std::string pci_name;
-			desc = pt_format(_("Runtime PM for port {} of PCI device: {}"), port, pci_id_to_name(vendor, device, pci_name, 4095));
+			desc = pt_format(_("Runtime PM for port {} of PCI device: {}"), port, pci_id_to_name(vendor, device));
 		}
 
 		if (path.find("block") != string::npos) {


### PR DESCRIPTION
Replace the two `pci_id_to_name` overloads (one taking `char *buffer, int len` and one taking `std::string &buffer, int len`) with a single function returning `std::string` by value.

The `pci_lookup_name` call and `pci_access` initialisation are now inlined directly into the one implementation; no intermediate `char*` overload exists any more. The `#else` stub is likewise reduced to a single definition.

All call sites updated to use the new signature; temporary `pci_name` buffer variables removed.

This makes the API cleaner, safer (no dependence on static buffers or caller-managed lifetimes), and reduces the code by ~19 lines.