### PR TITLE
Fixes for compiler warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -137,7 +137,7 @@ endforeach
 
 configure_file(output: 'config.h', configuration: conf_data)
 
-add_project_arguments('-DHAVE_CONFIG_H', language: ['c', 'cpp'])
+add_project_arguments('-DHAVE_CONFIG_H', '-Wall', language: ['c', 'cpp'])
 
 # src directory
 src_inc = include_directories('src')
@@ -296,7 +296,6 @@ executable('powertop',
     rt_dep,
   ],
   cpp_args: [
-    '-Wall',
     '-Wformat',
     '-Wshadow',
     '-fno-omit-frame-pointer',

--- a/meson.build
+++ b/meson.build
@@ -137,7 +137,7 @@ endforeach
 
 configure_file(output: 'config.h', configuration: conf_data)
 
-add_project_arguments('-DHAVE_CONFIG_H', '-Wall', language: ['c', 'cpp'])
+add_project_arguments('-DHAVE_CONFIG_H', '-Wall', '-W', language: ['c', 'cpp'])
 
 # src directory
 src_inc = include_directories('src')

--- a/review/review.md
+++ b/review/review.md
@@ -61,7 +61,7 @@ Suggested fix: <proposed fix, if any. leave out if none>
 ...
 ## Medium severity items
 
-## Low severity itemms
+## Low severity items
 
 ## Nit sevirty items
 

--- a/review/review.md
+++ b/review/review.md
@@ -59,7 +59,7 @@ Suggested fix: <proposed fix, if any. leave out if none>
 
 ### High severity item #1 : <short description>
 ...
-## Medium severty items
+## Medium severity items
 
 ## Low severity itemms
 

--- a/review/review.md
+++ b/review/review.md
@@ -63,7 +63,7 @@ Suggested fix: <proposed fix, if any. leave out if none>
 
 ## Low severity items
 
-## Nit sevirty items
+## Nit severity items
 
 # Tests performed
 

--- a/review/review.md
+++ b/review/review.md
@@ -46,7 +46,7 @@ Template output format:
 
 <summary of the prompt/task>
 
-## Criticial items
+## Critical items
 
 ### Critical item #1 : <short description>
 

--- a/review/review.md
+++ b/review/review.md
@@ -23,7 +23,7 @@ function.
 In addition, load these files into the context:
 - `style.md` - Coding style guide
 - `general-c++.md` - C++ coding rules
-- 'rules.md' - PowerTOP specific coding rules
+- `rules.md` - PowerTOP specific coding rules
 
 
 ## Perform code review

--- a/review/review.md
+++ b/review/review.md
@@ -23,4 +23,54 @@ function.
 In addition, load these files into the context:
 - `style.md` - Coding style guide
 - `general-c++.md` - C++ coding rules
+- 'rules.md' - PowerTOP specific coding rules
+
+
+## Perform code review
+
+Perform your normal code review process, but also check coding style
+(`style.md`), and **in addition** use the other rules that you collected in the 
+"Gather context" phase as part of your code review.
+
+Assign a priority to each issue found: 'nit', 'low', 'medium', 'high',
+'critical'.
+
+
+## Reporting results
+Generate a report in Markdown format. Use `review.md` as filename unless the
+prompt requested a different filename or filenames.
+
+Template output format:
+```
+# PowerTOP review of <filename, git commit hash or PR number>
+
+<summary of the prompt/task>
+
+## Criticial items
+
+### Critical item #1 : <short description>
+
+Location:  <filename> : <line number>
+Description: <one or two paragraph description>
+Severity rationale: <why was this critical>
+Suggested fix: <proposed fix, if any. leave out if none>
+
+## High severity items
+
+### High severity item #1 : <short description>
+...
+## Medium severty items
+
+## Low severity itemms
+
+## Nit sevirty items
+
+# Tests performed
+
+<a list of all checks performed during this code review>
+```
+This template shows only 1 critical item for the purpose of illustration, but use the same format for any
+item found at any severity.
+
+Leave out any severity levels for which nothing was found. 
 

--- a/review/rules.md
+++ b/review/rules.md
@@ -1,0 +1,14 @@
+# PowerTOP code review checks
+
+
+
+## Directory handling
+
+- [ ] When using opendir/readdir or equivalent, the code must skip the "."
+    and ".." entries in the directory and not process them as normal
+
+
+## General checks
+
+- [ ] All user visible strings must be translatable and use the _() gettext
+    pattern

--- a/src/calibrate/calibrate.cpp
+++ b/src/calibrate/calibrate.cpp
@@ -191,7 +191,7 @@ static void set_scsi_link(const std::string &state)
 }
 
 
-static void *burn_cpu(void *dummy)
+static void *burn_cpu(void *dummy __unused)
 {
 	volatile double d = 1.1;
 
@@ -213,7 +213,7 @@ static void *burn_cpu_wakeups(void *dummy)
 	return NULL;
 }
 
-static void *burn_disk(void *dummy)
+static void *burn_disk(void *dummy __unused)
 {
 	int fd;
 	char buffer[64*1024];

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <stdint.h>
 #include <sys/time.h>
+#include "../lib.h"
 
 using namespace std;
 
@@ -129,10 +130,10 @@ public:
 
 	virtual int	has_cstate_level(int level);
 
-	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="") { return "";};
-	virtual std::string  fill_cstate_percentage(int line_nr) { return ""; };
-	virtual std::string  fill_cstate_time(int line_nr) { return ""; };
-	virtual std::string  fill_cstate_name(int line_nr) { return "";};
+	virtual std::string  fill_cstate_line(int line_nr __unused, const std::string &separator __unused ="") { return "";};
+	virtual std::string  fill_cstate_percentage(int line_nr __unused) { return ""; };
+	virtual std::string  fill_cstate_time(int line_nr __unused) { return ""; };
+	virtual std::string  fill_cstate_name(int line_nr __unused) { return "";};
 
 
 	/* P state related methods */
@@ -141,8 +142,8 @@ public:
 	void		finalize_pstate(uint64_t freq, uint64_t duration, int count);
 
 
-	virtual std::string  fill_pstate_line(int line_nr) { return "";};
-	virtual std::string  fill_pstate_name(int line_nr) { return "";};
+	virtual std::string  fill_pstate_line(int line_nr __unused) { return "";};
+	virtual std::string  fill_pstate_name(int line_nr __unused) { return "";};
 	virtual int	has_pstate_level(int level);
 	virtual int	has_pstates(void) { return 1; };
 

--- a/src/cpu/cpu_core.cpp
+++ b/src/cpu/cpu_core.cpp
@@ -30,7 +30,7 @@
 
 #include <format>
 
-std::string cpu_core::fill_cstate_line(int line_nr, const string &separator)
+std::string cpu_core::fill_cstate_line(int line_nr, const string &separator __unused)
 {
 	unsigned int i;
 

--- a/src/cpu/cpu_package.cpp
+++ b/src/cpu/cpu_package.cpp
@@ -40,7 +40,7 @@ void cpu_package::freq_updated(uint64_t time)
 
 #include <format>
 
-std::string cpu_package::fill_cstate_line(int line_nr, const string &separator)
+std::string cpu_package::fill_cstate_line(int line_nr, const string &separator __unused)
 {
 	unsigned int i;
 

--- a/src/cpu/cpu_rapl_device.cpp
+++ b/src/cpu/cpu_rapl_device.cpp
@@ -65,7 +65,7 @@ void cpu_rapl_device::end_measurement(void)
 	}
 }
 
-double cpu_rapl_device::power_usage(struct result_bundle *result, struct parameter_bundle *bundle)
+double cpu_rapl_device::power_usage(struct result_bundle *result __unused, struct parameter_bundle *bundle __unused)
 {
 	if (rapl->pp0_domain_present())
 		return consumed_power;

--- a/src/cpu/dram_rapl_device.cpp
+++ b/src/cpu/dram_rapl_device.cpp
@@ -66,7 +66,7 @@ void dram_rapl_device::end_measurement(void)
 	}
 }
 
-double dram_rapl_device::power_usage(struct result_bundle *result, struct parameter_bundle *bundle)
+double dram_rapl_device::power_usage(struct result_bundle *result __unused, struct parameter_bundle *bundle __unused)
 {
 	if (rapl->dram_domain_present())
 		return consumed_power;

--- a/src/cpu/intel_cpus.h
+++ b/src/cpu/intel_cpus.h
@@ -29,6 +29,7 @@
 #include <dirent.h>
 
 #include "cpu.h"
+#include "../lib.h"
 
 
 #define MSR_TSC				0x10
@@ -166,7 +167,7 @@ public:
 	virtual std::string  fill_pstate_line(int line_nr);
 	virtual std::string  fill_pstate_name(int line_nr);
 	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator);
-	virtual int	has_pstate_level(int level) { return 0; };
+	virtual int	has_pstate_level(int level __unused) { return 0; };
 	virtual int	has_pstates(void) { return 0; };
 	virtual void	wiggle(void) { };
 

--- a/src/cpu/intel_gpu.cpp
+++ b/src/cpu/intel_gpu.cpp
@@ -54,7 +54,7 @@ void i965_core::measurement_start(void)
 	update_cstate("gpu rc6pp", "RC6pp", 0, rc6pp_before, 1, 3);
 }
 
-std::string i965_core::fill_cstate_line(int line_nr, const string &separator)
+std::string i965_core::fill_cstate_line(int line_nr, const string &separator __unused)
 {
 	double ratio, d = -1.0, time_delta;
 
@@ -101,12 +101,12 @@ void i965_core::measurement_end(void)
 	rc6pp_after = read_sysfs("/sys/class/drm/card0/power/rc6pp_residency_ms", NULL);
 }
 
-std::string i965_core::fill_pstate_line(int line_nr)
+std::string i965_core::fill_pstate_line(int line_nr __unused)
 {
 	return "";
 }
 
-std::string i965_core::fill_pstate_name(int line_nr)
+std::string i965_core::fill_pstate_name(int line_nr __unused)
 {
 	return "";
 }

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -44,7 +44,7 @@ using namespace std;
 
 vector <class ahci *> links;
 
-static string disk_name(const string &path, const string &target, const string &shortname)
+static string disk_name(const string &path, const string &target, const string &shortname __unused)
 {
 
 	DIR *dir;

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -118,7 +118,7 @@ void devfreq::update_devfreq_freq_state(uint64_t freq, uint64_t time)
 	state->time_after = time;
 }
 
-void devfreq::parse_devfreq_trans_stat(const string &dname)
+void devfreq::parse_devfreq_trans_stat(const string &dname __unused)
 {
 	std::string filename;
 	std::string content;
@@ -179,7 +179,7 @@ void devfreq::end_measurement(void)
 	process_time_stamps();
 }
 
-double devfreq::power_usage(struct result_bundle *result, struct parameter_bundle *bundle)
+double devfreq::power_usage(struct result_bundle *result __unused, struct parameter_bundle *bundle __unused)
 {
 	return 0;
 }

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -29,6 +29,7 @@
 #include <vector>
 #include <limits.h>
 #include <string>
+#include "../lib.h"
 
 struct parameter_bundle;
 struct result_bundle;
@@ -59,13 +60,13 @@ public:
 
 	virtual std::string human_name(void) { return device_name(); };
 
-	virtual double power_usage(struct result_bundle *results, struct parameter_bundle *bundle) { return 0.0; };
+	virtual double power_usage(struct result_bundle *results __unused, struct parameter_bundle *bundle __unused) { return 0.0; };
 
 	virtual bool show_in_list(void) {return !hide;};
 
 	virtual int power_valid(void) { return 1;};
 
-	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle) { ; };
+	virtual void register_power_with_devlist(struct result_bundle *results __unused, struct parameter_bundle *bundle __unused) { ; };
 
 	virtual int grouping_prio(void) { return 0; }; /* priority of this device class if multiple classes match to the same underlying device. 0 is lowest */
 };

--- a/src/devices/gpu_rapl_device.cpp
+++ b/src/devices/gpu_rapl_device.cpp
@@ -61,7 +61,7 @@ void gpu_rapl_device::end_measurement(void)
 	}
 }
 
-double gpu_rapl_device::power_usage(struct result_bundle *result, struct parameter_bundle *bundle)
+double gpu_rapl_device::power_usage(struct result_bundle *result __unused, struct parameter_bundle *bundle __unused)
 {
 	if (rapl.pp1_domain_present())
 		return consumed_power;

--- a/src/lib.h
+++ b/src/lib.h
@@ -25,6 +25,10 @@
 #ifndef INCLUDE_GUARD_LIB_H
 #define INCLUDE_GUARD_LIB_H
 
+#define __unused __attribute__((unused))
+
+#ifdef __cplusplus
+
 #include <format>
 #include <string_view>
 
@@ -34,11 +38,14 @@ inline std::string pt_format(std::string_view fmt, Args&&... args)
 	return std::vformat(fmt, std::make_format_args(args...));
 }
 
+#include <cstring>
+#include <string>
+
+#endif
+
 #include <libintl.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <cstring>
-#include <string>
 
 /* Include only for Automake builds */
 #ifdef HAVE_CONFIG_H
@@ -51,7 +58,7 @@ inline std::string pt_format(std::string_view fmt, Args&&... args)
 #define _(STRING)    (STRING)
 #endif
 
-#define __unused __attribute__((unused))
+#ifdef __cplusplus
 
 extern int is_turbo(uint64_t freq, uint64_t max, uint64_t maxmo);
 
@@ -67,7 +74,6 @@ extern std::string kernel_function(uint64_t address);
 
 
 #include <ctime>
-#include <string>
 #include <sys/time.h>
 using namespace std;
 
@@ -106,4 +112,7 @@ extern void align_string(std::string &str, size_t min_sz, size_t max_sz);
 extern void ui_notify_user_ncurses(const std::string &msg);
 extern void ui_notify_user_console(const std::string &msg);
 extern void (*ui_notify_user) (const std::string &msg);
-#endif
+
+#endif /* __cplusplus */
+
+#endif /* INCLUDE_GUARD_LIB_H */

--- a/src/lib.h
+++ b/src/lib.h
@@ -51,6 +51,8 @@ inline std::string pt_format(std::string_view fmt, Args&&... args)
 #define _(STRING)    (STRING)
 #endif
 
+#define __unused __attribute__((unused))
+
 extern int is_turbo(uint64_t freq, uint64_t max, uint64_t maxmo);
 
 extern int get_max_cpu(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -462,6 +462,7 @@ int main(int argc, char **argv)
 			switch (c) {
 			case OPT_AUTO_TUNE_DUMP:
 				auto_tune_dump = true; // do NOT `break;` here!
+				[[fallthrough]];
 			case OPT_AUTO_TUNE:
 				auto_tune = 1;
 				leave_powertop = 1;

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -55,7 +55,7 @@ static inline int sys_perf_event_open(struct perf_event_attr *attr,
 			group_fd, flags);
 }
 
-void perf_event::create_perf_event(const string &eventname, int _cpu)
+void perf_event::create_perf_event(const string &eventname __unused, int _cpu)
 {
 	struct perf_event_attr attr;
 	int ret;

--- a/src/perf/perf.h
+++ b/src/perf/perf.h
@@ -26,6 +26,7 @@
 #define _INCLUDE_GUARD_PERF_H_
 
 #include <iostream>
+#include "../lib.h"
 
 
 extern "C" {
@@ -67,7 +68,7 @@ public:
 
 	void process(void *cookie);
 
-	virtual void handle_event(struct perf_event_header *header, void *cookie) { };
+	virtual void handle_event(struct perf_event_header *header __unused, void *cookie __unused) { };
 
 	static struct tep_handle *tep;
 

--- a/src/perf/perf_bundle.cpp
+++ b/src/perf/perf_bundle.cpp
@@ -277,7 +277,7 @@ void perf_bundle::process(void)
 	}
 }
 
-void perf_bundle::handle_trace_point(void *trace, int cpu, uint64_t time)
+void perf_bundle::handle_trace_point(void *trace __unused, int cpu __unused, uint64_t time __unused)
 {
 	printf("UH OH... abstract handle_trace_point called\n");
 }

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -46,7 +46,7 @@ void process::account_disk_dirty(void)
 	disk_hits++;
 }
 
-void process::schedule_thread(uint64_t time, int thread_id)
+void process::schedule_thread(uint64_t time, int thread_id __unused)
 {
 	running_since = time;
 	running = 1;

--- a/src/report/report-formatter-csv.cpp
+++ b/src/report/report-formatter-csv.cpp
@@ -58,6 +58,7 @@ report_formatter_csv::escape_string(const string &str)
 		switch (str[i]) {
 			case '"':
 				res += '"';
+				[[fallthrough]];
 #ifdef REPORT_CSV_SPACE_NEED_QUOTES
 			case ' ':
 #endif /* REPORT_CSV_SPACE_NEED_QUOTES */
@@ -96,8 +97,8 @@ report_formatter_csv::add_logo()
 }
 
 
-void
-report_formatter_csv::add_div(struct tag_attr * div_attr)
+void report_formatter_csv::add_div(struct tag_attr * div_attr __unused)
+
 {
 	add_exact("\n");
 }
@@ -108,8 +109,8 @@ report_formatter_csv::end_div()
 	/*Do nothing*/
 }
 
-void
-report_formatter_csv::add_title(struct tag_attr *title_att, const string &title)
+void report_formatter_csv::add_title(struct tag_attr *title_att __unused, const string &title)
+
 {
 	add_exact("____________________________________________________________________\n");
 	add_exact(std::format(" *  *  *   {}   *  *  *\n", title));

--- a/src/report/report-formatter.h
+++ b/src/report/report-formatter.h
@@ -28,6 +28,7 @@
 
 #include <vector>
 #include "report-maker.h"
+#include "../lib.h"
 using namespace std;
 
 class report_formatter
@@ -39,19 +40,19 @@ public:
 	virtual std::string get_result() {return "Basic report_formatter::get_result() call\n";}
 	virtual void clear_result() {}
 
-	virtual void add(const std::string &str) {}
+	virtual void add(const std::string &str __unused) {}
 
 	/* *** Report Style *** */
 	virtual void add_logo() {}
 	virtual void add_header() {}
 	virtual void end_header() {}
-	virtual void add_div(struct tag_attr *div_attr) {}
+	virtual void add_div(struct tag_attr *div_attr __unused) {}
 	virtual void end_div() {}
-	virtual void add_title(struct tag_attr *att_title, const std::string &title) {}
+	virtual void add_title(struct tag_attr *att_title __unused, const std::string &title __unused) {}
 	virtual void add_navigation() {}
-	virtual void add_summary_list(const std::vector<std::string> &list) {}
-	virtual void add_table(const std::vector<std::string> &system_data,
-			struct table_attributes *tb_attr)     {}
+	virtual void add_summary_list(const std::vector<std::string> &list __unused) {}
+	virtual void add_table(const std::vector<std::string> &system_data __unused,
+			struct table_attributes *tb_attr __unused)     {}
 };
 
 #endif /* _REPORT_FORMATTER_H_ */

--- a/src/tuning/iw.c
+++ b/src/tuning/iw.c
@@ -49,6 +49,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <asm/errno.h>
 #include <linux/genetlink.h>
 #include "iw.h"
+#include "../lib.h"
 
 
 #ifndef HAVE_LIBNL20
@@ -123,8 +124,8 @@ static void nl80211_cleanup(struct nl80211_state *state)
 static int enable_power_save;
 
 
-static int set_power_save(struct nl80211_state *state,
-			  struct nl_cb *cb,
+static int set_power_save(struct nl80211_state *state __unused,
+			  struct nl_cb *cb __unused,
 			  struct nl_msg *msg)
 {
 	enum nl80211_ps_state ps_state;
@@ -141,7 +142,7 @@ static int set_power_save(struct nl80211_state *state,
 	return -ENOBUFS;
 }
 
-static int print_power_save_handler(struct nl_msg *msg, void *arg)
+static int print_power_save_handler(struct nl_msg *msg, void *arg __unused)
 {
 	struct nlattr *attrs[NL80211_ATTR_MAX + 1];
 	struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
@@ -165,16 +166,16 @@ static int print_power_save_handler(struct nl_msg *msg, void *arg)
 	return NL_SKIP;
 }
 
-static int get_power_save(struct nl80211_state *state,
+static int get_power_save(struct nl80211_state *state __unused,
 				   struct nl_cb *cb,
-				   struct nl_msg *msg)
+				   struct nl_msg *msg __unused)
 {
 	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM,
 		  print_power_save_handler, NULL);
 	return 0;
 }
 
-static int error_handler(struct sockaddr_nl *nla, struct nlmsgerr *err,
+static int error_handler(struct sockaddr_nl *nla __unused, struct nlmsgerr *err,
 			 void *arg)
 {
 	int *ret = arg;
@@ -182,14 +183,14 @@ static int error_handler(struct sockaddr_nl *nla, struct nlmsgerr *err,
 	return NL_STOP;
 }
 
-static int finish_handler(struct nl_msg *msg, void *arg)
+static int finish_handler(struct nl_msg *msg __unused, void *arg)
 {
 	int *ret = arg;
 	*ret = 0;
 	return NL_SKIP;
 }
 
-static int ack_handler(struct nl_msg *msg, void *arg)
+static int ack_handler(struct nl_msg *msg __unused, void *arg)
 {
 	int *ret = arg;
 	*ret = 0;

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -45,7 +45,7 @@
 #include "../lib.h"
 #include "wakeup_ethernet.h"
 
-ethernet_wakeup::ethernet_wakeup(const string &path, const string &iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
+ethernet_wakeup::ethernet_wakeup(const string &path __unused, const string &iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
 	interf = iface;
 	desc = pt_format(_("Wake-on-lan status for device {}"), iface);

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -45,7 +45,7 @@
 #include "../lib.h"
 #include "wakeup_usb.h"
 
-usb_wakeup::usb_wakeup(const string &path, const string &iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
+usb_wakeup::usb_wakeup(const string &path __unused, const string &iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
 	interf = iface;
 	desc = pt_format(_("Wake status for USB device {}"), iface);


### PR DESCRIPTION
- **build: include -Wall in project-wide compiler flags**
- **build: add -W to project-wide compiler flags**
- **lib: add __unused macro for compiler unused attribute**
- **wakeup: use __unused for unused 'path' parameter in usb_wakeup**
- **new review rules file**
- **inlcude review rules**
- **lib: move __unused macro and protect C++ content**
- **headers: apply __unused to virtual method parameters**
- **src: silence unused parameter and fallthrough warnings**
- **tuning: fix unused parameter warnings in iw.c**
