### PR TITLE
First batch of code review based fixes

### DIFF
--- a/local.md
+++ b/local.md
@@ -17,6 +17,13 @@ The process for working on this codebase always consists for 4 steps
 Also read `review/tools.md` when you're asked to use the various
 tooling to create and manipulate test data.
 
+# Code style notes
+
+- `using namespace std;` has been removed from all 50 source files (commit 41e0502).
+  The codebase now requires explicit `std::` qualification — bare `string`, `map`,
+  `vector`, etc. are unqualified and the build is currently broken until qualifiers
+  are added.
+
 # Prefered user style
 
 When asked to make a non-trivial change (multiple files/elements), create a

--- a/local.md
+++ b/local.md
@@ -19,6 +19,8 @@ tooling to create and manipulate test data.
 
 # Code style notes
 
+- All 59 header files now use `#pragma once` instead of `#ifndef`/`#define`/`#endif` include guards (commit 17c3046).
+
 - `using namespace std;` has been removed from all 50 source files (commit 41e0502).
   All bare STL names (string, vector, map, cout, etc.) have been explicitly qualified
   with std:: throughout the codebase (commit cb42d45). The build is now clean.

--- a/local.md
+++ b/local.md
@@ -20,9 +20,8 @@ tooling to create and manipulate test data.
 # Code style notes
 
 - `using namespace std;` has been removed from all 50 source files (commit 41e0502).
-  The codebase now requires explicit `std::` qualification — bare `string`, `map`,
-  `vector`, etc. are unqualified and the build is currently broken until qualifiers
-  are added.
+  All bare STL names (string, vector, map, cout, etc.) have been explicitly qualified
+  with std:: throughout the codebase (commit cb42d45). The build is now clean.
 
 # Prefered user style
 

--- a/logs.1/critical.md
+++ b/logs.1/critical.md
@@ -1,0 +1,99 @@
+
+## Review of interrupt.h, interrupt.cpp, timer.cpp, timer.h, do_process.cpp — batch 09
+
+### Critical item #1 : change_blame accesses cpu_level/cpu_blame without bounds check
+
+Location: src/process/do_process.cpp : 144
+Description: `change_blame()` accesses `cpu_level[cpu]` and `cpu_blame[cpu]` directly without any bounds check. By contrast, `consume_blame()` (line 152) does check bounds before accessing the same vectors. Both vectors are resized in `process_process_data()` to `get_max_cpu()+1`, but a trace event may carry a CPU number larger than `get_max_cpu()` (e.g., due to CPU hotplug or late-arriving events). An out-of-bounds write to these vectors is undefined behaviour and will likely cause a crash or silent data corruption.
+Severity rationale: Direct, unconditional write to a potentially out-of-bounds vector index; the inconsistency with `consume_blame` shows the missing guard is an oversight rather than intentional design.
+Suggested fix:
+```cpp
+static void change_blame(unsigned int cpu, class power_consumer *consumer, int level)
+{
+    if (cpu_level.size() <= cpu || cpu_blame.size() <= cpu)
+        return;
+    if (cpu_level[cpu] >= level)
+        return;
+    cpu_blame[cpu] = consumer;
+    cpu_level[cpu] = level;
+}
+```
+
+### Critical item #2 : perf_events dangling pointer after clear_process_data
+
+Location: src/process/do_process.cpp : 1213
+Description: `clear_process_data()` calls `delete perf_events` but never sets `perf_events = nullptr`. The variable is a file-scope static and retains the stale pointer value. If `start_process_measurement()` is subsequently called (e.g., on a second measurement run), the guard `if (!perf_events)` evaluates to *false* because the pointer is non-null, the initialisation block is skipped entirely, and `perf_events->start()` is invoked on the freed object — a classic use-after-free leading to undefined behaviour / crash.
+Severity rationale: Directly causes a use-after-free on any second invocation of the measurement cycle, which is normal PowerTOP operation.
+Suggested fix: Add `perf_events = nullptr;` immediately after `delete perf_events;` in `clear_process_data()`.
+
+## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
+
+### Critical item #1 : Null pointer dereference in `set_event_name` after `parse_event_format` succeeds
+
+Location: src/perf/perf.cpp : 163
+Description: In `set_event_name`, after `parse_event_format` returns success (ret >= 0), `tep_find_event_by_name` is called a second time. If it still returns NULL (e.g. the event was parsed but the name lookup fails), execution falls through to `trace_type = event->id` on the very next line with a NULL `event` pointer. No null check is present after the second call.
+Severity rationale: This is a direct null pointer dereference that will crash the process whenever an event format is parseable but not findable by name — a realistic scenario for any unexpected trace event name.
+Suggested fix:
+```cpp
+event = tep_find_event_by_name(perf_event::tep, system_name.c_str(), event_name.c_str());
+if (!event) {
+    trace_type = -1;
+    return;
+}
+trace_type = event->id;
+```
+
+### Critical item #2 : Null pointer dereference of `pc` after mmap failure in `process()`
+
+Location: src/perf/perf.cpp : 231
+Description: In `create_perf_event`, if `mmap()` fails the function returns early (line 122) without setting `pc` or `data_mmap`. However `perf_fd` has already been set to a valid file descriptor. The guard in `process()` only checks `if (perf_fd < 0)`, so when mmap has failed but `perf_fd` is valid, execution proceeds to `pc->data_tail` where `pc` is NULL (set only in the constructors, not explicitly initialized to NULL there either). This is an unconditional null pointer dereference.
+Severity rationale: Any call to `process()` after a mmap failure will crash the process. mmap failures are realistic (e.g. under low memory or file-descriptor pressure).
+Suggested fix: On mmap failure in `create_perf_event`, close and reset `perf_fd` to -1 before returning, so the guard in `process()` will correctly skip processing. Also initialize `pc = nullptr` and `data_mmap = nullptr` in both constructors.
+
+### Critical item #3 : `malloc` return value unchecked before `memcpy` in `handle_event`
+
+Location: src/perf/perf_bundle.cpp : 63
+Description: `malloc(header->size)` is called and its return value is immediately passed to `memcpy` without any null check. If the allocation fails, `buffer` is NULL and `memcpy(NULL, ...)` is undefined behavior and will crash the process.
+Severity rationale: `malloc` is documented to return NULL on allocation failure. Writing to a NULL pointer is undefined behavior and will cause a segfault in practice.
+Suggested fix:
+```cpp
+buffer = (unsigned char *)malloc(header->size);
+if (!buffer) {
+    fprintf(stderr, _("Out of memory in perf handle_event\n"));
+    return;
+}
+memcpy(buffer, header, header->size);
+```
+
+## Review of src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp — batch 16
+
+### Critical item #1 : Null pointer dereference of `cpu` in handle_trace_point
+
+Location: src/cpu/cpu.cpp : 953
+Description: In `perf_power_bundle::handle_trace_point`, after the upper-bounds check
+`if (cpunr >= (int)all_cpus.size())`, the code assigns `cpu = all_cpus[cpunr]`.
+The `all_cpus` vector is populated with explicit NULL sentinels when resized
+(`all_cpus.resize(number + 1, NULL)`), so any slot not filled by `handle_one_cpu`
+(e.g., due to non-contiguous CPU numbering, CPU hot-unplug, or late
+enumeration) will be NULL. `cpu` is then used unconditionally at lines 973, 975,
+987, 991, and 993 (`cpu->go_unidle`, `cpu->go_idle`, `cpu->change_freq`) with no
+null check, causing an immediate null pointer dereference and crash whenever a
+perf event arrives for such a slot.
+Severity rationale: This directly and materially crashes powertop on systems
+with non-contiguous CPU numbers or after CPU hot-unplug, which are common on
+server platforms and any machine that has ever used CPU hotplug.
+Suggested fix:
+```cpp
+cpu = all_cpus[cpunr];
+if (!cpu)
+    return;
+```
+
+## Review of src/measurement/extech.cpp — batch 21
+
+### Critical item #1 : parse_packet validation loop uses `i * 0` instead of `i * 5`
+
+Location: src/measurement/extech.cpp : 216
+Description: The outer validation loop in `parse_packet` iterates `i` from 0 to 3, but uses `i * 0` as the index, which is always 0. Consequently all four iterations check only `buf[0] != 2` and `buf[0 + 4] != 3`, never validating the 2nd, 3rd, or 4th five-byte packet. Any corrupt or truncated packet that has valid bytes at positions 0 and 4 will silently pass validation. The intended expression is `i * 5` and `i * 5 + 4`.
+Severity rationale: The validation function is completely broken for all but the first packet block. Malformed packets can pass undetected, leading to incorrect power readings being reported to users — this directly and materially impacts the tool's core measurement function.
+Suggested fix: Change `p->buf[i * 0]` to `p->buf[i * 5]` and `p->buf[i * 0 + 4]` to `p->buf[i * 5 + 4]`.

--- a/logs.1/high.md
+++ b/logs.1/high.md
@@ -1,0 +1,862 @@
+# PowerTOP High Severity Review Findings
+
+## Review of calibrate.cpp, calibrate.h, lib.cpp, devlist.cpp, main.cpp — batch 01
+
+### High item #1 : Missing thread joins in calibration functions
+
+Location: src/calibrate/calibrate.cpp : 240–376
+
+Description:
+`cpu_calibration()` (line 248) calls `pthread_create` in a loop but re-uses the single `thr` variable, discarding all but the last thread handle. None of the calibration functions — `cpu_calibration`, `wakeup_calibration`, `disk_calibration` — call `pthread_join` before returning. The pattern used is `stop_measurement = 1; sleep(1);` and then returning. The calibration threads may still be running when the next calibration phase begins, or when `calibrate()` returns and the program proceeds. This is a race condition and resource leak.
+
+Severity rationale: Multiple threads reading and writing shared state (`stop_measurement`, I/O, power measurement data) without synchronization can corrupt results or cause crashes.
+
+Suggested fix: Store all created thread handles and call `pthread_join` on each after setting `stop_measurement = 1`. For the CPU calibration loop, store handles in a local `std::vector<pthread_t>`.
+
+---
+
+### High item #2 : `system()` return value check is inverted in calibration functions
+
+Location: src/calibrate/calibrate.cpp : 342–356
+
+Description:
+In both `backlight_calibration` and `idle_calibration`, the condition used is:
+```cpp
+if (!system("DISPLAY=:0 /usr/bin/xset dpms force off"))
+    printf("System is not available\n");
+```
+`system()` returns 0 on success. `!0` evaluates to `true`, so the message is printed when the command **succeeds**, not when it fails. The error message is thus never visible on a system where xset works, and no error is reported when it fails. Additionally, the message `"System is not available\n"` is not wrapped in `_()` and is therefore not translatable.
+
+Severity rationale: Inverted error checking means calibration silently proceeds even when the display power command failed. The user sees a confusing message on success instead.
+
+Suggested fix:
+```cpp
+if (system("DISPLAY=:0 /usr/bin/xset dpms force off") != 0)
+    printf(_("Failed to set display power state\n"));
+```
+
+---
+
+### High item #3 : `clean_open_devices()` leaves dangling pointers in vectors
+
+Location: src/devlist.cpp : 76–91
+
+Description:
+`clean_open_devices()` deletes all allocated `devuser` and `devpower` objects but never calls `.clear()` on the `one`, `two`, or `devpower` vectors. After the function returns, all three vectors contain dangling pointers. Any subsequent call to `collect_open_devices()` iterates `target` to delete its contents before refilling (lines 107–110), but if `clean_open_devices()` was called first, those deletes operate on already-freed memory — use-after-free.
+
+Severity rationale: Double-free / use-after-free is undefined behaviour and can cause crashes or memory corruption.
+
+Suggested fix: Add `.clear()` calls at the end of each delete loop in `clean_open_devices()`:
+```cpp
+one.clear();
+two.clear();
+devpower.clear();
+```
+
+---
+
+### High item #4 : `fmt_prefix` — no bounds check before indexing `prefixes[]`
+
+Location: src/lib.cpp : 351–413
+
+Description:
+```cpp
+static const char prefixes[] = "yzafpnum kMGTPEZY";  // indices 0..16
+...
+pfx = prefixes[npfx + 8];
+```
+`npfx` is derived as `((omag + 27) / 3) - 9`. For `omag = -27` → `npfx = -9` → index `-1` (before the array). For `omag >= 27` → index `>= 17` (past the null terminator). The SI prefix table only covers yocto (10⁻²⁴) to yotta (10²⁴), i.e., `omag` must stay in `[-24, +24]`. Any value outside that range — which can occur with very small denormalized or very large floating-point inputs — reads out of bounds.
+
+Severity rationale: Out-of-bounds read from a static array is undefined behaviour; on certain architectures this could return a garbage prefix character or trigger a fault.
+
+Suggested fix: Clamp `npfx` before use:
+```cpp
+npfx = std::clamp(npfx, -8, 8);
+```
+
+---
+
+### High item #5 : `freopen` return-value check is inverted for `-q` (quiet) mode
+
+Location: src/main.cpp : 512–514
+
+Description:
+```cpp
+case 'q':
+    if (freopen("/dev/null", "a", stderr))
+        fprintf(stderr, _("Quiet mode failed!\n"));
+    break;
+```
+`freopen` returns the stream pointer on **success** and `NULL` on failure. The condition is true when `freopen` succeeds (quiet mode worked), so the "Quiet mode failed!" message is printed to `/dev/null` (invisible). When `freopen` fails, nothing is printed and `stderr` is left in an indeterminate state (undefined behaviour per C standard). The `!` is missing.
+
+Severity rationale: A `freopen` failure leaves `stderr` in an undefined state; any subsequent `fprintf(stderr, …)` is undefined behaviour. The diagnostic message is also never actually shown.
+
+Suggested fix:
+```cpp
+case 'q':
+    if (!freopen("/dev/null", "a", stderr))
+        fprintf(stderr, _("Quiet mode failed!\n"));
+    break;
+```
+
+## Review of src/test_framework.h, src/test_framework.cpp, src/display.cpp, src/display.h, src/lib.h — batch 02
+
+### High item #1 : `using namespace std;` in display.h header
+
+Location: src/display.h : 33
+Description: `using namespace std;` appears in a header file. Because display.h is included by many translation units, this silently injects the entire `std` namespace into every includer's scope, leading to name collisions, ambiguous lookups, and hard-to-diagnose compilation failures. Style rule 4.2 and general-c++.md both explicitly forbid this. The impact in a header is far worse than in a .cpp file.
+Severity rationale: Header-file namespace pollution affects the entire build; violates an explicit project rule.
+Suggested fix: Remove the `using namespace std;` line and qualify all identifiers with `std::` (e.g., `std::map`, `std::string`).
+
+---
+
+### High item #2 : `using namespace std;` in lib.h header
+
+Location: src/lib.h : 78
+Description: Same issue as display.h but worse: lib.h is the project's most widely-included header (pulled in by virtually every translation unit). The `using namespace std;` inside the `#ifdef __cplusplus` block silently exposes the full `std` namespace everywhere. The function declarations on lines 80–84 already benefit from this (`string` instead of `std::string`), making them incorrect as well once the directive is removed.
+Severity rationale: Affects the entire codebase; any future std symbol added by a compiler upgrade can silently shadow application-level names.
+Suggested fix: Remove `using namespace std;`. Replace bare `string` with `std::string` on the affected `extern` declarations (lines 80–84). Qualified uses like `std::string` on lines 69–93 are already correct.
+
+---
+
+### High item #3 : Missing bounds check in `show_tab()` before indexing `tab_names`
+
+Location: src/display.cpp : 125
+Description: `show_tab(unsigned int tab)` immediately indexes `tab_names[tab]` at line 125 without verifying that `tab < tab_names.size()`. An out-of-bounds access invokes undefined behaviour; on a typical STL implementation it will read garbage memory or crash. The function is called directly from external code with a caller-supplied index, making the missing check a real risk.
+Severity rationale: Out-of-bounds vector access is undefined behaviour and can crash the process.
+Suggested fix:
+```cpp
+void show_tab(unsigned int tab)
+{
+if (!display || tab >= tab_names.size())
+return;
+```
+
+---
+
+### High item #4 : Tab position calculated from internal name length instead of translated name length
+
+Location: src/display.cpp : 143
+Description: Inside the loop in `show_tab()`, the rendered string is `tab_translations[tab_names[i]]` (the translated name), but the horizontal advance `tab_pos` is incremented by `tab_names[i].length()` — the length of the *internal* (English) key, not the displayed translation. When a translation is longer than the key, tabs will visually overlap or be misaligned; when shorter, there will be extra gaps. This is a functional display bug.
+Severity rationale: Produces incorrect on-screen layout for any locale where translation lengths differ from internal names.
+Suggested fix:
+```cpp
+tab_pos += 3 + tab_translations[tab_names[i]].length();
+```
+
+## Review of src/tuning/tunable.h, src/tuning/runtime.h, src/tuning/runtime.cpp — batch 03
+
+### High item #1 : `using namespace std;` in header file tunable.h
+
+Location: src/tuning/tunable.h : 34
+Description: `using namespace std;` appears at file scope in a header file. Every translation unit that includes `tunable.h` (directly or transitively) will have the entire `std` namespace injected into its global namespace, causing potential name collisions and violating the project's coding style.
+Severity rationale: Header-level namespace pollution is a HIGH issue per style.md §4.2 and general-c++.md — it affects all includers and cannot be undone by the including translation unit.
+Suggested fix: Remove the `using namespace std;` line. Replace all unqualified `string` usages in the header with `std::string` (already done for most; the `string` parameters in constructor declarations on line 55 rely on this directive).
+
+### High item #2 : `using namespace std;` in header file runtime.h
+
+Location: src/tuning/runtime.h : 32
+Description: Same violation as in tunable.h — `using namespace std;` at file scope in a header file pollutes every includer's namespace.
+Severity rationale: Same as item #1. Both `tunable.h` and `runtime.h` have this issue; `runtime.h` also includes `tunable.h`, compounding the pollution.
+Suggested fix: Remove the `using namespace std;` line. Qualify all bare `string` references with `std::string`.
+
+### High item #3 : Logic bug — `"on"` returns `TUNE_GOOD` in `good_bad()`
+
+Location: src/tuning/runtime.cpp : 102–103
+Description: In `runtime_tunable::good_bad()`, the control value `"on"` (which means the device is forced always-on, disabling runtime power management) incorrectly returns `TUNE_GOOD`. Only `"auto"` (kernel may auto-suspend the device) should be `TUNE_GOOD`; `"on"` should return `TUNE_BAD`. As a result, `toggle()` will always write `"on"` (since `good_bad()` returns `TUNE_GOOD` for both states) and will never write `"auto"`, making it impossible to enable runtime PM via PowerTOP's toggle. The generated `toggle_script()` also always returns the "turn on" script for the same reason.
+Severity rationale: This is a functional correctness bug. The core purpose of this class — enabling runtime power management — is broken. Devices stuck in `"on"` mode cannot be toggled to `"auto"` through PowerTOP.
+Suggested fix: Change line 102–103 to return `TUNE_BAD` for `"on"`:
+```cpp
+if (content == "on")
+    return TUNE_BAD;
+```
+
+## Review of ethernet.cpp, ethernet.h, wifi.cpp, wifi.h, tuningusb.h — batch 04
+
+### High item #1 : `using namespace std;` in header file ethernet.h
+
+Location: src/tuning/ethernet.h : 32
+Description: `using namespace std;` is present at file scope in a header. This pollutes the namespace of every translation unit that includes this header, which is explicitly forbidden by the style guide and general-c++ rules. Any file including ethernet.h will have the entire `std` namespace injected.
+Severity rationale: The style guide explicitly states "Avoid `using namespace std;`" and general-c++.md marks it as a deprecated construct. Headers are the worst place for this because the pollution is invisible to includers.
+Suggested fix: Remove the `using namespace std;` line. The class already correctly uses `std::string` for its members, so no other changes are needed.
+
+### High item #2 : `using namespace std;` in header file wifi.h
+
+Location: src/tuning/wifi.h : 34
+Description: Same issue as ethernet.h — `using namespace std;` at file scope in a header contaminates all includers. The constructor parameter already uses `std::string`, and the member uses `std::string`, so the `using` declaration is entirely unnecessary.
+Severity rationale: Same as High item #1; prohibited by both style.md and general-c++.md.
+Suggested fix: Remove the `using namespace std;` line from wifi.h.
+
+### High item #3 : `using namespace std;` in header file tuningusb.h
+
+Location: src/tuning/tuningusb.h : 33
+Description: Same issue — `using namespace std;` at file scope in a public header. All three affected headers (ethernet.h, wifi.h, tuningusb.h) share this violation.
+Severity rationale: Same as High items #1 and #2.
+Suggested fix: Remove the `using namespace std;` line from tuningusb.h.
+
+### High item #4 : Unchecked `ioctl` return value for `SIOCETHTOOL` in `good_bad()`
+
+Location: src/tuning/ethernet.cpp : 87
+Description: The `ioctl(sock, SIOCETHTOOL, &ifr)` call to fetch WoL info (`ETHTOOL_GWOL`) has its return value silently discarded. If the ioctl fails (e.g., the interface does not support ethtool, or an error occurs), `wol.wolopts` will remain zero (from the preceding memset), causing the function to silently return `TUNE_GOOD` — a false "good" result. The interface may actually have WoL enabled and the diagnostic will miss it.
+Severity rationale: Incorrect diagnostic result on ioctl failure; the code operates on stale/initialised-to-zero data rather than real device state. This is a logic correctness issue.
+Suggested fix:
+```cpp
+ret = ioctl(sock, SIOCETHTOOL, &ifr);
+if (ret < 0) {
+    close(sock);
+    return TUNE_UNKNOWN;
+}
+```
+
+### High item #5 : `new` without `std::nothrow` and no null check in `add_wifi_tunables()`
+
+Location: src/tuning/wifi.cpp : 91
+Description: `wifi = new class wifi_tunable(entry->d_name);` uses plain `new`, which throws `std::bad_alloc` on allocation failure. Unlike the analogous `ethtunable_callback()` in ethernet.cpp which correctly uses `new(std::nothrow)` followed by a null check, `add_wifi_tunables()` neither catches the exception nor uses the nothrow form. An allocation failure will propagate an unhandled exception, potentially crashing powertop.
+Severity rationale: Inconsistency with the established pattern and risk of unhandled exception causing a crash.
+Suggested fix:
+```cpp
+wifi = new(std::nothrow) wifi_tunable(entry->d_name);
+if (wifi)
+    all_tunables.push_back(wifi);
+```
+
+### High item #6 : Wi-Fi interface detection misses modern predictable interface names
+
+Location: src/tuning/wifi.cpp : 90
+Description: `strstr(entry->d_name, "wlan")` only matches interfaces whose name contains the substring "wlan" (e.g., `wlan0`). On systems using systemd's predictable network interface naming (the default on virtually all modern Linux distributions), wireless interfaces are named `wlp2s0`, `wlx001122334455`, etc. — none of which contain "wlan". Power saving will silently not be applied to any wireless interface on a modern system.
+Severity rationale: Functional regression on modern Linux — power-saving tunable is never created for the majority of real-world Wi-Fi interfaces.
+Suggested fix: Check the interface type via `/sys/class/net/<iface>/phy80211` or match using the `wl` prefix that all wireless interfaces share:
+```cpp
+if (strncmp(entry->d_name, "wl", 2) == 0) {
+```
+
+## Review of tuningusb.cpp, tuning.cpp, tuning.h, bluetooth.cpp, bluetooth.h — batch 05
+
+### High item #1 : `using namespace std;` in a header file
+
+Location: src/tuning/bluetooth.h : 32
+Description: `using namespace std;` appears at file scope in a public header. This injects the entire `std` namespace into every translation unit that includes bluetooth.h, which can silently cause name clashes or ambiguities that are hard to diagnose. The project style guide explicitly forbids this.
+Severity rationale: Header-level namespace pollution affects every consumer of the header. The style guide explicitly prohibits `using namespace std;`.
+Suggested fix: Remove the `using namespace std;` line. The only std type used in the class declaration is inherited indirectly via `tunable.h`; bluetooth.h itself does not need the directive.
+
+### High item #2 : Deprecated `hcitool` used to detect active Bluetooth connections
+
+Location: src/tuning/bluetooth.cpp : 144
+Description: `popen("/usr/bin/hcitool con 2> /dev/null", "r")` invokes the `hcitool` command, which was deprecated in BlueZ 5.x (circa 2014) and removed from many modern distributions. On systems where `/usr/bin/hcitool` is absent or a stub, popen still succeeds (the shell starts) but produces no useful output, meaning the second fgets call returns NULL immediately. The code then concludes there are no connections and returns `TUNE_GOOD` (BT interface is idle), potentially toggling BT off when it is in active use.
+Severity rationale: Silent functional regression on all modern Linux systems — Bluetooth may be disabled while connections are active. The hardcoded path also fails silently if moved.
+Suggested fix: Replace with a D-Bus query via the BlueZ 5 API (e.g., `org.bluez.Device1.Connected`), or use `/sys/class/bluetooth/hci0/` sysfs attributes, or at minimum check for `bluetoothctl` before falling back to `hcitool`.
+
+### High item #3 : Redefinition of implementation-reserved `__`-prefixed identifiers
+
+Location: src/tuning/bluetooth.cpp : 60–62
+Description: The file defines `#define __u16 uint16_t`, `#define __u8 uint8_t`, and `#define __u32 uint32_t`. All identifiers beginning with `__` (two underscores) are reserved for the C/C++ implementation. Redefining them is undefined behavior and can silently conflict with identically named macros or typedefs in `<stdint.h>`, kernel uapi headers, or glibc, leading to type mismatches or build failures depending on include order.
+Severity rationale: Undefined behavior; platform-specific headers already define these names; conflicts will manifest differently per toolchain version.
+Suggested fix: Replace the three macros with type aliases using non-reserved names, or simply use `uint8_t`, `uint16_t`, `uint32_t` directly in the struct definitions and remove the `#define` lines.
+
+## Review of src/tuning/tuningsysfs.cpp, src/tuning/tuningsysfs.h, src/tuning/nl80211.h, src/tuning/iw.h, src/tuning/iw.c — batch 06
+
+### High item #1 : Resource leak when NLA_PUT_U32 fails in __handle_cmd
+
+Location: src/tuning/iw.c : 234 / 261
+Description: The `NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, devidx)` macro expands to a `goto nla_put_failure` on failure. The `nla_put_failure:` label is placed at line 261, *after* the cleanup labels `out:` (which calls `nl_cb_put(cb)`) and `out_free_msg:` (which calls `nlmsg_free(msg)`). As a result, when `NLA_PUT_U32` fails, execution jumps directly to `nla_put_failure:`, bypassing both cleanup steps. Both `cb` (allocated at line 219) and `msg` (allocated at line 213) are leaked on every such failure path.
+Severity rationale: Confirmed resource leak bug on an error path; in a power-management tool that may call this for every wireless interface on every cycle, repeated nl80211 allocation failures could exhaust file descriptors or memory.
+Suggested fix: Move the `nla_put_failure:` label *before* `out:` so it falls through into the normal cleanup chain:
+```c
+ nla_put_failure:
+    fprintf(stderr, "building message failed\n");
+    err = -ENOBUFS;
+ out:
+    nl_cb_put(cb);
+ out_free_msg:
+    nlmsg_free(msg);
+    return err;
+```
+
+### High item #2 : `using namespace std` in a header file
+
+Location: src/tuning/tuningsysfs.h : 33
+Description: `using namespace std;` appears at file scope in the header. This injects the entire `std` namespace into every translation unit that includes `tuningsysfs.h`, including transitively included files. This is explicitly prohibited by both `style.md` ("Avoid `using namespace std;`") and `general-c++.md` ("`using namespace std;` is a deprecated construct"). The effect is especially harmful in a header because it cannot be undone by including files.
+Severity rationale: Namespace pollution in a header affects all consumers; can silently cause name collisions that are hard to diagnose.
+Suggested fix: Remove line 33 (`using namespace std;`). All uses of `string` in the header already use the fully qualified `std::string`, so no other changes are required.
+
+### High item #3 : Unchecked return value of nla_parse() in print_power_save_handler
+
+Location: src/tuning/iw.c : 150
+Description: `nla_parse(attrs, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL)` can return a negative error code if the attribute buffer is malformed. The return value is discarded. If parsing fails, the `attrs` array may be partially or incorrectly filled; accessing `attrs[NL80211_ATTR_PS_STATE]` on the next line then reads potentially uninitialised pointer data.  The practical consequence is that `enable_power_save` silently remains at its previous value rather than being updated to reflect the actual state returned by the kernel.
+Severity rationale: Unchecked return value of a function that can fail; leads to silent, incorrect power-save state reporting.
+Suggested fix:
+```c
+if (nla_parse(attrs, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
+              genlmsg_attrlen(gnlh, 0), NULL) < 0)
+    return NL_SKIP;
+```
+
+## Review of tuningi2c.h, tuningi2c.cpp, powerconsumer.h, powerconsumer.cpp, processdevice.h — batch 07
+
+### High item #1 : Division by zero risk on `measurement_time`
+
+Location: src/process/powerconsumer.cpp : 59, 83, 92 and src/process/powerconsumer.h : 68
+Description: `measurement_time` is used as a divisor in `Witts()` (line 59), `usage()` (lines 83, 92), and the inline `events()` method (powerconsumer.h:68) without any guard against it being zero. If `measurement_time == 0` (e.g. at startup before the first measurement interval completes, or due to a timing anomaly), these divisions produce `+Inf`, `-Inf`, or `NaN`. These silent bad values then propagate into power estimates and event-rate displays, corrupting every metric shown to the user without any indication that something is wrong.
+Severity rationale: Corrupts core power/event metrics silently; NaN values can also trigger undefined behaviour when compared or formatted.
+Suggested fix: Guard every division with a check, e.g.:
+```cpp
+if (measurement_time <= 0.0)
+    return 0.0;
+cost = cost / measurement_time;
+```
+Apply the same pattern in `usage()`, `usage_units()`, and `events()`.
+
+## Review of processdevice.cpp, process.h, process.cpp, work.cpp, work.h — batch 08
+
+### High item #1 : Unsigned wraparound before overflow guard corrupts accumulated_runtime
+
+Location: src/process/process.cpp : 63-71
+Description: In `process::deschedule_thread()`, `delta = time - running_since` (line 63) is computed *before* the guard `if (time < running_since)` (line 65). Because both `time` and `running_since` are `uint64_t`, when `time < running_since` the subtraction wraps around to a huge positive value. The `printf` on line 66–67 fires after `delta` has already been incorrectly set, and the corrupted `delta` is subsequently added to `accumulated_runtime` on line 71. This silently inflates per-process CPU accounting.
+Severity rationale: Produces incorrect measurements that propagate throughout the tool's power estimates; the bug is triggered by any measurement period where a thread's last scheduled-in time straddles a counter reset or wrap.
+Suggested fix: Move the overflow check before the subtraction:
+```cpp
+if (time < running_since) {
+    fprintf(stderr, "time %llu < running_since %llu\n",
+            (unsigned long long)time, (unsigned long long)running_since);
+    running = 0;
+    return 0;
+}
+delta = time - running_since;
+```
+
+### High item #2 : Logic error — kernel-process detection is dead code
+
+Location: src/process/process.cpp : 119-127
+Description: The outer `if (!cmdline.empty())` (line 119) ensures `cmdline.size() >= 1`, making the inner `if (cmdline.size() < 1)` (line 120) permanently false. The branch that sets `is_kernel = 1` and formats the bracketed description is therefore unreachable. Kernel threads (which have an empty `/proc/<pid>/cmdline`) are caught by the outer `if` being false, meaning neither `is_kernel` nor the bracketed `desc` is ever set from this code path.
+Severity rationale: Kernel processes are silently misidentified as user processes; `is_kernel` stays 0 for all processes, breaking any downstream logic that relies on that flag.
+Suggested fix: Invert the condition:
+```cpp
+if (cmdline.empty()) {
+    is_kernel = 1;
+    desc = std::format("[PID {}] [{}]", pid, comm);
+} else {
+    cmdline_to_string(cmdline);
+    desc = std::format("[PID {}] {}", pid, cmdline);
+}
+```
+
+## Review of interrupt.h, interrupt.cpp, timer.cpp, timer.h, do_process.cpp — batch 09
+
+### High item #1 : using namespace std in timer.cpp
+
+Location: src/process/timer.cpp : 39
+Description: `using namespace std;` is present at file scope in timer.cpp. The project style guide and general-c++ rules both explicitly prohibit this construct. All standard library identifiers must be qualified with the `std::` prefix.
+Severity rationale: Explicit prohibition in both style.md and general-c++.md; pollutes the global namespace.
+Suggested fix: Remove the `using namespace std;` line and add `std::` qualifiers wherever needed (e.g., `std::map`, `std::pair`, `std::string_view`, `std::string`, `std::for_each`, `std::getline`, `std::istringstream`).
+
+### High item #2 : cpu_idle event: tep_get_field_val return value ignored, val potentially uninitialised
+
+Location: src/process/do_process.cpp : 584
+Description: The `cpu_idle` event handler calls `tep_get_field_val(NULL, event, "state", &rec, &val, 0)` without checking the return value. Every other call to `tep_get_field_val` in this function guards on `ret < 0` and returns early. If this call fails, `val` retains an indeterminate value and the subsequent comparison `val == (unsigned int)-1` uses garbage, potentially triggering `set_wakeup_pending` or `consume_blame` incorrectly on every idle event.
+Severity rationale: Silently corrupts the wakeup-attribution state for every cpu_idle event when the field read fails; directly affects the accuracy of power-consumer accounting.
+Suggested fix:
+```cpp
+ret = tep_get_field_val(NULL, event, "state", &rec, &val, 0);
+if (ret < 0)
+    return;
+if (val == (unsigned int)-1)
+    ...
+```
+
+### High item #3 : Division by zero — measurement_time not guarded
+
+Location: src/process/do_process.cpp : 723
+Description: `measurement_time` (a global `double`) is zero-initialised and is only updated inside `handle_trace_point` when a trace event with `time > last_stamp` arrives. If no trace events are captured during a measurement cycle (e.g., on the very first run or on a system with all tracepoints disabled), `measurement_time` remains 0.0. All of `total_wakeups()`, `total_gpu_ops()`, `total_disk_hits()`, `total_hard_disk_hits()`, `total_xwakes()` (lines 716–784) and several inline divisions in `report_process_update_display()` (lines 963–973) divide by `measurement_time`, producing infinity or NaN values that propagate to display output and report data.
+Severity rationale: Directly corrupts displayed data on any measurement run that produces no events; NaN/Inf values can cause undefined behaviour in subsequent arithmetic.
+Suggested fix: Guard each division site, e.g.: `if (measurement_time > 0.0) total = total / measurement_time;`
+
+### High item #4 : static prev_time persists across measurement cycles
+
+Location: src/process/do_process.cpp : 631
+Description: `prev_time` is declared `static uint64_t` inside `handle_trace_point`, meaning it survives between complete measurement cycles. The `hard_disk_hits` logic fires when `(time - prev_time) > 1000000000`, but `prev_time` carries over from the previous measurement window. The first disk event in a new measurement cycle will almost always satisfy the condition because the gap since the last event in the prior cycle is typically > 1 second, inflating `hard_disk_hits` counts spuriously.
+Severity rationale: Directly corrupts `hard_disk_hits` accounting on every measurement cycle after the first; this is a primary metric shown to users.
+Suggested fix: Reset `prev_time = 0` at the start of each measurement cycle (e.g., in `start_process_measurement()` or `process_process_data()`), or store it in a per-measurement-cycle structure.
+
+### High item #5 : timer_is_deferred reads /proc/timer_stats which was removed in Linux 4.11
+
+Location: src/process/timer.cpp : 44
+Description: `timer_is_deferred()` attempts to read `/proc/timer_stats` to determine whether a timer uses the deferrable flag. This procfs file was removed in Linux kernel 4.11 (2017). On all modern kernels the file does not exist; `read_file_content` returns an empty string and the function always returns `false`. The `deferred` field is set in the constructor but is permanently `false`, and `is_deferred()` has no useful effect, yet it silently skips adding deferred timers in `timer_expire_entry` handling.
+Severity rationale: Functionality is permanently inoperative on any kernel >= 4.11 (essentially all current distributions); the silent no-op may mask accounting bugs.
+Suggested fix: Remove `timer_is_deferred()` and the `deferred` field, or replace with a mechanism that works on current kernels (or simply always return false explicitly and document the limitation).
+
+### High item #6 : Copy-paste error in error message — wrong event name
+
+Location: src/process/do_process.cpp : 457
+Description: Inside the `timer_expire_entry` handler, the error message reads `"softirq_entry event returned no timer ?"`. This is a copy-paste from the nearby `softirq_entry` block. The message is misleading for any developer debugging a missing timer field in a `timer_expire_entry` event.
+Severity rationale: Wrong diagnostic information emitted to stderr; impedes debugging of a real error.
+Suggested fix: Change to `"timer_expire_entry event returned no timer?\n"`.
+
+### High item #7 : all_timers_to_all_power adds all timers regardless of accumulated_runtime
+
+Location: src/process/timer.cpp : 117
+Description: `all_timers_to_all_power()` unconditionally pushes every timer from `all_timers` into `all_power`. By contrast, `all_interrupts_to_all_power()` (interrupt.cpp:117) filters on `accumulated_runtime > 0`. Zero-runtime timers will appear in the overview display and all accounting functions, distorting wakeup counts, sort order, and report tables.
+Severity rationale: Directly inflates the `all_power` list with zero-contribution entries that show in the user-visible overview, degrading display accuracy.
+Suggested fix:
+```cpp
+void all_timers_to_all_power(void)
+{
+    for (auto &[addr, t] : all_timers)
+        if (t->accumulated_runtime)
+            all_power.push_back(t);
+}
+```
+
+## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
+
+### High item #1 : `perf_fd` left open and `pc` left NULL on mmap failure in `create_perf_event`
+
+Location: src/perf/perf.cpp : 119
+Description: When `mmap()` fails, the function prints an error and returns, but `perf_fd` (already assigned a valid fd at line 95) is never closed, and `pc` / `data_mmap` are never set. This causes two problems: (1) a file descriptor leak on every mmap failure, and (2) a subsequent null pointer dereference in `process()` as described in Critical item #2.
+Severity rationale: File descriptor leaks accumulate over the lifetime of the program and can exhaust OS limits. The combination with the null pointer dereference makes this a high-severity resource management bug.
+Suggested fix:
+```cpp
+if (perf_mmap == MAP_FAILED) {
+    fprintf(stderr, _("failed to mmap perf buffer: %d (%s)\n"), errno, strerror(errno));
+    close(perf_fd);
+    perf_fd = -1;
+    return;
+}
+```
+
+### High item #2 : `perf_event` destructor does not call `clear()` in the else branch — resource leak
+
+Location: src/perf/perf.cpp : 167
+Description: The destructor only calls `clear()` when the last reference to `tep` is being released (i.e., `tep_get_ref() == 1`). In the `else` branch (more references exist), `tep_unref()` is called but `clear()` is never invoked. As a result, the `perf_fd` file descriptor and the `perf_mmap` memory mapping are leaked for every `perf_event` object that is destroyed while other `perf_event` objects still exist.
+Severity rationale: In normal operation, many `perf_event` objects share the `tep` handle, so the else branch is the common path. Every destroyed event except the very last will leak an fd and an mmap region.
+Suggested fix:
+```cpp
+perf_event::~perf_event(void)
+{
+    clear();
+    if (tep_get_ref(perf_event::tep) == 1) {
+        tep_free(perf_event::tep);
+        perf_event::tep = NULL;
+    } else {
+        tep_unref(perf_event::tep);
+    }
+}
+```
+
+### High item #3 : Missing memory barrier after reading `data_head` in `perf_event::process()`
+
+Location: src/perf/perf.cpp : 231
+Description: The `perf_event_mmap_page` documentation (present in `perf_event.h` lines 299-308) explicitly states: "User-space reading the @data_head value should issue an rmb(), on SMP capable platforms, after reading this value." The `process()` loop reads `pc->data_head` and immediately accesses ring buffer data without any read memory barrier (`rmb()` / `__sync_synchronize()` / `std::atomic_thread_fence`). On SMP systems the kernel may still be writing the data, causing the process to read stale or incomplete event data.
+Severity rationale: On any SMP machine (the typical PowerTOP target), this can silently corrupt perf event processing, leading to incorrect power analysis results.
+Suggested fix: Insert `__sync_synchronize()` (or `asm volatile("" ::: "memory")`) immediately after reading `pc->data_head` and before accessing `data_mmap`.
+
+## Review of persistent.cpp, parameters.cpp, parameters.h, learn.cpp, report-formatter.h — batch 11
+
+### High item #1 : `using namespace std` in header file parameters.h
+
+Location: src/parameters/parameters.h : 37
+Description: `using namespace std;` appears in parameters.h, which is a shared header included by most of the codebase. This silently injects the entire `std` namespace into every translation unit that includes parameters.h (directly or transitively). This is explicitly forbidden by both style.md ("Avoid `using namespace std;`") and general-c++.md ("`using namespace std;` is a deprecated construct"). In a header file the damage is amplified because the developer of any including .cpp file has no visible indication that `std` has been imported.
+Severity rationale: Header-level namespace pollution affects the entire codebase. It can cause silent name collisions and is an explicit rule violation.
+Suggested fix: Remove `using namespace std;` from parameters.h and qualify all unqualified `map`, `vector`, `string` etc. references with the `std::` prefix.
+
+### High item #2 : `using namespace std` in header file report-formatter.h
+
+Location: src/report/report-formatter.h : 32
+Description: Same violation as in parameters.h — `using namespace std;` in a header file forces the entire `std` namespace into every translation unit that includes this header.
+Severity rationale: Same as item #1. Header-level namespace pollution, explicit rule violation.
+Suggested fix: Remove `using namespace std;` and prefix all standard-library types with `std::`.
+
+### High item #3 : Acknowledged but unfixed memory leaks in `store_results` and `load_results`
+
+Location: src/parameters/parameters.cpp : 342 ; src/parameters/persistent.cpp : 117
+Description: In both `store_results` (parameters.cpp:342) and `load_results` (persistent.cpp:117), when `past_results` has reached `MAX_PARAM` capacity the code overwrites a slot with a new pointer without freeing the old one. Both sites are annotated with `/* memory leak, must free old one first */`. Because this path is taken on every new measurement after the buffer is full, the leak is unbounded over a long PowerTOP session. The correct fix is one additional `delete past_results[overflow_index];` before the assignment.
+Severity rationale: Unbounded memory growth during normal long-running operation.
+Suggested fix:
+```cpp
+// Before:
+past_results[overflow_index] = clone_results(&all_results);
+// After:
+delete past_results[overflow_index];
+past_results[overflow_index] = clone_results(&all_results);
+```
+Apply the same pattern in `load_results`.
+
+### High item #4 : `get_parameter_weight` has no bounds check — undefined behaviour
+
+Location: src/parameters/parameters.cpp : 129
+Description: `get_parameter_weight(int index, struct parameter_bundle *the_bundle)` directly returns `the_bundle->weights[index]` without checking that `index` is non-negative or that `index < the_bundle->weights.size()`. An out-of-range index causes undefined behaviour (likely a crash with debug iterators, silent data corruption otherwise). The neighbouring `get_parameter_value(unsigned int index, …)` at line 120 does perform this check and emits a "BUG:" message.
+Severity rationale: Silent UB / potential crash in production code; no bounds guard exists.
+Suggested fix:
+```cpp
+double get_parameter_weight(int index, struct parameter_bundle *the_bundle)
+{
+    if (index < 0 || (unsigned int)index >= the_bundle->weights.size()) {
+        fprintf(stderr, "BUG: requesting unregistered weight %d\n", index);
+        return 1.0;
+    }
+    return the_bundle->weights[index];
+}
+```
+
+### High item #5 : `utilization_power_valid(const std::string &u)` accesses `past_results[0]` without empty check
+
+Location: src/parameters/parameters.cpp : 401
+Description: The string-parameter overload of `utilization_power_valid` accesses `past_results[0]->utilization[index]` unconditionally. If `past_results` is empty this is an out-of-bounds vector access — undefined behaviour, typically a crash. The integer-parameter overload of the same function at line 420 does correctly guard with `if (past_results.size() == 0) return 0;`.
+Severity rationale: Missing guard that the sister overload has, leading to UB / crash if called before any results are stored.
+Suggested fix: Add `if (past_results.size() == 0) return 0;` immediately after the `if (index <= 0) return 0;` check on line 399.
+
+## Review of report-formatter-html.h, report.cpp, report.h, report-formatter-csv.h, report-maker.cpp — batch 12
+
+### High item #1 : `using namespace std` in header files pollutes all includers
+
+Location: report.h : 35, report-formatter-html.h : 35, report-formatter-csv.h : 46
+Description: All three header files contain `using namespace std;` at file scope. Per the C++ coding guidelines this is a deprecated construct, and placing it in a header is especially harmful: every translation unit that includes these headers (directly or transitively) has the entire `std` namespace injected, making it impossible for downstream code to keep the namespaces separate. The style guide also mandates the explicit `std::` prefix at all times.
+Severity rationale: In a header file the pollution is unconditional and affects all includers; it is a correctness hazard (silent name-hiding / ADL surprises) that is impossible for consumers to work around.
+Suggested fix: Remove the `using namespace std;` line from all three headers. Replace bare `string` with `std::string` where it appears in those headers (e.g., `report-formatter-html.h:68`, `report-formatter-csv.h:67`).
+
+### High item #2 : Non-translatable user-visible string in report output
+
+Location: report.cpp : 131
+Description: `system_data[1]` is built with `std::format("{} ran at {}", PACKAGE_VERSION, get_time_string("%c", now))`. The phrase "ran at" is directly visible in the generated report but is never passed through the gettext `_()` macro, so it will always appear in English regardless of the user's locale. The style guide requires that all user-visible strings be wrapped in `_()` and that user-facing formatted strings use `pt_format` rather than `std::format`.
+Severity rationale: Explicit rule: "All user visible strings must be translatable and use the `_()` gettext pattern." This affects all non-English users every time a report is produced.
+Suggested fix: Replace with `pt_format(_("{} ran at {}"), PACKAGE_VERSION, get_time_string("%c", now))`.
+
+### High item #3 : `localtime()` return value not checked before use
+
+Location: report.cpp : 105-106
+Description: `localtime(&t)` can return `NULL` (e.g., for an out-of-range `time_t` value). The return value is stored in `tm_info` but is passed directly to `strftime` without a null check. Passing a null pointer to `strftime` is undefined behaviour and will cause a crash.
+Severity rationale: Undefined behaviour / potential null-pointer dereference in code that runs on every report-generating invocation.
+Suggested fix:
+```cpp
+struct tm *tm_info = localtime(&t);
+if (!tm_info)
+    return "";
+if (strftime(buf, sizeof(buf), fmt.c_str(), tm_info))
+    return buf;
+return "";
+```
+
+## Review of report-maker.h, report-data-html.cpp, report-data-html.h, report-formatter-base.cpp, report-formatter-base.h — batch 13
+
+### High item #1 : `double_to_string` — unsigned wrap on `npos+2` produces single-character output for integer-valued doubles
+
+Location: src/report/report-data-html.cpp : 124
+Description: `str.find(".")` returns `std::string::npos` (the maximum `size_t` value) when the formatted double contains no decimal point (e.g., `100.0` formats as `"100"` via `ostringstream`). The expression `str.find(".")+2` then wraps around via unsigned arithmetic to `1`. Consequently `str.substr(0, 1)` is returned — only the first character of the number. For example, a power value of `100.0` W would display as `"1"` in the HTML report. Any integer-valued double triggers this bug.
+Severity rationale: Produces visibly wrong numeric data in the generated power report for any integer-valued measurement.
+Suggested fix:
+```cpp
+std::string double_to_string(double dval)
+{
+std::ostringstream dtmp;
+dtmp << dval;
+std::string str = dtmp.str();
+auto dot = str.find('.');
+if (dot != std::string::npos)
+str = str.substr(0, dot + 2);
+return str;
+}
+```
+
+### High item #2 : `using namespace std;` in header files
+
+Location: src/report/report-maker.h : 65  and  src/report/report-data-html.h : 7
+Description: Both headers contain `using namespace std;` at file scope. Because these are headers, every translation unit that includes them (directly or transitively) has the entire `std` namespace injected without opt-in. This can cause silent name collisions, ambiguous overload sets, and violates the project's own style guide (style.md §4.2) and the general C++ rules.
+Severity rationale: Namespace pollution that silently affects all includers, a first-class style violation in both the style guide and general-c++ rules.
+Suggested fix: Remove `using namespace std;` from both headers and qualify all standard-library names with `std::`.
+
+## Review of report-formatter-csv.cpp, report-formatter-html.cpp, dram_rapl_device.cpp, dram_rapl_device.h, cpu_linux.cpp — batch 14
+
+### High item #1 : `csv_need_quotes` member variable used uninitialized
+
+Location: src/report/report-formatter-csv.cpp : 67  (also src/report/report-formatter-csv.h : 68)
+Description: The `csv_need_quotes` bool member of `report_formatter_csv` is declared in the header but never initialized — not in the constructor, not in the member initializer list. The constructor body contains only `/* Do nothing special */`. When `escape_string()` sets `csv_need_quotes = true` on line 67, it only ever writes to it; any code that reads `csv_need_quotes` (e.g., the declared-but-unimplemented `add_quotes()`) would read garbage. Reading an uninitialized bool is undefined behavior in C++. The companion member `text_start` (size_t) suffers the same defect.
+Severity rationale: Uninitialized member variable read is undefined behavior. While `add_quotes()` is currently not implemented, the member is part of the class invariant and any future reader would encounter UB. It also signals incomplete/broken initialization.
+Suggested fix: Initialize both members in the constructor member initializer list:
+```cpp
+report_formatter_csv::report_formatter_csv()
+    : csv_need_quotes(false), text_start(0)
+{}
+```
+
+### High item #2 : Out-of-bounds access in `add_summary_list` for odd-length vectors
+
+Location: src/report/report-formatter-html.cpp : 318-320
+Description: `add_summary_list` iterates over a `std::vector<std::string>` in steps of 2 (`i+=2`) and unconditionally accesses both `list[i]` and `list[i+1]` inside the loop. If the caller passes a vector with an odd number of elements, the last iteration accesses `list[i+1]` which is one past the end — undefined behavior and likely a crash or memory corruption. There is no assertion or bounds check guarding this. The same pattern in `report-formatter-csv.cpp` line 129-131 partially guards with `if(i < (list.size() - 1))` but that check itself underflows when `list.size() == 0` (size_t wraps to SIZE_MAX) — though harmless because the loop doesn't execute.
+Severity rationale: Out-of-bounds vector access is undefined behavior that can cause crashes or silent memory corruption in normal program operation if any caller provides an odd-length list.
+Suggested fix:
+```cpp
+for (size_t i = 0; i + 1 < list.size(); i += 2) {
+    add_exact(std::format("...", list[i], list[i+1]));
+}
+```
+
+## Review of src/cpu/cpu_core.cpp, src/cpu/cpudevice.h, src/cpu/cpudevice.cpp, src/cpu/abstract_cpu.cpp, src/cpu/cpu_rapl_device.cpp — batch 15
+
+### High item #1 : `using namespace std` in header file cpudevice.h
+
+Location: src/cpu/cpudevice.h : 31
+Description: `using namespace std;` appears at file scope in a header file. This is explicitly
+forbidden by both style.md (§4.2) and general-c++.md. Placing it in a header silently pollutes
+the global namespace for every translation unit that includes this header directly or transitively,
+making it far worse than the same statement in a .cpp file.
+Severity rationale: Header-scope `using namespace std` is explicitly banned and causes broad,
+hard-to-diagnose name collision risks across the entire codebase.
+Suggested fix: Remove the `using namespace std;` line. All standard types used in the header
+already carry explicit `std::` prefixes (e.g. `std::string`, `std::vector`), so no further
+changes are needed to make the header compile correctly.
+
+### High item #2 : `using namespace std` in header file cpu_rapl_device.h
+
+Location: src/cpu/cpu_rapl_device.h : 31
+Description: Same violation as cpudevice.h — `using namespace std;` at file scope in a header.
+Every file that includes `cpu_rapl_device.h` (directly or via cpudevice.h) inherits this
+namespace pollution.
+Severity rationale: Same as item #1; header-scope `using namespace std` is explicitly banned.
+Suggested fix: Remove the `using namespace std;` line. All identifiers in the header already
+use `std::` qualifiers or are fully spelled out.
+
+## Review of src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp — batch 16
+
+### High item #1 : Division by zero in report_display_cpu_cstates when num_cores == 0
+
+Location: src/cpu/cpu.cpp : 500
+Description: `cpu_tbl_size.cols = (2 * (num_cpus / num_cores)) + 1` is computed after
+counting only children whose `get_type()` returns exactly `"Core"`. GPU cores
+(type `"GPU"`) are present in the same children vector (added by `new_i965_gpu`).
+If a package contains only a GPU child or all `_core` pointers happen to be NULL,
+`num_cores` stays 0 and the integer division causes a divide-by-zero crash.
+Severity rationale: Any system with an integrated GPU (the i965 path) combined
+with certain topology configurations will hit this.
+Suggested fix: Guard the division: `cpu_tbl_size.cols = num_cores > 0 ? (2 * (num_cpus / num_cores)) + 1 : 1;`
+
+### High item #2 : Division by zero in report_display_cpu_pstates when num_cores == 0
+
+Location: src/cpu/cpu.cpp : 708
+Description: Same pattern as High item #1 in `report_display_cpu_pstates`:
+`cpu_tbl_size.cols = (num_cpus / num_cores) + 1` when `num_cores == 0` is a
+divide-by-zero crash.
+Severity rationale: Same reasoning as High item #1; both report paths are
+reachable from normal operation.
+Suggested fix: Guard as above: `cpu_tbl_size.cols = num_cores > 0 ? (num_cpus / num_cores) + 1 : 1;`
+
+### High item #3 : Null pointer dereference of `_core` after inner loop in report_display_cpu_cstates
+
+Location: src/cpu/cpu.cpp : 620
+Description: `_core` is declared as `NULL` at line 437. Inside the `for (core = ...)` loop it is
+assigned `_core = _package->children[core]`; when the child is NULL the loop
+`continue`s. After the loop `_core` holds the value from the last *executed*
+assignment, which may itself be NULL (if the last child slot is a NULL sentinel).
+At line 620, `_core->can_collapse()` is then called unconditionally, causing a
+null pointer dereference. The same pointer is used at line 621 as well.
+Severity rationale: Any package whose last indexed child slot is a gap (NULL)
+triggers this; this can happen with non-contiguous core numbering.
+Suggested fix: Test before use: `if (_core && !_core->can_collapse()) { ... }`
+
+### High item #4 : `using namespace std;` in header files
+
+Location: src/cpu/cpu.h : 36  and  src/cpu/cpu_rapl_device.h : 31
+Description: Both header files contain `using namespace std;` at file scope.
+This is explicitly prohibited by the project style guide and the C++ coding
+guidelines ("'using namespace std;' is a deprecated construct"). Being in headers,
+this silently forces every translation unit that includes these widely-used headers
+to import the entire `std` namespace, creating hidden name-collision hazards and
+polluting the namespace of all downstream code.
+Severity rationale: Affects every file in the project that transitively includes
+these headers; a name conflict introduced by a future standard library addition
+would be extremely hard to diagnose.
+Suggested fix: Remove both `using namespace std;` lines and qualify all bare uses
+of `vector`, `string`, `cout` etc. with `std::`.
+
+## Review of src/cpu/rapl/rapl_interface.cpp — batch 17
+
+### High item #1 : readdir loop does not skip "." and ".." entries (first loop)
+
+Location: src/cpu/rapl/rapl_interface.cpp : 98
+Description: The `while ((entry = readdir(dir)) != NULL)` loop starting at line 98 iterates over all entries in `/sys/class/powercap/intel-rapl/` without skipping the special entries "." and "..". The code constructs paths such as `base_path + entry->d_name + "/name"`, which for "." yields `.../intel-rapl/./name` (resolves to the parent directory's `name` file) and for ".." yields `.../powercap/name`. While `read_sysfs_string` likely returns an empty string for these nonexistent paths, this is an explicit violation of the rules.md requirement and could potentially read unintended sysfs files if the filesystem layout changes.
+Severity rationale: Explicit violation of the rules.md directory-traversal rule. Low-probability but not zero risk of reading unintended paths.
+Suggested fix: Add a check at the top of the loop body: `if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;`
+
+### High item #2 : readdir loop does not skip "." and ".." entries (second loop)
+
+Location: src/cpu/rapl/rapl_interface.cpp : 116
+Description: The second `while ((entry = readdir(dir)) != NULL)` loop at line 116 iterates over a package subdirectory without skipping "." and "..". It constructs `path = package_path + entry->d_name` and then reads `path + "/name"`. For ".." this would resolve to the parent path `/sys/class/powercap/intel-rapl/<entry>/name`, potentially matching a domain name of "core", "dram", or "uncore" in unexpected locations if the sysfs tree structure were ever to include such files at the parent level.
+Severity rationale: Same rule violation as item #1; the second loop compounds the issue.
+Suggested fix: Same as item #1 — add a "." / ".." skip guard at the top of the loop body.
+
+## Review of wakeup_usb.h, wakeup_ethernet.h, waketab.cpp, wakeup_ethernet.cpp, wakeup.cpp — batch 18
+
+### High item #1 : stray semicolon at start of wakeup_ethernet.cpp
+
+Location: src/wakeup/wakeup_ethernet.cpp : 1
+Description: The file begins with `;/*` — a bare semicolon before the copyright comment. While C++11 permits empty declarations at namespace scope, this is clearly a typo/corruption that has no business being there. It confuses source tools, diff viewers, and static analysers, and is a latent sign of file-level editing damage.
+Severity rationale: High — it is an unambiguous file corruption that affects every build. It is only not critical because C++11 empty-declaration rules save it from a compile error.
+Suggested fix: Remove the leading `;` so the file starts with `/*`.
+
+### High item #2 : out-of-bounds vector access in cursor_enter when wakeup_all is empty
+
+Location: src/wakeup/waketab.cpp : 46, 105
+Description: `win->cursor_max` is assigned `wakeup_all.size() - 1`. When `wakeup_all` is empty, `size_t(0) - 1` wraps to `SIZE_MAX`; the implicit narrowing conversion to `int cursor_max` yields -1. The navigation guards (`cursor_pos < cursor_max`) therefore prevent moving the cursor, but `cursor_pos` is initialised to 0 and `cursor_enter()` is called unconditionally on Enter. Inside `cursor_enter`, `wakeup_all[cursor_pos]` (line 105) accesses `wakeup_all[0]` on an empty vector — undefined behaviour that in practice crashes.
+Severity rationale: High — any system with no wakeup-capable devices will crash on Enter in the WakeUp tab. The unsigned-to-signed truncation also silently suppresses any diagnostic.
+Suggested fix:
+```cpp
+win->cursor_max = wakeup_all.empty() ? 0 : (int)wakeup_all.size() - 1;
+```
+And add a bounds guard in `cursor_enter`:
+```cpp
+if ((size_t)cursor_pos >= wakeup_all.size())
+    return;
+```
+
+### High item #3 : `using namespace std` in headers
+
+Location: src/wakeup/wakeup_usb.h : 32  and  src/wakeup/wakeup_ethernet.h : 32
+Description: Both headers contain `using namespace std;` at file scope. This silently injects the entire `std` namespace into every translation unit that includes them, potentially causing name collisions or hiding bugs in unrelated code. The coding style guide explicitly forbids this.
+Severity rationale: High — namespace pollution from a header affects all includers and is a hard style-guide violation.
+Suggested fix: Remove both `using namespace std;` lines. The classes already use fully-qualified `std::string` everywhere they need it.
+
+## Review of src/measurement/acpi.cpp — batch 19
+
+### High item #1 : `/proc/acpi/battery/` path removed from Linux kernel
+
+Location: src/measurement/acpi.cpp : 74
+Description: The `acpi_power_meter::measure()` function reads from `/proc/acpi/battery/{name}/state`. This `/proc/acpi/battery/` interface was removed from the Linux kernel in version 2.6.39 (released April 2011). On any kernel shipped in the past decade, `read_file_content()` will always return an empty string, causing `measure()` to return immediately without setting any values. As a result, `power()` always returns 0.0 — the entire `acpi_power_meter` class is silently non-functional on modern systems. The replacement interface is `/sys/class/power_supply/` with the `energy_now`, `power_now`, `voltage_now`, etc. attributes.
+Severity rationale: High — the entire measurement class fails silently on all modern kernels; users relying on ACPI battery data receive no power readings.
+Suggested fix: Rewrite `measure()` to use `/sys/class/power_supply/{name}/power_now` (or `current_now` × `voltage_now`) from the sysfs power supply class. Remove the `/proc/acpi/battery/` parsing entirely.
+
+## Review of sysfs.h, sysfs.cpp, measurement.h, measurement.cpp, extech.h — batch 20
+
+### High item #1 : `using namespace std;` in a header file
+
+Location: src/measurement/measurement.h : 31
+Description: `using namespace std;` appears at global scope in a header file. Every translation unit that includes `measurement.h` (directly or indirectly) inherits this namespace pollution. This is explicitly forbidden by general-c++.md ("using namespace std; is a deprecated construct") and style.md §4.2. It is also the root cause of unqualified `string` and `vector` usage in sysfs.cpp (lines 32, 38) and measurement.cpp (line 58).
+Severity rationale: Broad, silent namespace pollution that violates an explicit project rule and can cause unexpected name collisions in any including file.
+Suggested fix: Remove `using namespace std;` from measurement.h. Replace `vector<class power_meter *>` on line 61 with `std::vector<power_meter *>`. Update all callers that relied on the implicit `using namespace std;` (sysfs.cpp lines 32/38 and measurement.cpp line 58) to use fully qualified `std::string` and `std::vector`.
+
+### High item #2 : `CLOCK_REALTIME` used for elapsed-time measurement
+
+Location: src/measurement/measurement.cpp : 65, 102
+Description: Both `start_power_measurement` (line 65) and `global_sample_power` (line 102) call `clock_gettime(CLOCK_REALTIME, ...)` to measure elapsed wall-clock time. `CLOCK_REALTIME` can jump forward or backward due to NTP corrections, leap-second smearing, or manual adjustments. A backward jump makes `tnow - tlast` negative, accumulating negative joules. A large forward jump inflates the joules figure by hours of phantom energy. `CLOCK_MONOTONIC` is the correct clock for measuring elapsed time intervals.
+Severity rationale: Directly corrupts the joules accumulation used for battery life estimates whenever the system clock is adjusted during a measurement period.
+Suggested fix: Replace `CLOCK_REALTIME` with `CLOCK_MONOTONIC` at both call sites.
+
+### High item #3 : Data race on `sum` and `samples` in extech_power_meter
+
+Location: src/measurement/extech.h : 36-37
+Description: `sum` (double) and `samples` (int) are written by the sampling thread (`sample()` in extech.cpp) and read by the main thread in `end_measurement()` without any mutex, lock, or atomic type. Under the C++20 memory model this is a data race and constitutes undefined behavior. On architectures that do not guarantee atomic double/int reads the final `rate = sum / samples` can observe a torn value.
+Severity rationale: Undefined behavior triggered on every use of an Extech power meter device; can produce garbage power readings or crash.
+Suggested fix: Use `std::atomic<double> sum` and `std::atomic<int> samples`, or protect access with a `std::mutex`. Since `std::atomic<double>` only became lock-free on common hardware in C++20, a mutex is the safer portable choice.
+
+## Review of src/measurement/extech.cpp, src/devices/backlight.cpp — batch 21
+
+### High item #1 : Thread data races on shared variables in extech sampling thread
+
+Location: src/measurement/extech.cpp : 311-312, 330-333, 341-342
+Description: The member variables `sum`, `samples`, and `end_thread` are accessed from two threads concurrently — the sampling thread (via `sample()`) and the main thread (via `start_measurement()` and `end_measurement()`) — with no synchronization whatsoever. `end_thread` is a plain `int` used as a thread-termination flag, which the compiler may cache in a register and never re-read from memory. Reading and writing these variables from multiple threads without atomics or mutexes is undefined behavior under the C++ memory model.
+Severity rationale: Data races are undefined behavior in C++20. The race on `end_thread` can cause the sampling thread to loop forever; races on `sum`/`samples` can produce torn reads and corrupt power-usage values reported to users.
+Suggested fix: Declare `end_thread` as `std::atomic<int>` (or `std::atomic<bool>`). Protect `sum` and `samples` with a `std::mutex`, or use `std::atomic<double>`/`std::atomic<int>` for them.
+
+### High item #2 : Division by zero in backlight::utilization() and end_measurement() when max_level is 0
+
+Location: src/devices/backlight.cpp : 102, 117
+Description: Both `backlight::end_measurement()` (line 102) and `backlight::utilization()` (line 117) compute `100.0 * (...) / max_level`. `max_level` is read from sysfs in `start_measurement()` and is initialized to 0 in the constructor. If the sysfs read fails, or if `start_measurement()` is never called, `max_level` remains 0, causing a division by zero (or, for IEEE 754 double, a ±inf/NaN result) that propagates into power estimates.
+Severity rationale: A missing or unreadable sysfs file causes a divide-by-zero, producing meaningless (inf/NaN) power values that corrupt downstream calculations and user-visible output.
+Suggested fix: Guard both call sites: `if (max_level <= 0) return 0.0;` before the division.
+
+### High item #3 : Error sentinel values from extech_read() silently accumulated into sum
+
+Location: src/measurement/extech.cpp : 311
+Description: `extech_read()` returns `-1.0` on select timeout/error and `-1000.0` on parse failure. In `sample()`, the return value is unconditionally added to `sum` with `sum += extech_read(fd)`. Whenever the device fails to respond or returns a bad packet, a large negative value is folded into the running average, producing a badly wrong `rate` once `end_measurement()` computes `sum / samples`.
+Severity rationale: Error readings directly contaminate the power measurement average, leading to incorrect (heavily negative) watt values shown to the user.
+Suggested fix: Check the return value before accumulating: `double v = extech_read(fd); if (v >= 0.0) { sum += v; samples++; }` (and remove the separate `samples++` on line 312).
+
+## Review of src/devices/usb.h, src/devices/usb.cpp, src/devices/gpu_rapl_device.h, src/devices/gpu_rapl_device.cpp, src/devices/ahci.h — batch 22
+
+### High item #1 : `using namespace std;` in header file gpu_rapl_device.h
+
+Location: src/devices/gpu_rapl_device.h : 31
+Description: The file contains `using namespace std;` at global scope in a header. This is explicitly forbidden by both `style.md` (§4.2) and `general-c++.md`. When placed in a header file, it silently injects the entire `std` namespace into every translation unit that includes this header, causing hard-to-diagnose name collisions and making it impossible for includers to opt out. All other headers in the project use the `std::` prefix convention; this one is an outlier.
+Severity rationale: Header-level `using namespace std` pollutes all includers' namespaces and is explicitly listed as a deprecated construct in the coding rules. The impact is project-wide.
+Suggested fix: Remove `using namespace std;` and prefix all standard-library types in the header with `std::`. Because the header itself only uses `std::string` and `std::vector` (via the includes), the fix is mechanical: drop line 31 and verify no bare `string` or `vector` names remain in the header.
+
+### High item #2 : `power_valid()` can return values other than 0/1 in ahci.h
+
+Location: src/devices/ahci.h : 63
+Description: The method `power_valid()` returns `utilization_power_valid(partial_rindex) + utilization_power_valid(active_rindex)`. Each `utilization_power_valid()` call returns 0 or 1. When both AHCI states are valid, the sum is 2. The base-class `device::power_valid()` contract returns an int treated as a boolean flag; callers that check `power_valid() == 1` or cast to bool (which is fine), but callers checking `!= 0` also work. However the semantics of "how many sub-metrics are valid" vs "is power valid at all" are conflated. If the intent is "power is valid if either partial or active is valid" the expression should be `||` not `+`; if it means "valid only when both are valid" the expression should be `&&`. Neither intention produces the value 2.
+Severity rationale: Incorrect boolean arithmetic in a validation predicate that controls whether power data is displayed to the user. Could cause incorrect display behavior depending on caller comparison style.
+Suggested fix: Change to: `return utilization_power_valid(partial_rindex) || utilization_power_valid(active_rindex);` (or `&&` if both are required).
+
+
+## Review of src/devices/ahci.cpp, src/devices/thinkpad-fan.h, src/devices/thinkpad-fan.cpp, src/devices/device.h, src/devices/device.cpp — batch 23
+
+### High item #1 : `using namespace std;` in a header file
+
+Location: src/devices/device.h : 74
+Description: `using namespace std;` appears at the end of device.h, after the class definition. Because this is a header file, every translation unit that includes device.h silently inherits this directive. This can cause hard-to-diagnose name collisions with std names (e.g. `string`, `vector`, `sort`) silently resolving to `std::` symbols when the programmer may intend otherwise. The `std::` prefix is already used correctly throughout the class definition above it, making this directive entirely unnecessary.
+Severity rationale: Placing `using namespace std;` in a header is explicitly prohibited by style.md §4.2 and general-c++.md ("using namespace std; is a deprecated construct"). Its presence in a header is strictly worse than in a .cpp file because it contaminates all includers transitively.
+Suggested fix: Remove line 74 (`using namespace std;`) from device.h entirely.
+
+### High item #2 : `report_device_stats` never writes the Link-name column; all stats shifted one column
+
+Location: src/devices/ahci.cpp : 307–325
+Description: The table built in `ahci_create_device_stats_table` has five columns: "Link", "Active", "Partial", "Slumber", "Devslp". For row `idx`, the first cell occupies position `idx*5+5` (the "Link" column). `report_device_stats` starts writing at `offset = idx*5+5` and stores `active_util`, then `partial_util`, `slumber_util`, `devslp_util` — four values. Consequently: (1) the "Link" column for every row shows the active-utilization number instead of the device name; (2) "Active" shows partial utilisation; "Partial" shows slumber; "Slumber" shows devslp; and (3) the "Devslp" column is always empty. The human-readable link/disk name is never stored in the table at all.
+Severity rationale: This is a logic error that always produces a visibly wrong HTML report for any system with AHCI links — a user-facing functional defect that always fires.
+Suggested fix: Prepend a store of the link name before the utilisation values:
+```cpp
+void ahci::report_device_stats(std::vector<std::string> &ahci_data, int idx)
+{
+    int offset = (idx * 5 + 5);
+    ahci_data[offset] = humanname;   // Link column
+    offset += 1;
+    ahci_data[offset] = std::format("{:5.1f}", get_result_value(active_rindex, &all_results));
+    offset += 1;
+    ahci_data[offset] = std::format("{:5.1f}", get_result_value(partial_rindex, &all_results));
+    offset += 1;
+    ahci_data[offset] = std::format("{:5.1f}", get_result_value(slumber_rindex, &all_results));
+    offset += 1;
+    ahci_data[offset] = std::format("{:5.1f}", get_result_value(devslp_rindex, &all_results));
+}
+```
+
+### High item #3 : `closedir` not called before early return in `model_name`
+
+Location: src/devices/ahci.cpp : 98
+Description: Inside the `model_name` function, when a directory entry whose name contains both ':' and "target" is found, the code does `return disk_name(pathname, d_name, shortname);` immediately, bypassing the `closedir(dir)` call at line 101. Every call to `model_name` that successfully finds a matching entry leaks one open directory file descriptor. Because `create_all_ahcis` calls `ahci::ahci` which calls `model_name` for every AHCI device at start-up, each AHCI disk leaks one fd per measurement session start.
+Severity rationale: File descriptor leak; bounded by number of AHCI devices but still a resource management defect.
+Suggested fix:
+```cpp
+    std::string result = disk_name(pathname, d_name, shortname);
+    closedir(dir);
+    return result;
+```
+## Review of src/devices/devfreq.cpp, src/devices/devfreq.h, src/devices/alsa.h, src/devices/alsa.cpp, src/devices/runtime_pm.cpp — batch 24
+
+### High item #1 : `using namespace std;` in alsa.cpp
+
+Location: src/devices/alsa.cpp : 33
+Description: `using namespace std;` appears at file scope in alsa.cpp. This is explicitly forbidden by both style.md ("Avoid `using namespace std;`") and general-c++.md ("`using namespace std;` is a deprecated construct"). All other files in this batch that need std names obtain them through the transitive pull of `device.h`'s own `using namespace std;`, which is itself a problem (see batch 23), but alsa.cpp adds a second independent violation. Pollutes the global namespace for all translation-unit consumers of this header chain.
+Severity rationale: Explicitly named as forbidden in both style and language rules.
+Suggested fix: Remove line 33 (`using namespace std;`). Add `std::` prefix to all unqualified standard-library names in the file (they are already there for most; the remaining uses of unqualified `string` on lines 44, 102, etc. are covered by device.h's `using namespace std;` leak, which should also be cleaned up separately).
+
+### High item #2 : Unsigned underflow in `process_time_stamps()` loop bound
+
+Location: src/devices/devfreq.cpp : 76
+Description: `dstates.size()` returns `size_t` (unsigned). The expression `dstates.size()-1` wraps to `SIZE_MAX` when `dstates` is empty. The for-loop `for (i=0; i < dstates.size()-1; i++)` would then iterate from 0 to SIZE_MAX, repeatedly accessing `dstates[i]` out of bounds, causing undefined behaviour. After the loop, `dstates[i]` is accessed again at line 82 on the last element (the idle state). Under normal operation `start_measurement()` always inserts at least the idle state via `update_devfreq_freq_state(0,0)`, so this is not triggered at runtime today — but the code is one misuse or refactor away from silent memory corruption.
+Severity rationale: Unsigned wrap-around producing an enormous loop bound and subsequent out-of-bounds vector access; undefined behaviour if triggered.
+Suggested fix:
+```cpp
+if (dstates.empty())
+    return;
+for (i = 0; i < dstates.size() - 1; i++) { ... }
+dstates[i]->time_after = sample_time - active_time;
+```
+
+### High item #3 : Division by zero in `fill_freq_utilization()` when `sample_time == 0`
+
+Location: src/devices/devfreq.cpp : 196
+Description: `fill_freq_utilization()` computes `percentage(1.0 * state->time_after / sample_time)`. `sample_time` is a `double` member initialised to 0 in `start_measurement()`. If `end_measurement()` has not been called yet, or if the two timestamps are identical (extremely short measurement window), `sample_time` is 0.0 and the division is undefined (IEEE 754 returns ±∞ or NaN). This value propagates into `percentage()` and eventually into the ncurses display as a garbage string.
+Severity rationale: Results in NaN/infinity being formatted and displayed to the user; directly impacts user-visible output.
+Suggested fix:
+```cpp
+if (sample_time <= 0.0)
+    return "";
+return std::format(" {:5.1f}% ", percentage(1.0 * state->time_after / sample_time));
+```

--- a/logs.1/low.md
+++ b/logs.1/low.md
@@ -1,0 +1,1197 @@
+# PowerTOP Low Severity Review Findings
+
+## Review of calibrate.cpp, calibrate.h, lib.cpp, devlist.cpp, main.cpp — batch 01
+
+### Low item #1 : `calibrate.h` uses `#ifndef` guard instead of `#pragma once`
+
+Location: src/calibrate/calibrate.h : 25–27
+
+Description:
+The header uses a traditional include guard:
+```cpp
+#ifndef __INCLUDE_GUARD_CALIBRATE_H
+#define __INCLUDE_GUARD_CALIBRATE_H
+```
+The project style guide (style.md §4.1) mandates `#pragma once` for all headers.
+
+Severity rationale: Style violation; `#pragma once` is the project standard and is universally supported by the compilers in use.
+
+Suggested fix: Replace with `#pragma once` and remove the `#endif` at the bottom.
+
+---
+
+### Low item #2 : `calibrate.h` uses `std::string` without including `<string>`
+
+Location: src/calibrate/calibrate.h : 28
+
+Description:
+The declaration `void one_measurement(int, int, const std::string &)` references `std::string` but the header does not include `<string>`. Any translation unit that includes `calibrate.h` before pulling in `<string>` itself will fail to compile. Headers must be self-contained.
+
+Severity rationale: Latent compilation error; currently masked because all callers happen to include `<string>` earlier.
+
+Suggested fix: Add `#include <string>` to `calibrate.h`.
+
+---
+
+### Low item #3 : Duplicate `#include` directives in lib.cpp
+
+Location: src/lib.cpp : 35, 51, 37, 53, 55, 56, 36, 62
+
+Description:
+The following headers are included more than once:
+- `<stdio.h>` — lines 35 and 51
+- `<stdlib.h>` — lines 37 and 53
+- `<sys/types.h>` — lines 55 and 56 (consecutive duplicates)
+- `<math.h>` — lines 36 and 62
+
+While harmless due to include guards, duplicate includes are noise and may indicate copy-paste accumulation.
+
+Severity rationale: Code quality / maintenance issue; violates the principle of clean, intentional includes.
+
+Suggested fix: Remove the duplicate include directives; keep one of each.
+
+---
+
+### Low item #4 : `setrlimit` return value not checked
+
+Location: src/main.cpp : 369
+
+Description:
+```cpp
+rlmt.rlim_cur = rlmt.rlim_max = get_nr_open();
+setrlimit(RLIMIT_NOFILE, &rlmt);
+```
+The return value of `setrlimit` is silently discarded. If the call fails, PowerTOP will run with a lower file-descriptor limit than required, potentially causing spurious "too many open files" errors later when iterating `/proc/PID/fd/`.
+
+Severity rationale: Unchecked system-call failure can lead to confusing downstream errors.
+
+Suggested fix:
+```cpp
+if (setrlimit(RLIMIT_NOFILE, &rlmt) != 0)
+    fprintf(stderr, _("Failed to raise open file limit: %s\n"), strerror(errno));
+```
+
+---
+
+### Low item #5 : `mkdir` return values not checked in `powertop_init`
+
+Location: src/main.cpp : 402–404
+
+Description:
+```cpp
+if (access("/var/cache/", W_OK) == 0)
+    mkdir("/var/cache/powertop", 0600);
+else
+    mkdir("/data/local/powertop", 0600);
+```
+Neither `mkdir` call checks its return value. If directory creation fails for any reason other than the directory already existing (`EEXIST`), the subsequent `load_results` / `save_parameters` calls will silently fail to find or write their data files.
+
+Severity rationale: Silent failure to create the cache directory; saved calibration data may be quietly lost.
+
+Suggested fix: Check the return value and ignore only `EEXIST`:
+```cpp
+if (mkdir("/var/cache/powertop", 0600) != 0 && errno != EEXIST)
+    fprintf(stderr, _("Failed to create cache directory: %s\n"), strerror(errno));
+```
+
+---
+
+### Low item #6 : `blmax` global is overwritten for each backlight device
+
+Location: src/calibrate/calibrate.cpp : 152–154
+
+Description:
+```cpp
+static int blmax;
+...
+static void find_backlight_callback(const std::string &d_name)
+{
+    ...
+    backlight_devices.push_back(filename);
+    filename = std::format("/sys/class/backlight/{}/max_brightness", d_name);
+    blmax = read_sysfs(filename);
+}
+```
+`blmax` is a single global. When multiple backlight devices exist, each call to the callback overwrites it. `backlight_calibration` then uses this single `blmax` value for all devices, but writes it back only to the device that was current at calibration time, not to each device's own max. The brightness levels written (`blmax/4`, `blmax/2`, etc.) will be wrong for all but the last discovered device.
+
+Severity rationale: Incorrect calibration data for multi-backlight systems.
+
+Suggested fix: Store `(device_path, max_brightness)` pairs together, e.g., using a `std::vector<std::pair<std::string,int>>`.
+
+---
+
+### Low item #7 : Hardcoded `"wlan0"` wireless interface name
+
+Location: src/calibrate/calibrate.cpp : 77, 385, 393, 408
+
+Description:
+The interface name `"wlan0"` is hardcoded in `restore_all_sysfs`, `calibrate`, and the `set_wifi_power_saving` calls. On modern Linux systems the interface may be named `wlp2s0`, `wlan1`, or something else entirely. If `"wlan0"` does not exist, `get_wifi_power_saving` / `set_wifi_power_saving` will silently do nothing (or fail silently), and the saved PS state will be incorrect.
+
+Severity rationale: Calibration will incorrectly handle Wi-Fi power saving on systems without a `wlan0` interface; no error is reported.
+
+Suggested fix: Auto-detect the active wireless interface (e.g., by scanning `/sys/class/net/*/wireless/`) rather than hardcoding `"wlan0"`.
+
+## Review of src/test_framework.h, src/test_framework.cpp, src/display.cpp, src/display.h, src/lib.h — batch 02
+
+### Low item #1 : `NULL` used instead of `nullptr` in lib.h
+
+Location: src/lib.h : 81
+Description: `bool *ok = NULL` uses the C-style null pointer constant `NULL`. In C++11+ (and especially C++20) `nullptr` is the correct null pointer literal, providing type safety. `NULL` is typically `0` or `(void*)0`, which can cause overload ambiguity.
+Severity rationale: C++ best-practice violation; no runtime risk in this specific context but wrong idiom.
+Suggested fix: `bool *ok = nullptr`
+
+---
+
+### Low item #2 : `create_tab()` `bottom_line` parameter passed by value
+
+Location: src/display.h : 96
+Description: `void create_tab(const string &name, const string &translation, class tab_window *w = NULL, string bottom_line = "")` — the `bottom_line` parameter is passed by value (copy), requiring a heap allocation for every non-empty string argument. It should be `const std::string&` consistent with the other string parameters.
+Severity rationale: Unnecessary copy; inconsistent with surrounding API.
+Suggested fix:
+```cpp
+void create_tab(const std::string &name, const std::string &translation,
+                tab_window *w = nullptr, const std::string &bottom_line = "");
+```
+
+---
+
+### Low item #3 : `tab_windows` map holds raw owning pointers with no cleanup
+
+Location: src/display.h : 91, src/display.cpp : 41
+Description: `map<string, class tab_window *> tab_windows` stores raw owning pointers to `tab_window` objects. These are never deleted when the map is destroyed or when tabs are removed. The destructor of `tab_window` deletes the ncurses window (`delwin(win)`), so proper ownership is needed. Using `std::unique_ptr<tab_window>` would enforce automatic cleanup.
+Severity rationale: Memory leak and potential use-after-free if tabs are ever programmatically replaced.
+Suggested fix: Change to `std::map<std::string, std::unique_ptr<tab_window>> tab_windows;` and adjust call sites.
+
+---
+
+### Low item #4 : Magic sentinel string `"__POWERTOP_FILE_NOT_FOUND__"` should be a named constant
+
+Location: src/test_framework.cpp : 52, 62, 125, 159
+Description: The special sentinel value `"__POWERTOP_FILE_NOT_FOUND__"` is used in four places but defined nowhere as a constant. If it is ever changed in one location and not another, the record/replay mechanism silently breaks.
+Severity rationale: Maintainability risk; magic string repeated in multiple locations.
+Suggested fix:
+```cpp
+static constexpr const char* FILE_NOT_FOUND_SENTINEL = "__POWERTOP_FILE_NOT_FOUND__";
+```
+
+---
+
+### Low item #5 : `new(class tab_window)` — misleading placement-new syntax
+
+Location: src/display.cpp : 49
+Description: `w = new(class tab_window);` uses the parenthesised `(type-id)` form of `new`, which is valid C++ but visually identical to placement-new syntax `new(ptr) T`. Any reader encountering `new(...)` expects a placement expression, not a regular heap allocation. The elaborated type specifier `class tab_window` inside the parentheses adds further confusion.
+Severity rationale: Readability/maintenance issue; no runtime risk.
+Suggested fix: `w = new tab_window();`
+
+---
+
+### Low item #6 : `replay_write()` logs mismatch to `cerr` but does not throw — silent test failure
+
+Location: src/test_framework.cpp : 72–85
+Description: When a write mismatch is detected during replay, the function prints to `cerr` and returns normally. The calling code continues executing as if the write was correct. Contrast with `replay_read()` and `replay_msr()`, which throw `test_exception` on unexpected conditions. This inconsistency means write-mismatch test failures are easy to miss, especially in automated pipelines that do not scan `stderr`.
+Severity rationale: Silent test failure undermines the reliability of the test framework.
+Suggested fix: Replace the `cerr` output with `throw test_exception(...)`.
+
+---
+
+### Low item #7 : "PowerTOP %s" version header string not translatable
+
+Location: src/display.cpp : 119
+Description: `mvwprintw(tab_bar, 0,0, "PowerTOP %s", PACKAGE_VERSION)` prints a static English string. While the product name is typically not translated, the format string itself is not wrapped in `_()`, inconsistent with the project i18n policy and preventing translators from reordering tokens if needed.
+Severity rationale: Minor i18n policy violation.
+Suggested fix: `mvwprintw(tab_bar, 0, 0, _("PowerTOP %s"), PACKAGE_VERSION);`
+
+## Review of src/devlist.h, src/tuning/tunable.h, src/tuning/tunable.cpp, src/tuning/runtime.h, src/tuning/runtime.cpp — batch 03
+
+### Low item #1 : Missing copyright/license header in devlist.h
+
+Location: src/devlist.h : 1
+Description: `devlist.h` has no copyright and GPL license header. Every file in the project is required to carry the standard Intel copyright block per style.md §3.1.
+Severity rationale: License compliance issue; all other headers in the project carry the required header.
+Suggested fix: Add the standard copyright/license block at the top of the file (same template as in tunable.h, runtime.h, etc.).
+
+### Low item #2 : `#ifndef`/`#define` header guards instead of `#pragma once` in devlist.h
+
+Location: src/devlist.h : 1–2, 29
+Description: `devlist.h` uses the old-style `#ifndef __INCLUDE_GUARD_DEVLIST_H__` / `#define` / `#endif` guard. The project style (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style violation; inconsistent with the stated project standard.
+Suggested fix: Replace the three guard lines with `#pragma once`.
+
+### Low item #3 : `#ifndef`/`#define` header guards instead of `#pragma once` in tunable.h
+
+Location: src/tuning/tunable.h : 25–26, 92
+Description: Same violation as Low #2. `tunable.h` uses `#ifndef _INCLUDE_GUARD_TUNABLE_H`.
+Severity rationale: Style violation.
+Suggested fix: Replace with `#pragma once`.
+
+### Low item #4 : `#ifndef`/`#define` header guards instead of `#pragma once` in runtime.h
+
+Location: src/tuning/runtime.h : 25–26, 48
+Description: Same violation as Low #2 and Low #3. `runtime.h` uses `#ifndef _INCLUDE_GUARD_RUNTIME_TUNE_H`.
+Severity rationale: Style violation.
+Suggested fix: Replace with `#pragma once`.
+
+### Low item #5 : Constructors do not use member initializer lists in tunable.cpp
+
+Location: src/tuning/tunable.cpp : 35–52
+Description: Both constructors assign to member variables in the constructor body (`desc = str;`, `score = _score;`, etc.) rather than using a member initializer list. In C++, member initializer lists are preferred as they initialize members directly rather than default-constructing them first and then assigning.
+Severity rationale: C++ best-practice violation per general-c++.md. For `std::string` members this causes a default construction followed by a copy-assignment instead of a single copy construction.
+Suggested fix: Use member initializer lists, e.g.:
+```cpp
+tunable::tunable(const std::string &str, double _score,
+                 const std::string &good, const std::string &bad,
+                 const std::string &neutral)
+    : desc(str), score(_score),
+      good_string(good), bad_string(bad), neutral_string(neutral)
+{}
+```
+
+### Low item #6 : `while (1)` instead of `while (true)` in runtime.cpp
+
+Location: src/tuning/runtime.cpp : 133
+Description: `while (1)` is a C idiom. C++ code should use `while (true)` for clarity and to avoid implicit int-to-bool conversion.
+Severity rationale: C++ style violation per general-c++.md.
+Suggested fix: Change `while (1)` to `while (true)`.
+
+### Low item #7 : Redundant `extern` keyword on function declarations in devlist.h
+
+Location: src/devlist.h : 21–27
+Description: All function declarations in `devlist.h` are prefixed with `extern`. In C++, free functions declared at namespace scope are externally linked by default; the `extern` keyword is redundant and adds noise.
+Severity rationale: Low severity style inconsistency; no functional impact.
+Suggested fix: Remove the `extern` keyword from all function declarations in the header.
+
+## Review of ethernet.cpp, ethernet.h, wifi.cpp, wifi.h, tuningusb.h — batch 04
+
+### Low item #1 : C-style casts `(caddr_t)` in ethernet.cpp
+
+Location: src/tuning/ethernet.cpp : 86 and 122
+Description: `ifr.ifr_data = (caddr_t)&wol;` uses a C-style cast. In C++ code, `reinterpret_cast` should be used when casting between unrelated pointer types to make the intent explicit and to be caught by static analysis tools.
+Severity rationale: C++ best-practice violation; C-style casts bypass type-safety checks.
+Suggested fix: `ifr.ifr_data = reinterpret_cast<caddr_t>(&wol);`
+
+### Low item #2 : `interf` member is `public` in `ethernet_tunable`
+
+Location: src/tuning/ethernet.h : 36
+Description: The `interf` data member is declared `public`, exposing the internal interface name of the tunable to all callers. It is only used internally by the class's own methods. Encapsulation calls for it to be `private` (or at most `protected`).
+Severity rationale: Unnecessary exposure of internals; violates encapsulation; matches the pattern used in wifi_tunable where `iface` is correctly `private`.
+Suggested fix: Move `std::string interf;` to the `private:` section.
+
+### Low item #3 : Redundant `class` keyword in local variable declarations
+
+Location: src/tuning/ethernet.cpp : 134 and src/tuning/wifi.cpp : 80, 91
+Description: `class ethernet_tunable *eth` and `class wifi_tunable *wifi` use the elaborated type specifier `class`. In C++ this is unnecessary and unusual; `ethernet_tunable *eth` and `wifi_tunable *wifi` are idiomatic.
+Severity rationale: Low-impact style violation; not idiomatic C++.
+Suggested fix: Remove the redundant `class` keyword from all three variable declarations.
+
+### Low item #4 : Unused includes `<utility>` and `<iostream>` in ethernet.cpp
+
+Location: src/tuning/ethernet.cpp : 33 and 34
+Description: Neither `<utility>` (std::pair, std::move, etc.) nor `<iostream>` (std::cout, std::cin, etc.) symbols are used anywhere in ethernet.cpp. These unused includes add unnecessary compilation overhead and obscure the file's real dependencies.
+Severity rationale: Dead code; same pattern flagged in previous batches.
+Suggested fix: Remove `#include <utility>` and `#include <iostream>` from ethernet.cpp.
+
+### Low item #5 : Unused includes `<utility>` and `<iostream>` in wifi.cpp
+
+Location: src/tuning/wifi.cpp : 31 and 32
+Description: Same as Low item #4 — `<utility>` and `<iostream>` are included but nothing from them is used in wifi.cpp.
+Severity rationale: Same as Low item #4.
+Suggested fix: Remove `#include <utility>` and `#include <iostream>` from wifi.cpp.
+
+## Review of tuningusb.cpp, tuning.cpp, tuning.h, bluetooth.cpp, bluetooth.h — batch 05
+
+### Low item #1 : System header included with quotes instead of angle brackets
+
+Location: src/tuning/tuningusb.cpp : 28
+Description: `#include "unistd.h"` uses double-quote syntax for a system header. Double-quote includes first search the local directory, which can accidentally shadow a system header with a local file of the same name. System headers must use `<unistd.h>`.
+Severity rationale: Incorrect include style; harmless in practice but violates the include-order style rule.
+Suggested fix: Change to `#include <unistd.h>`.
+
+### Low item #2 : Duplicate `#include` directives
+
+Location: src/tuning/bluetooth.cpp : 28 and 35 (`<unistd.h>`), 36 and 38 (`<sys/types.h>`)
+Description: Both `<unistd.h>` and `<sys/types.h>` are included twice in bluetooth.cpp. While include guards make this harmless at the preprocessor level, it is dead code and adds confusion.
+Severity rationale: Unnecessary noise; style issue.
+Suggested fix: Remove the duplicate `#include <unistd.h>` at line 35 and the duplicate `#include <sys/types.h>` at line 38.
+
+### Low item #3 : `strcpy` into a fixed-size struct field
+
+Location: src/tuning/bluetooth.cpp : 123 and 209
+Description: `strcpy(devinfo.name, "hci0")` copies into `hci_dev_info::name[8]`. While "hci0\0" is only 5 bytes so no overflow occurs here, using `strcpy` into a fixed-size field is fragile — a future change to the device name (e.g., "hci10\0") or the field size could silently overflow. The project style guide prefers `std::string` over C-style char arrays.
+Severity rationale: Technically safe with the current string, but unsafe pattern; style violation.
+Suggested fix: Use `strncpy(devinfo.name, "hci0", sizeof(devinfo.name) - 1); devinfo.name[sizeof(devinfo.name)-1] = '\0';` or restructure to avoid the C struct entirely using BlueZ D-Bus APIs.
+
+### Low item #4 : Non-translatable user-visible error string
+
+Location: src/tuning/bluetooth.cpp : 181 and 185
+Description: `printf("System is not available\n")` outputs a user-visible string without the `_()` gettext wrapper. Per the project's i18n rules (rules.md, style.md §5), all user-facing strings must be wrapped in `_()`. Additionally, error output should go to `stderr` not `stdout`, and `printf` should be replaced with `fprintf(stderr, ...)`.
+Severity rationale: Violates mandatory i18n rule; error goes to wrong stream.
+Suggested fix:
+```cpp
+fprintf(stderr, _("Bluetooth toggle failed: system() call unavailable\n"));
+```
+
+### Low item #5 : Mixed tabs and spaces indentation in `report_show_tunables`
+
+Location: src/tuning/tuning.cpp : 207–215
+Description: The `report_show_tunables` function mixes 8-space indentation with tab indentation in adjacent lines (e.g., lines 209–213 use spaces where the rest of the file uses tabs). The project style guide mandates tabs-only indentation.
+Severity rationale: Style violation; makes the file inconsistent and harder to read in editors configured for different tab widths.
+Suggested fix: Convert the space-indented lines to use a single tab at the appropriate nesting level.
+
+### Low item #6 : `#ifndef` header guard instead of `#pragma once`
+
+Location: src/tuning/tuning.h : 26–27; src/tuning/bluetooth.h : 25–26
+Description: Both headers use traditional `#ifndef`/`#define`/`#endif` include guards. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style guide violation; `#pragma once` is simpler and less prone to guard-name collisions.
+Suggested fix: Replace each include-guard triplet with a single `#pragma once` at the top of the file.
+
+### Low item #7 : Unused `#include` directives in bluetooth.cpp
+
+Location: src/tuning/bluetooth.cpp : 32–34
+Description: `#include <utility>`, `#include <iostream>`, and `#include <fstream>` are present but nothing from these headers (`std::move`, `std::cout`, `std::ifstream`, etc.) is used in bluetooth.cpp.
+Severity rationale: Dead includes add compile-time cost and mislead readers about the file's dependencies.
+Suggested fix: Remove the three unused include lines.
+
+### Low item #8 : User-visible notification string not wrapped in `_()`
+
+Location: src/tuning/tuning.cpp : 157
+Description: `ui_notify_user(std::format(">> {}\n", toggle_script))` passes a format string literal that is not wrapped in `_()`. The `">> {}\n"` part is displayed to the user in the Tunables tab when a tunable is toggled. Per the i18n rules, user-visible strings must use the gettext `_()` macro.
+Severity rationale: i18n rule violation; the string is not translatable.
+Suggested fix: `ui_notify_user(pt_format(_(">> {}\n"), toggle_script));`
+
+## Review of src/tuning/tuningsysfs.cpp, src/tuning/tuningsysfs.h, src/tuning/nl80211.h, src/tuning/iw.h, src/tuning/iw.c — batch 06
+
+### Low item #1 : Old-style #ifndef header guard in tuningsysfs.h instead of #pragma once
+
+Location: src/tuning/tuningsysfs.h : 25–26
+Description: The header uses `#ifndef _INCLUDE_GUARD_SYSFS_TUNE_H` / `#define _INCLUDE_GUARD_SYSFS_TUNE_H`. Per `style.md` section 4.1, the project convention is `#pragma once`.
+Severity rationale: Style violation; not a functional bug but inconsistent with project convention.
+Suggested fix: Replace lines 25–26 and 51 with `#pragma once` at the top of the file.
+
+### Low item #2 : Old-style #ifndef header guard in iw.h instead of #pragma once
+
+Location: src/tuning/iw.h : 1–2
+Description: The header uses `#ifndef __IW_H` / `#define __IW_H`. Per `style.md` section 4.1, the project convention is `#pragma once`. Also, the guard name `__IW_H` starts with a double underscore, which is a reserved identifier in C/C++.
+Severity rationale: Style violation and use of reserved identifier name for the macro.
+Suggested fix: Replace with `#pragma once` and remove the closing `#endif /* __IW_H */`.
+
+### Low item #3 : Include ordering in tuningsysfs.cpp mixes project and system headers
+
+Location: src/tuning/tuningsysfs.cpp : 26–37
+Description: Per `style.md` section 4.4, standard library headers should appear before project-specific headers. In `tuningsysfs.cpp` the order is: `"tuning.h"` (project), `"tunable.h"` (project), `<unistd.h>` (system), `"tuningsysfs.h"` (project), `<string.h>` (system), `<dirent.h>` (system), `<utility>` (stdlib), `<iostream>` (stdlib), `<fstream>` (stdlib), `<limits.h>` (system), `<format>` (stdlib), then `"../lib.h"` (project). System and project headers are interleaved rather than grouped.
+Severity rationale: Style violation; ordering makes include dependencies harder to track.
+Suggested fix: Group standard library/system headers first, then project headers.
+
+### Low item #4 : Unused include <limits.h> in tuningsysfs.h
+
+Location: src/tuning/tuningsysfs.h : 29
+Description: `#include <limits.h>` is present but nothing from `<limits.h>` (e.g. `PATH_MAX`, `CHAR_BIT`) is used anywhere in the header.
+Severity rationale: Dead code; increases compilation dependencies unnecessarily.
+Suggested fix: Remove the `#include <limits.h>` line.
+
+### Low item #5 : Unused include <vector> in tuningsysfs.h
+
+Location: src/tuning/tuningsysfs.h : 28
+Description: `#include <vector>` is present but `std::vector` is not used in the header itself. The vector operations on `all_tunables` are in the `.cpp` file which includes the appropriate headers transitively.
+Severity rationale: Unused include; increases compilation overhead.
+Suggested fix: Remove the `#include <vector>` line.
+
+### Low item #6 : Unused include <limits.h> in tuningsysfs.cpp
+
+Location: src/tuning/tuningsysfs.cpp : 35
+Description: `#include <limits.h>` is included in the `.cpp` file but no symbol from it (`PATH_MAX`, etc.) is used in `tuningsysfs.cpp`.
+Severity rationale: Dead code; unnecessary compile-time dependency.
+Suggested fix: Remove line 35.
+
+### Low item #7 : ETH_ALEN defined without a #ifndef guard in iw.h
+
+Location: src/tuning/iw.h : 37
+Description: `#define ETH_ALEN 6` is an unconditional definition. `ETH_ALEN` is also defined in `<linux/if_ether.h>` and in some libnl headers. If iw.h is included after any of those headers, the compiler will emit a macro-redefinition warning (or error with `-Werror`). Additionally, `ETH_ALEN` is never used anywhere in the reviewed files, making the definition dead code.
+Severity rationale: Potential redefinition conflict; unused dead code.
+Suggested fix: Either remove the definition entirely (it is unused), or guard it: `#ifndef ETH_ALEN\n#define ETH_ALEN 6\n#endif`.
+
+### Low item #8 : Redundant `class` keyword in pointer declarations in add_sysfs_tunable
+
+Location: src/tuning/tuningsysfs.cpp : 80–82
+Description: `class sysfs_tunable *st;` and `st = new class sysfs_tunable(...)` use the `class` keyword in variable declarations and `new` expressions. In C++ the `class` tag is not required when the class type is already visible; the idiomatic form is simply `sysfs_tunable *st = new sysfs_tunable(...)`. The `class` keyword in declarations is a C-ism that is unnecessary and non-idiomatic in C++.
+Severity rationale: Non-idiomatic C++; style inconsistency.
+Suggested fix:
+```cpp
+sysfs_tunable *st = new sysfs_tunable(str, _sysfs_path, _target_content);
+all_tunables.push_back(st);
+```
+
+## Review of tuningi2c.h, tuningi2c.cpp, powerconsumer.h, powerconsumer.cpp, processdevice.h — batch 07
+
+### Low item #1 : `#ifndef` header guard instead of `#pragma once` in tuningi2c.h
+
+Location: src/tuning/tuningi2c.h : 20-21
+Description: The header uses the old `#ifndef _INCLUDE_GUARD_I2C_TUNE_H` idiom instead of the project-standard `#pragma once`.
+Severity rationale: Per style.md §4.1, `#pragma once` is the required form.
+Suggested fix: Replace lines 20-21 and 44 with `#pragma once`.
+
+### Low item #2 : `#ifndef` header guard instead of `#pragma once` in powerconsumer.h
+
+Location: src/process/powerconsumer.h : 25-26
+Description: Same as Low item #1 — old `#ifndef` guard instead of `#pragma once`.
+Severity rationale: Per style.md §4.1.
+Suggested fix: Replace guard with `#pragma once`.
+
+### Low item #3 : `#ifndef` header guard instead of `#pragma once` in processdevice.h
+
+Location: src/process/processdevice.h : 25-26
+Description: Same as Low item #1.
+Severity rationale: Per style.md §4.1.
+Suggested fix: Replace guard with `#pragma once`.
+
+### Low item #4 : `"unistd.h"` included with quotes instead of angle brackets
+
+Location: src/tuning/tuningi2c.cpp : 22
+Description: `#include "unistd.h"` uses double-quotes for a system header. The convention (style.md §4.4) is that system/standard headers use angle brackets `<>`.
+Severity rationale: Style violation; can also cause the wrong file to be included if a local `unistd.h` exists.
+Suggested fix: `#include <unistd.h>`
+
+### Low item #5 : C-style headers used instead of C++ equivalents
+
+Location: src/tuning/tuningi2c.cpp : 24, 29, 30
+Description: `<string.h>`, `<ctype.h>`, and `<limits.h>` are C headers. In C++20 code the C++ wrappers `<cstring>`, `<cctype>`, and `<climits>` should be used so that identifiers are placed in `namespace std`.
+Severity rationale: Use of deprecated C-style includes in C++20 code; per general-c++.md, C++20 standard constructs should be preferred.
+Suggested fix: Replace with `<cstring>`, `<cctype>`, `<climits>`.
+
+### Low item #6 : `NULL` used instead of `nullptr`
+
+Location: src/process/powerconsumer.cpp : 75, 76
+Description: The constructor assigns `waker = NULL` and `last_waker = NULL`. In C++11 and later (and mandated by C++20), `nullptr` is the type-safe null pointer constant.
+Severity rationale: `NULL` is a C holdover; `nullptr` is the correct C++20 form per general-c++.md.
+Suggested fix: Replace both occurrences with `nullptr`.
+
+### Low item #7 : Silent clamping of inconsistent `child_runtime`
+
+Location: src/process/powerconsumer.cpp : 40-41
+Description: When `child_runtime > accumulated_runtime`, the code silently resets `child_runtime = 0` with no log or diagnostic. This masks accounting bugs in callers and makes root-cause analysis harder.
+Severity rationale: Defensive silencing of data corruption without any trace; low severity because the clamp prevents a negative cost value, but the lack of any diagnostic makes bugs invisible.
+Suggested fix: Add a debug-mode `fprintf(stderr, ...)` or assertion before clamping so that the anomaly is at least visible during development.
+
+## Review of processdevice.cpp, process.h, process.cpp, work.cpp, work.h — batch 08
+
+### Low item #1 : Index-based for loops where range-for is cleaner
+
+Location: src/process/processdevice.cpp : 61 ; src/process/process.cpp : 156, 213
+Description: Several loops use `unsigned int i` index variables to iterate over `std::vector` containers (`all_proc_devices`, `all_processes`). C++11 range-for is simpler and eliminates the risk of index type mismatch.
+Severity rationale: Style and maintainability; no correctness issue, but inconsistent with modern C++ idioms.
+Suggested fix: Replace, e.g.:
+```cpp
+for (auto *cdev : all_proc_devices) { ... }
+for (auto *proc : all_processes)    { ... }
+```
+
+### Low item #2 : Verbose iterator type declarations; prefer `auto`
+
+Location: src/process/processdevice.cpp : 93 ; src/process/process.cpp : 221
+Description: `std::vector<class device_consumer *>::iterator it = ...` and `std::vector <class process *>::iterator it = ...` are unnecessarily verbose. The `auto` keyword was introduced precisely for this pattern.
+Severity rationale: Readability; no correctness issue.
+Suggested fix: `auto it = all_proc_devices.begin();` / `auto it = all_processes.begin();`.
+
+### Low item #3 : O(n²) clear_work implementation
+
+Location: src/process/work.cpp : 100-108
+Description: `clear_work()` erases one element at a time and resets `it = all_work.begin()` on each iteration, making it O(n²). The standard idiom for clearing a map (freeing each value first) is a simple range-for followed by `all_work.clear()`.
+Severity rationale: Performance; for large work-item maps this degrades noticeably.
+Suggested fix:
+```cpp
+void clear_work(void)
+{
+    for (auto &[key, val] : all_work)
+        delete val;
+    all_work.clear();
+    running_since.clear();
+}
+```
+
+### Low item #4 : Type inconsistency: constructor takes `unsigned long`, caller passes `uint64_t`
+
+Location: src/process/work.h : 38 ; src/process/work.cpp : 122
+Description: `work::work(unsigned long work_func)` accepts `unsigned long`, but `find_create_work(uint64_t func)` passes a `uint64_t`. On LP64 Linux these are the same size, but the inconsistency is confusing and would silently truncate on ILP64 platforms.
+Severity rationale: Portability and clarity.
+Suggested fix: Change the constructor parameter to `uint64_t`: `work(uint64_t work_func);`.
+
+## Review of interrupt.h, interrupt.cpp, timer.cpp, timer.h, do_process.cpp — batch 09
+
+### Low item #1 : Index-based for loops should be range-based for loops
+
+Location: src/process/interrupt.cpp : 104, 117  /  src/process/do_process.cpp : 107, 117, 720, 733, 747, 762, 776
+Description: Numerous loops use the pattern `for (unsigned int i = 0; i < vec.size(); i++)` with index access. C++20 (and the project's general preference for STL constructs) favours range-based for loops which are cleaner and avoid off-by-one errors.
+Severity rationale: Style/best-practice violation; no correctness impact but reduces readability.
+Suggested fix: Convert to `for (auto *item : vec)` or `for (const auto &item : vec)` as appropriate.
+
+### Low item #2 : all_power.erase(begin, end) should be all_power.clear()
+
+Location: src/process/do_process.cpp : 1144, 1201
+Description: `all_power.erase(all_power.begin(), all_power.end())` is equivalent to `all_power.clear()` but is more verbose and less idiomatic C++. `clear()` better expresses intent.
+Severity rationale: Readability; no functional difference.
+Suggested fix: Replace both occurrences with `all_power.clear();`.
+
+### Low item #3 : add_timer takes pair by value instead of const reference
+
+Location: src/process/timer.cpp : 112
+Description: The `add_timer` helper function signature is `static void add_timer(const pair<unsigned long, class timer*>& elem)` — actually the code shows it accepts a `pair` by value. In any case the use with `std::for_each` copies each pair; it should accept `const std::pair<const unsigned long, class timer*>&`.
+Severity rationale: Minor inefficiency.
+Suggested fix: Use a range-based for loop instead, e.g.:
+```cpp
+void all_timers_to_all_power(void)
+{
+    for (auto &[addr, t] : all_timers)
+        all_power.push_back(t);
+}
+```
+
+### Low item #4 : std::string_view wrapping of std::string for starts_with
+
+Location: src/process/do_process.cpp : 284
+Description: `!std::string_view(next_comm).starts_with("migration/")` creates an unnecessary `string_view` wrapper. Since `next_comm` is already a `std::string` and C++20 `std::string` has `starts_with()` directly, the cast is redundant.
+Severity rationale: Minor inefficiency and unnecessary verbosity.
+Suggested fix: Replace with `!next_comm.starts_with("migration/")` etc.
+
+### Low item #5 : Iterator types spelled out instead of using auto
+
+Location: src/process/interrupt.cpp : 124  /  src/process/timer.cpp : 148
+Description: `std::vector<class interrupt *>::iterator it = ...` and `std::map<unsigned long, class timer *>::iterator it = ...` are verbose iterator declarations that obscure intent. The project uses C++20; `auto` should be preferred.
+Severity rationale: Readability; verbose type declarations.
+Suggested fix: Use `auto it = ...`.
+
+### Low item #6 : Local variable timer shadows the class name timer
+
+Location: src/process/timer.cpp : 136
+Description: Inside `find_create_timer`, the local variable is named `timer`, which shadows the class name `timer`. While the compiler handles this correctly, it is confusing to read and maintain.
+Severity rationale: Readability and potential for confusion.
+Suggested fix: Rename to `new_timer` (consistent with `find_create_interrupt` which uses `new_irq`).
+
+## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
+
+### Low item #1 : `malloc`/`free` used in C++ code instead of `new[]`/`delete[]`
+
+Location: src/perf/perf_bundle.cpp : 63, 91, 160
+Description: Raw `malloc` and `free` are used to allocate and release event record buffers. In C++ code, `new[]` / `delete[]` (or `std::vector<unsigned char>`) is strongly preferred. Mixing C and C++ allocation can cause type-safety issues and prevents use of RAII.
+Severity rationale: Low — it works but is against C++ best practices and project style.
+Suggested fix: Use `new unsigned char[header->size]` / `delete[]` or use a `std::vector<unsigned char>` and store by value.
+
+### Low item #2 : `exit(-1)` instead of `exit(EXIT_FAILURE)`
+
+Location: src/perf/perf.cpp : 113
+Description: `exit(-1)` uses a non-portable, non-standard exit code. The portable way to signal failure is `exit(EXIT_FAILURE)`.
+Severity rationale: Minor portability issue.
+Suggested fix: Replace with `exit(EXIT_FAILURE)`.
+
+### Low item #3 : Unused `eventname` parameter in `create_perf_event`
+
+Location: src/perf/perf.cpp : 58
+Description: The `eventname` parameter (of type `const string &`) is marked `__unused` and never referenced inside the function body. The event type is taken from `trace_type` directly. If the parameter is truly unnecessary it should be removed or documented; if it was intended to be used, it is a functional gap.
+Severity rationale: Dead parameter increases maintenance burden and could indicate a missing code path.
+Suggested fix: Remove the parameter from the signature (updating the call site in `start()`) or document why it is intentionally unused.
+
+### Low item #4 : C-style casts used throughout
+
+Location: src/perf/perf_bundle.cpp : 63, 67, 69, 187, 268; src/perf/perf.cpp : 130, 131, 187, 235
+Description: Multiple C-style casts (`(unsigned char *)`, `(struct perf_event_header *)`, `(struct perf_sample *)`, `(perf_event_mmap_page *)`) are used instead of C++ named casts (`reinterpret_cast<>`, `static_cast<>`). C-style casts bypass the type system silently.
+Severity rationale: C++ named casts make intent explicit and are safer.
+Suggested fix: Replace with appropriate named casts, e.g. `reinterpret_cast<unsigned char *>(...)`.
+
+### Low item #5 : `__unused` macro used instead of C++17 `[[maybe_unused]]`
+
+Location: src/perf/perf.cpp : 58, 280
+Description: The project uses `#define __unused __attribute__((unused))` (a GCC extension) rather than the C++17 standard attribute `[[maybe_unused]]`. Since the project targets C++20, the standard attribute should be used.
+Severity rationale: Minor — GCC extension works fine but the standard attribute is preferred in C++17/20 code.
+Suggested fix: Replace `__unused` with `[[maybe_unused]]` in function parameter declarations.
+
+### Low item #6 : `#include <malloc.h>` is a non-standard header
+
+Location: src/perf/perf_bundle.cpp : 26
+Description: `<malloc.h>` is a Linux/glibc-specific header. The standard C/C++ header for `malloc` is `<cstdlib>` (C++) or `<stdlib.h>` (C). `stdlib.h` is already included on line 31 of `perf.cpp`; `perf_bundle.cpp` should use `<cstdlib>` or `<stdlib.h>`.
+Severity rationale: Minor portability issue.
+Suggested fix: Replace `#include <malloc.h>` with `#include <cstdlib>`.
+
+### Low item #7 : Return value of `fcntl` not checked
+
+Location: src/perf/perf.cpp : 115
+Description: `fcntl(perf_fd, F_SETFL, O_NONBLOCK)` is called without checking the return value. If this fails, the fd will remain in blocking mode and subsequent `read`/`process` calls may block indefinitely.
+Severity rationale: Silent failure in a system call that affects event processing behavior.
+Suggested fix:
+```cpp
+if (fcntl(perf_fd, F_SETFL, O_NONBLOCK) < 0)
+    fprintf(stderr, _("fcntl O_NONBLOCK failed: %s\n"), strerror(errno));
+```
+
+## Review of persistent.cpp, parameters.cpp, parameters.h, learn.cpp, report-formatter.h — batch 11
+
+### Low item #1 : `using namespace std` in persistent.cpp
+
+Location: src/parameters/persistent.cpp : 34
+Description: `using namespace std;` in a .cpp translation unit is explicitly discouraged by style.md and general-c++.md. While the impact is limited to this translation unit (unlike a header), it is still a rule violation that hides which symbols come from the standard library, reducing readability and increasing collision risk.
+Severity rationale: Rule violation contained to one TU.
+Suggested fix: Remove the `using namespace std;` line and add the `std::` prefix to `ofstream`, `istringstream`, `string`, `getline`, `setprecision`, `setiosflags`, etc.
+
+### Low item #2 : Old-style iterator and index loops instead of range-based for
+
+Location: src/parameters/persistent.cpp : 50, 55 ; src/parameters/parameters.cpp : 55, 166, 256, 278
+Description: Multiple loops use `for (it = …begin(); it != …end(); it++)` or `for (i = 0; i < vec.size(); i++)` patterns. C++20 range-based for (`for (auto &x : container)`) is clearer, less error-prone and preferred by the project style.
+Severity rationale: C++20 style violation; no functional impact.
+Suggested fix: Convert to range-based for where possible, e.g. `for (auto &[name, idx] : param_index) { … }`.
+
+### Low item #3 : `#ifndef` include guard instead of `#pragma once` in parameters.h
+
+Location: src/parameters/parameters.h : 25
+Description: The header uses `#ifndef __INCLUDE_GUARD_PARAMETERS_H_` / `#define` / `#endif` style guards. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style violation; `#pragma once` is universally supported and less error-prone.
+Suggested fix: Replace the `#ifndef`/`#define`/`#endif` triple with `#pragma once`.
+
+### Low item #4 : `#ifndef` include guard instead of `#pragma once` in report-formatter.h
+
+Location: src/report/report-formatter.h : 26
+Description: Same violation as Low item #3 — `#ifndef _REPORT_FORMATTER_H_` guard instead of `#pragma once`.
+Severity rationale: Style violation.
+Suggested fix: Replace with `#pragma once`.
+
+### Low item #5 : GCC-specific `__unused` attribute instead of standard `[[maybe_unused]]`
+
+Location: src/report/report-formatter.h : 43, 49, 50, 51, 53, 54
+Description: Six virtual method parameters use the GCC extension `__unused` (e.g. `const std::string &str __unused`). C++17 introduced `[[maybe_unused]]` as the portable, standard-compliant spelling. Since the project targets C++20, the standard attribute should be used instead.
+Severity rationale: Non-portable, GCC-specific attribute in a C++20 codebase.
+Suggested fix: Replace `__unused` with `[[maybe_unused]]` on each affected parameter.
+
+## Review of report-formatter-html.h, report.cpp, report.h, report-formatter-csv.h, report-maker.cpp — batch 12
+
+### Low item #1 : Duplicate `#include <string.h>`
+
+Location: report.cpp : 31, 36
+Description: `<string.h>` is included twice. The second inclusion is redundant and suggests copy-paste; the same translation unit also includes `<string>` (the C++ header), so the C header should likely be replaced with `<cstring>` and included only once.
+Severity rationale: Harmless (include guards prevent double-definition), but indicates dead code and the wrong header name.
+Suggested fix: Remove one of the two occurrences and ensure the remaining one uses `<cstring>`.
+
+### Low item #2 : Non-standard `#include <malloc.h>`
+
+Location: report.cpp : 37
+Description: `<malloc.h>` is a GNU extension, not a standard C or C++ header. Nothing in `report.cpp` appears to use any `malloc.h`-specific declarations; `malloc`/`free` are available via `<cstdlib>`. Including it reduces portability.
+Severity rationale: Portability issue; the header is unnecessary in this file.
+Suggested fix: Remove `#include <malloc.h>`.
+
+### Low item #3 : `NULL` used instead of `nullptr`
+
+Location: report-maker.cpp : 41, report.cpp : 114
+Description: `formatter = NULL` (report-maker.cpp:41) and `time(NULL)` (report.cpp:114) use the C-style `NULL` macro. In C++11 and later, `nullptr` is the correct null-pointer constant; `NULL` is implementation-defined and may expand to an integer.
+Severity rationale: C++ style / correctness hygiene; not a runtime bug in practice.
+Suggested fix: Replace `NULL` with `nullptr` where used as a pointer; `time(nullptr)` for the `time()` call.
+
+### Low item #4 : `formatter` member is a raw owning pointer
+
+Location: report-maker.cpp : 40-51, 99-110
+Description: `report_maker` manages the lifetime of its `formatter` through manual `new` / `delete`. This is fragile: if `setup_report_formatter()` is called while an exception propagates (e.g., from `new`), the previously held `formatter` may already have been deleted, leaving the member dangling. Using `std::unique_ptr<report_formatter>` would express ownership clearly and make the destructor body trivial.
+Severity rationale: Low — exception propagation from `new` in this code path is very unlikely in practice.
+Suggested fix: Declare `formatter` as `std::unique_ptr<report_formatter>` and replace `new`/`delete` with `std::make_unique`.
+
+## Review of report-maker.h, report-data-html.cpp, report-data-html.h, report-formatter-base.cpp, report-formatter-base.h — batch 13
+
+### Low item #1 : C-style headers used instead of C++ equivalents
+
+Location: src/report/report-maker.h : 61  and  src/report/report-formatter-base.cpp : 29, 31
+Description: `report-maker.h` includes `<stdarg.h>` and `report-formatter-base.cpp` includes `<stdio.h>` and `<stdarg.h>`. In C++ code these should be `<cstdarg>` and `<cstdio>` respectively, which place their declarations in the `std` namespace and avoid polluting the global namespace with C names.
+Severity rationale: C++ best practice; the C headers are deprecated in C++.
+Suggested fix: Replace `<stdarg.h>` with `<cstdarg>` and `<stdio.h>` with `<cstdio>`. If neither is actually used in these files, remove the includes entirely.
+
+### Low item #2 : Unqualified `string` in `report-formatter-base.cpp`
+
+Location: src/report/report-formatter-base.cpp : 54, 62
+Description: The parameter type in `add(const string &str)` and `add_exact(const string &str)` uses the unqualified name `string` rather than `std::string`. This only compiles because `using namespace std;` is injected transitively via the included headers — a dependency on namespace pollution.
+Severity rationale: Style guide violation (style.md §4.2); correct names must be fully qualified.
+Suggested fix: Replace `const string &` with `const std::string &` in both definitions.
+
+### Low item #3 : `__()` macro silently depends on a global variable named `report`
+
+Location: src/report/report-maker.h : 68–70
+Description: The `__()` translation macro is defined as `((report.get_type() == REPORT_CSV) ? (STRING) : gettext(STRING))`. It silently requires a globally visible `report_maker` object named `report`. Any translation unit that includes `report-maker.h` and uses `__()` without such a global will get a compilation error or, worse, accidentally reference a different `report` object in scope. The macro provides no warning about this hidden dependency.
+Severity rationale: Hidden global-state dependency in a header-level macro; fragile and non-obvious to users of the header.
+Suggested fix: Rename the macro to something that makes the dependency explicit, or refactor it as a function taking a `const report_maker &` parameter.
+
+## Review of report-formatter-csv.cpp, report-formatter-html.cpp, dram_rapl_device.cpp, dram_rapl_device.h, cpu_linux.cpp — batch 14
+
+### Low item #1 : `dram_rapl_device.h` uses `#ifndef`/`#define` guard instead of `#pragma once`
+
+Location: src/cpu/dram_rapl_device.h : 25-26
+Description: The style guide specifies `#pragma once` for header guards. `dram_rapl_device.h` uses the older `#ifndef _INCLUDE_GUARD_DRAM_RAPL_DEVICE_H` / `#define` pattern.
+Severity rationale: Deviation from stated style guide. Low impact in practice.
+Suggested fix: Replace with `#pragma once` and remove the `#ifndef`/`#define`/`#endif` guards.
+
+### Low item #2 : `NULL` used instead of `nullptr` in C++20 code
+
+Location: src/cpu/dram_rapl_device.h : 46 ; src/cpu/dram_rapl_device.cpp : 40, 50, 57
+Description: In C++20 code, `nullptr` is the correct null pointer constant. `NULL` is a C macro and, while still valid, is discouraged in modern C++. In `dram_rapl_device.h` line 46 the default argument uses `NULL`; in `dram_rapl_device.cpp` `time(NULL)` appears three times (though `time()` takes a `time_t*`, so `nullptr` is the right form).
+Severity rationale: Style rule violation; `NULL` vs `nullptr` does not affect correctness here but is inconsistent with C++20 practice.
+Suggested fix: Replace `NULL` with `nullptr` in all occurrences.
+
+### Low item #3 : `device_name()` and `human_name()` not marked `const` in `dram_rapl_device.h`
+
+Location: src/cpu/dram_rapl_device.h : 48-49
+Description: Both `device_name()` and `human_name()` return a compile-time constant string and do not modify any member state, yet neither is declared `const`. The C++ rule states: "Use 'const' when possible for method and function parameters [and methods]."
+Severity rationale: Missing `const` prevents calling these methods on const references/pointers and violates the stated coding rule.
+Suggested fix:
+```cpp
+virtual std::string device_name() const { return "DRAM"; }
+virtual std::string human_name() const  { return "DRAM"; }
+```
+
+### Low item #4 : `cpu_linux.cpp` has duplicate `#include` directives
+
+Location: src/cpu/cpu_linux.cpp : 37-38 and 41, 192
+Description: `#include <sys/types.h>` appears on two consecutive lines (37 and 38). Additionally, `#include <format>` appears at both line 41 and again at line 192 (after `measurement_end()`). Duplicate includes are harmless due to include guards but indicate sloppy maintenance.
+Severity rationale: Minor style/maintenance issue; no functional impact.
+Suggested fix: Remove the duplicate `#include <sys/types.h>` on line 38 and the duplicate `#include <format>` on line 192.
+
+### Low item #5 : Bare `string` type used without `std::` qualifier
+
+Location: src/report/report-formatter-html.cpp : 102, 105, 280, 331 ; src/report/report-formatter-csv.cpp : 52, 55, 112, 143
+Description: These files use `string` (and the return type `string` for functions) without the `std::` prefix. The style guide requires always using `std::string`. The bare `string` resolves only because the included headers (`report-formatter-html.h`, `report-formatter-csv.h`) themselves contain `using namespace std;`, which itself is a style violation. The `.cpp` files should use `std::string` explicitly.
+Severity rationale: Style rule violation; indirect resolution through a namespace-polluting header.
+Suggested fix: Replace all bare `string` with `std::string` in both `.cpp` files, and remove `using namespace std;` from the included headers.
+
+### Low item #6 : C-style headers used instead of C++ equivalents
+
+Location: src/report/report-formatter-html.cpp : 29-31 ; src/report/report-formatter-csv.cpp : 29-31 ; src/cpu/dram_rapl_device.cpp : 25-27 ; src/cpu/cpu_linux.cpp : 32, 35-36
+Description: Multiple files include C-style headers (`<stdio.h>`, `<assert.h>`, `<stdarg.h>`, `<stdlib.h>`, `<string.h>`) in C++20 code. The C++ equivalents (`<cstdio>`, `<cassert>`, `<cstdarg>`, `<cstdlib>`, `<cstring>`) are preferred as they place declarations in the `std` namespace and avoid potential macro/symbol pollution.
+Severity rationale: Style violation; no functional impact but inconsistent with modern C++20 practice.
+Suggested fix: Replace each C-style header with its `<c...>` equivalent.
+
+### Low item #7 : Include order: C standard headers after project headers in `cpu_linux.cpp`
+
+Location: src/cpu/cpu_linux.cpp : 29-40
+Description: The style guide specifies "Standard library headers first, followed by project-specific headers." In `cpu_linux.cpp`, `"cpu.h"` (line 29) and `"../lib.h"` (line 30) appear before `<stdlib.h>`, `<unistd.h>`, `<stdio.h>`, `<string.h>`, etc. (lines 32–40).
+Severity rationale: Style rule violation.
+Suggested fix: Move all standard/system `<...>` headers before the project `"..."` headers.
+
+## Review of src/cpu/cpu_core.cpp, src/cpu/cpudevice.h, src/cpu/cpudevice.cpp, src/cpu/abstract_cpu.cpp, src/cpu/cpu_rapl_device.cpp — batch 15
+
+### Low item #1 : `#ifndef`/`#define` include guard instead of `#pragma once` in cpudevice.h
+
+Location: src/cpu/cpudevice.h : 25-27
+Description: The file uses the traditional `#ifndef _INCLUDE_GUARD_CPUDEVICE_H` / `#define`
+/ `#endif` pattern. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style guide violation; `#pragma once` is simpler and avoids possible
+macro name collisions.
+Suggested fix: Replace the three guard lines with `#pragma once`.
+
+### Low item #2 : `#ifndef`/`#define` include guard instead of `#pragma once` in cpu_rapl_device.h
+
+Location: src/cpu/cpu_rapl_device.h : 25-27
+Description: Same violation as item #1 in this header.
+Severity rationale: Style guide violation; same rationale.
+Suggested fix: Replace with `#pragma once`.
+
+### Low item #3 : `NULL` used instead of `nullptr` in cpudevice.h
+
+Location: src/cpu/cpudevice.h : 51
+Description: The default parameter `class abstract_cpu *_cpu = NULL` uses the C-style `NULL`
+macro. C++11 and later (the project targets C++20) provide the type-safe `nullptr` keyword
+which should always be preferred.
+Severity rationale: C++20 code should not use the untyped `NULL` macro.
+Suggested fix: Change `= NULL` to `= nullptr`.
+
+### Low item #4 : `NULL` used instead of `nullptr` in cpu_rapl_device.h
+
+Location: src/cpu/cpu_rapl_device.h : 46
+Description: Same violation — `class abstract_cpu *_cpu = NULL` in the constructor default.
+Severity rationale: Same as item #3.
+Suggested fix: Change `= NULL` to `= nullptr`.
+
+### Low item #5 : Error diagnostic strings not wrapped in `_()` for translation
+
+Location: src/cpu/abstract_cpu.cpp : 275, 375
+Description: The error messages `"Invalid C state finalize "` and `"Invalid P state finalize "`
+are not wrapped in the `_()` gettext macro. Even though these are internal diagnostics, the
+project rule states all user-visible strings must be translatable. These messages do appear in
+the terminal when unexpected state transitions occur, making them user-visible in practice.
+Severity rationale: Violates the universal translation requirement (rules.md).
+Suggested fix: Wrap the string literals in `_()`, e.g.
+`fprintf(stderr, _("Invalid C state finalize %s\n"), linux_name.c_str());`
+
+## Review of src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp — batch 16
+
+### Low item #1 : cpu_rapl_dev and dram_rapl_dev created with identical packagename
+
+Location: src/cpu/cpu.cpp : 90, 97
+Description: Both the `cpu_rapl_device` and `dram_rapl_device` are created using
+the same `packagename = pt_format(_("package-{}"), cpu)` string (the assignment
+is repeated identically on lines 90 and 97). While this may be intentional, it
+means both devices share the same identifier, which could cause confusion in the
+device list and in parameter lookups. This looks like a copy-paste artefact.
+Severity rationale: Potential functional confusion in device naming/lookup; low risk on current code paths but a maintenance hazard.
+Suggested fix: Give the DRAM device a distinct name, e.g. `pt_format(_("dram-package-{}"), cpu)`.
+
+### Low item #2 : `exit(-2)` uses a non-standard exit code
+
+Location: src/cpu/intel_cpus.cpp : 147
+Description: `exit(-2)` is called on MSR read failure. Negative exit codes are
+non-portable; POSIX only guarantees correct behaviour for 0 and values
+representable in the low 8 bits of an unsigned char. On Linux, exit(-2) is
+received by the parent as exit code 254 (a confusing, meaningless value).
+The project style guide states `exit(EXIT_FAILURE)` for fatal errors.
+Severity rationale: Low impact on Linux, but a portability and style issue.
+Suggested fix: Replace with `exit(EXIT_FAILURE)`.
+
+### Low item #3 : Inconsistent hex literal case — uppercase `0X`
+
+Location: src/cpu/intel_cpus.cpp : 83, 401
+Description: Two hex literals use uppercase `0X8F` and `0X9A` (capital X). Every
+other hex literal in these files uses lowercase `0x`. While both forms are valid
+C++, the inconsistency is a readability issue and deviates from the established
+style.
+Severity rationale: Pure style/consistency issue.
+Suggested fix: Change to `0x8F` and `0x9A`.
+
+### Low item #4 : Unnecessary `.c_str()` conversion passed to `std::string` parameter
+
+Location: src/cpu/intel_cpus.cpp : 627
+Description: `update_pstate(state->freq, state->human_name.c_str(), ...)` converts
+`state->human_name` (a `std::string`) to `const char *` for a function that accepts
+`const std::string&`. This is an unnecessary round-trip that creates a temporary
+`std::string`.
+Severity rationale: Minor inefficiency; violates the "prefer std::string over C-style strings" guideline.
+Suggested fix: Pass `state->human_name` directly without `.c_str()`.
+
+### Low item #5 : Bare `vector<>` without `std::` in public class members in cpu.h
+
+Location: src/cpu/cpu.h : 103-105
+Description: The public data members `children`, `cstates`, and `pstates` in
+`abstract_cpu` are declared as bare `vector<...>` without the `std::` prefix:
+```cpp
+vector<class abstract_cpu *> children;
+vector<struct idle_state *> cstates;
+vector<struct frequency *> pstates;
+```
+The project C++ guidelines and style guide both require `std::vector<>`. These
+are tolerated at present only because `using namespace std;` is (incorrectly) in
+the header, but once that is removed they will not compile.
+Severity rationale: Directly tied to the `using namespace std` violation; fixing
+that without fixing these would break the build.
+Suggested fix: Change to `std::vector<...>` for all three members.
+
+## Review of src/cpu/intel_cpus.h, src/cpu/rapl/rapl_interface.h, src/cpu/rapl/rapl_interface.cpp, src/wakeup/wakeup.h — batch 17
+
+### Low item #1 : `#ifndef` header guard instead of `#pragma once` (intel_cpus.h)
+
+Location: src/cpu/intel_cpus.h : 1
+Description: The file uses a traditional `#ifndef`/`#define`/`#endif` header guard instead of the project-mandated `#pragma once` (style.md §4.1).
+Severity rationale: Style violation; `#pragma once` is required by the project style guide.
+Suggested fix: Replace the `#ifndef` guard with `#pragma once`.
+
+### Low item #2 : `#ifndef` header guard instead of `#pragma once` (rapl_interface.h)
+
+Location: src/cpu/rapl/rapl_interface.h : 24
+Description: Same issue as Low item #1 — uses `#ifndef RAPL_INTERFACE_H` instead of `#pragma once`.
+Severity rationale: Style violation per style.md §4.1.
+Suggested fix: Replace the `#ifndef` guard with `#pragma once`.
+
+### Low item #3 : `#ifndef` header guard instead of `#pragma once` (wakeup.h)
+
+Location: src/wakeup/wakeup.h : 25
+Description: Same issue — uses `#ifndef _INCLUDE_GUARD_WAKEUP_H` instead of `#pragma once`.
+Severity rationale: Style violation per style.md §4.1.
+Suggested fix: Replace the `#ifndef` guard with `#pragma once`.
+
+### Low item #4 : Pervasive typo `measurment_interval` (missing 'e')
+
+Location: src/cpu/rapl/rapl_interface.h : 47, src/cpu/rapl/rapl_interface.cpp : 79, 661, 671, 681, 691, 696
+Description: The member variable and all references are spelled `measurment_interval` instead of `measurement_interval`. The typo propagates across the header and all uses in the implementation.
+Severity rationale: Misspelling in a protected member variable name; low functional impact but reduces readability and searchability.
+Suggested fix: Rename to `measurement_interval` throughout.
+
+### Low item #5 : Missing space between `if` and `(` in multiple locations (rapl_interface.cpp)
+
+Location: src/cpu/rapl/rapl_interface.cpp : 248, 262, 276, 294, 315, 335, 355, 384, 405, 428, 447, 474, 495, 512, 532, 562, 583, 600, 620
+Description: Many `if` statements are written as `if(ret < 0)` without a space between the keyword and the opening parenthesis, violating the K&R style requirement (style.md §1.2) and the project's Linux-kernel-variant brace/spacing convention.
+Severity rationale: Consistent style violation throughout the file.
+Suggested fix: Add a space: `if (ret < 0)`.
+
+### Low item #6 : Space-indented line in intel_cpus.h (mixed indentation)
+
+Location: src/cpu/intel_cpus.h : 56
+Description: The line `        DIR *dir;` uses 8 spaces for indentation instead of a tab character. All other members in the class use tab indentation. This breaks the "tabs only" rule from style.md §1.1.
+Severity rationale: Mixed indentation in a single class declaration; style violation per style.md §1.1.
+Suggested fix: Replace the leading spaces with a tab character.
+
+## Review of wakeup_usb.h, wakeup_ethernet.h, waketab.cpp, wakeup_ethernet.cpp, wakeup.cpp — batch 18
+
+### Low item #1 : duplicate sysfs path construction in wakeup_eth_callback
+
+Location: src/wakeup/wakeup_ethernet.cpp : 99-103
+Description: `filename` is set by `std::format(...)` on line 99, checked with `access()`, then set identically again on line 103 before being passed to the constructor. The second assignment is dead code and suggests a copy/paste error. The same pattern occurs in `wakeup_usb_callback`.
+Severity rationale: Low — no functional impact, but dead code is misleading and could mask a future bug if lines diverge.
+Suggested fix: Remove the second (redundant) `filename = std::format(...)` assignment on line 103.
+
+### Low item #2 : virtual overrides missing `override` specifier
+
+Location: src/wakeup/wakeup_usb.h : 40-44  and  src/wakeup/wakeup_ethernet.h : 40-44
+Description: The three virtual methods (`wakeup_value`, `wakeup_toggle`, `wakeup_toggle_script`) declared in both headers are overrides of the base class `wakeup`, but they lack the `override` keyword. Without `override`, a typo in a method signature silently creates a new virtual function instead of overriding the base.
+Severity rationale: Low — no current bug, but `override` is a C++11 safety net that costs nothing and prevents subtle errors.
+Suggested fix: Add `override` and remove the redundant `virtual`:
+```cpp
+int wakeup_value(void) override;
+void wakeup_toggle(void) override;
+std::string wakeup_toggle_script(void) override;
+```
+
+### Low item #3 : `#ifndef`/`#define` include guards instead of `#pragma once`
+
+Location: src/wakeup/wakeup_usb.h : 25-26  and  src/wakeup/wakeup_ethernet.h : 25-26
+Description: Both headers use old-style `#ifndef _INCLUDE_GUARD_*` guards. The project style guide mandates `#pragma once`.
+Severity rationale: Low — style guide violation; `#pragma once` is simpler and universally supported by all toolchains targeted by PowerTOP.
+Suggested fix: Replace the `#ifndef`/`#define`/`#endif` guards with `#pragma once`.
+
+### Low item #4 : user-visible string not wrapped in `_()` for translation
+
+Location: src/wakeup/waketab.cpp : 110
+Description: `ui_notify_user(std::format(">> {}\n", wakeup_toggle_script))` presents text to the user but the format string `">> {}\n"` is not marked for translation with `_()`. All user-facing strings must use the gettext `_()` macro per the style guide. Additionally, the style guide states user-facing `pt_format` should be used for translated strings with arguments.
+Severity rationale: Low — i18n requirement clearly stated in the style guide; the string will never be translated.
+Suggested fix:
+```cpp
+ui_notify_user(pt_format(_(">> {}\n"), wakeup_toggle_script));
+```
+
+### Low item #5 : excessive unused includes in wakeup_ethernet.cpp
+
+Location: src/wakeup/wakeup_ethernet.cpp : 27-43
+Description: The following headers are included but nothing from them is used in the file: `<sys/socket.h>`, `<errno.h>`, `<linux/types.h>`, `<net/if.h>`, `<linux/sockios.h>`, `<sys/ioctl.h>`, `<linux/ethtool.h>`, `<iostream>`, `<fstream>`, `<stdlib.h>`, `<string.h>`, `<sys/types.h>`, `<unistd.h>`, `<utility>`. These appear to be leftovers from an earlier implementation that used raw ethtool ioctls.
+Severity rationale: Low — no functional impact, but unnecessary includes increase compile time, pollute the macro/symbol namespace, and hide the real dependencies of the file.
+Suggested fix: Remove all unused includes. Keep only: `<stdio.h>`, `<format>`, `"wakeup.h"`, `"../lib.h"`, `"wakeup_ethernet.h"`.
+
+## Review of src/wakeup/wakeup_usb.cpp, src/measurement/acpi.cpp, src/measurement/acpi.h, src/measurement/opal-sensors.h — batch 19
+
+### Low item #1 : Duplicate `filename` computation in `wakeup_usb_callback`
+
+Location: src/wakeup/wakeup_usb.cpp : 99 and 103
+Description: `filename` is computed with `std::format("/sys/bus/usb/devices/{}/power/wakeup", d_name)` on line 99, used only for the `access()` call, and then immediately recomputed with the exact same expression on line 103. The second assignment is dead code — it produces the same value as the first. This is misleading (suggests the value might differ) and wasteful.
+Severity rationale: Low — no functional impact, but creates confusion and violates DRY; the double computation also hints at a refactoring left half-done.
+Suggested fix: Remove line 103. The existing value of `filename` from line 99 is valid for passing to the `usb_wakeup` constructor.
+
+### Low item #2 : Unused includes in wakeup_usb.cpp
+
+Location: src/wakeup/wakeup_usb.cpp : 33-40
+Description: The following headers are included but no symbols from them are referenced anywhere in the file: `<sys/socket.h>`, `<net/if.h>`, `<linux/sockios.h>`, `<sys/ioctl.h>`, `<linux/ethtool.h>`, and `<iostream>`. These appear to be leftover from copy-paste from an ethernet wakeup file. Unnecessary includes increase compilation time and mislead readers about the file's dependencies.
+Severity rationale: Low — no functional impact, but violates clean-code principles and harms readability.
+Suggested fix: Remove the six unused include directives.
+
+### Low item #3 : Override methods in `acpi_power_meter` lack `override` keyword
+
+Location: src/measurement/acpi.h : 37-42
+Description: `start_measurement`, `end_measurement`, `power`, and `dev_capacity` are declared with `virtual` in the derived class `acpi_power_meter` but without the `override` specifier. C++11 and later best practice (and the C++20 standard used by this project) require `override` on overriding functions so the compiler can catch signature mismatches.
+Severity rationale: Low — no crash risk but silently hides interface-mismatch bugs; violates C++20 best practices.
+Suggested fix: Add `override` and remove the redundant `virtual` on all four overriding method declarations.
+
+### Low item #4 : Override methods in `opal_sensors_power_meter` lack `override` keyword
+
+Location: src/measurement/opal-sensors.h : 34-38
+Description: Same issue as batch 19 Low item #3: `start_measurement`, `end_measurement`, `power`, and `dev_capacity` use `virtual` without `override`.
+Severity rationale: Low — same rationale as item #3 above.
+Suggested fix: Add `override`, remove `virtual`, on all four declarations.
+
+## Review of sysfs.h, sysfs.cpp, measurement.h, measurement.cpp, extech.h — batch 20
+
+### Low item #1 : C headers used instead of C++ headers in sysfs.cpp
+
+Location: src/measurement/sysfs.cpp : 28-30
+Description: `#include <string.h>`, `#include <stdio.h>`, and `#include <limits.h>` are C headers. The C++ equivalents (`<cstring>`, `<cstdio>`, `<climits>`) place all symbols in the `std::` namespace, avoiding accidental name collisions. The project uses C++20 throughout.
+Severity rationale: Low — compiles correctly, but uses non-idiomatic headers for a C++20 codebase.
+Suggested fix: Replace with `<cstring>`, `<cstdio>`, `<climits>`.
+
+### Low item #2 : `power_meters.size() == 0` instead of `power_meters.empty()`
+
+Location: src/measurement/measurement.cpp : 174
+Description: Comparing `size()` to 0 is less idiomatic and slightly less efficient than `empty()`. The STL guideline (and general C++ best practice) is to use `empty()` when testing for an empty container.
+Severity rationale: Correctness is unaffected, but violates the "prefer STL constructs" rule in general-c++.md.
+Suggested fix: `if (power_meters.empty()) {`
+
+### Low item #3 : Index-based loops where range-based for loops should be used
+
+Location: src/measurement/measurement.cpp : 66-67, 73-74, 83-86, 121-125
+Description: Four loops iterate over `power_meters` using `unsigned int i` as an index. The project uses C++20 and range-based for loops are cleaner, avoid off-by-one risk, and do not require a manual index variable. general-c++.md states to strongly prefer STL constructs.
+Severity rationale: Style / best-practice violation; no functional impact.
+Suggested fix: Replace e.g. `for (i = 0; i < power_meters.size(); i++) power_meters[i]->start_measurement();` with `for (auto *m : power_meters) m->start_measurement();`.
+
+### Low item #4 : Unqualified `vector` and unqualified `string` due to namespace pollution
+
+Location: src/measurement/measurement.cpp : 58; src/measurement/sysfs.cpp : 32, 38
+Description: `vector<class power_meter *> power_meters;` (measurement.cpp:58) and `const string &` parameters (sysfs.cpp:32,38) are unqualified. They compile only because `using namespace std;` in measurement.h leaks `std::vector` and `std::string`. Once the `using namespace std;` is removed (High item #1), these lines will fail to compile.
+Severity rationale: Latent compilation error that will surface when fixing the high-severity issue.
+Suggested fix: Use `std::vector<power_meter *>` and `const std::string &` at the affected locations.
+
+## Review of src/measurement/extech.cpp, src/devices/backlight.h, src/devices/rfkill.h, src/devices/rfkill.cpp — batch 21
+
+### Low item #1 : Duplicate includes in extech.cpp
+
+Location: src/measurement/extech.cpp : 37-48 and 58-62
+Description: `<string.h>`, `<stdio.h>`, and `<stdlib.h>` are each included twice — once near the top of the file and again after the project headers. While harmless at compile time due to include guards, it indicates copy-paste accumulation and clutters the file.
+Severity rationale: Code hygiene; redundant code obscures intent.
+Suggested fix: Remove the second block of duplicate includes (lines 60-62).
+
+### Low item #2 : Header guards use `#ifndef` style instead of `#pragma once` (backlight.h, rfkill.h)
+
+Location: src/devices/backlight.h : 25-26 | src/devices/rfkill.h : 25-26
+Description: Both headers use the traditional `#ifndef _INCLUDE_GUARD_*` / `#define` / `#endif` pattern. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style rule violation in two files.
+Suggested fix: Replace each `#ifndef … #define … #endif` triple with `#pragma once`.
+
+### Low item #3 : Fixed-size `char buf[4096]` in rfkill constructor
+
+Location: src/devices/rfkill.cpp : 47
+Description: A fixed-size 4096-byte buffer is used for `readlink()` output. Although the call is correctly bounded with `sizeof(buf) - 1`, the use of a fixed C-style buffer is discouraged by the style guide and general-c++.md in favor of `std::string`-based alternatives. The kernel maximum path length is `PATH_MAX` (typically 4096), so the size is correct, but the idiom is out of place in C++20 code.
+Severity rationale: Style/practice concern; provably safe but violates the preference for STL types.
+Suggested fix: Use `std::array<char, PATH_MAX>` and reference `sizeof` from that, or use an OS-level path query helper if available.
+
+### Low item #4 : `<unistd.h>` included twice in rfkill.cpp
+
+Location: src/devices/rfkill.cpp : 31 and 42
+Description: `<unistd.h>` is included twice in the same translation unit. Harmless but redundant.
+Severity rationale: Code cleanliness; signals lack of attention during editing.
+Suggested fix: Remove the second `#include <unistd.h>` at line 42.
+
+### Low item #5 : `rate` member initialized in constructor body, not initializer list
+
+Location: src/measurement/extech.cpp : 271
+Description: `rate = 0.0;` is assigned in the constructor body instead of the member initializer list. For a plain `double`, there is no performance difference, but it is inconsistent with C++ best practice and with how other data members are initialized.
+Severity rationale: Minor C++ best-practice violation.
+Suggested fix: Move `rate(0.0)` into the initializer list: `extech_power_meter::extech_power_meter(const string &extech_name) : power_meter(extech_name), rate(0.0)`.
+
+## Review of src/devices/usb.h, src/devices/usb.cpp, src/devices/gpu_rapl_device.h, src/devices/gpu_rapl_device.cpp, src/devices/ahci.h — batch 22
+
+### Low item #1 : Header guards using `#ifndef` instead of `#pragma once`
+
+Location: src/devices/usb.h : 25-26, src/devices/gpu_rapl_device.h : 25-26, src/devices/ahci.h : 25-26
+Description: All three headers use the traditional `#ifndef _INCLUDE_GUARD_XXX` / `#define` / `#endif` pattern. The project style guide (`style.md §4.1`) specifies `#pragma once` as the required form. All other recently touched headers in the codebase already use `#pragma once`.
+Severity rationale: Style rule violation; non-conforming to stated project standard.
+Suggested fix: Replace the `#ifndef`/`#define`/`#endif` triple with a single `#pragma once` at the top of each header (after the copyright block).
+
+### Low item #2 : Include order violation in usb.cpp
+
+Location: src/devices/usb.cpp : 25-39
+Description: `#include <iostream>` and `#include <fstream>` (lines 38-39) appear after the project-specific headers `#include "../lib.h"` etc. The project style (`style.md §4.4`) requires standard library headers to appear before project-specific headers. Additionally `#include <iostream>` is never used in this translation unit (no `std::cin`, `std::cout`, etc.), so it is dead code.
+Severity rationale: Style violation; dead include adds unnecessary compile-time overhead.
+Suggested fix: Move `<iostream>` and `<fstream>` before the project includes, and remove `<iostream>` entirely if it is not needed.
+
+### Low item #3 : C-style `class` keyword in variable declaration and `new` expression
+
+Location: src/devices/usb.cpp : 144, 158
+Description: Line 144 declares `class usbdevice *usb;` and line 158 uses `new class usbdevice(...)`. Prefixing the class name with the `class` keyword in expressions is a C idiom not idiomatic C++; in C++ the type name `usbdevice` is sufficient. This is the only file in the recently reviewed batch that does this.
+Severity rationale: Style violation; C idiom in C++ code.
+Suggested fix: Change to `usbdevice *usb;` and `usb = new usbdevice(...)`.
+
+### Low item #4 : Missing `const` on pure-getter methods
+
+Location: src/devices/usb.h : 55-62, src/devices/gpu_rapl_device.h : 47-50, src/devices/ahci.h : 58-65
+Description: Methods such as `class_name()`, `device_name()`, `human_name()`, `power_valid()`, `grouping_prio()`, and `device_present()` access no mutable state and should be declared `const`. The project rules (`general-c++.md`) require `const` where possible. Omitting `const` prevents calling these methods on `const` references or through `const` pointers to the objects.
+Severity rationale: C++ best-practice and coding-rule violation; limits const-correctness of callers.
+Suggested fix: Append `const` to each getter: e.g., `virtual std::string class_name(void) const { return "usb"; }`.
+
+### Low item #5 : Unused `#include <iostream>` in usb.cpp
+
+Location: src/devices/usb.cpp : 38
+Description: `<iostream>` is included but no symbols from it (`std::cin`, `std::cout`, `std::cerr`, etc.) are used anywhere in `usb.cpp`. Dead includes slow compilation and confuse readers.
+Severity rationale: Dead code / style violation.
+Suggested fix: Remove `#include <iostream>`.
+
+### Low item #6 : Return value of `rapl.get_pp1_energy_status()` is silently ignored
+
+Location: src/devices/gpu_rapl_device.cpp : 39, 47, 57
+Description: `c_rapl_interface::get_pp1_energy_status()` presumably returns a status code indicating success or failure. All three call sites discard the return value. If the call fails, `last_energy` / `energy` will hold an outdated or garbage value and `consumed_power` will be computed incorrectly. At minimum, a failure check should log a warning or set `consumed_power = 0.0`.
+Severity rationale: Missing error handling; silent failure mode could produce incorrect power readings.
+Suggested fix: Check the return value and, on failure, skip the energy update: `if (rapl.get_pp1_energy_status(&energy) == 0) { consumed_power = ...; last_energy = energy; }`.
+
+### Low item #7 : Unused `#include <limits.h>` in usb.h
+
+Location: src/devices/usb.h : 28
+Description: `<limits.h>` is included in usb.h but no symbol from it (e.g., `INT_MAX`, `PATH_MAX`) is used in the header. If it was needed in usb.cpp, the include belongs there. Dead includes in headers are transitive and affect all translation units that include usb.h.
+Severity rationale: Dead include in a header; increases compile time and can mask missing includes in .cpp files.
+Suggested fix: Remove `#include <limits.h>` from usb.h; add it to usb.cpp only if actually needed there (it is not used in usb.cpp either, so remove entirely).
+
+
+## Review of src/devices/ahci.cpp, src/devices/thinkpad-fan.h, src/devices/thinkpad-fan.cpp, src/devices/device.h, src/devices/device.cpp — batch 23
+
+### Low item #1 : Typo "macine" in user-visible translatable string
+
+Location: src/devices/ahci.cpp : 277
+Description: The string `__("AHCI ALPM Residency Statistics - Not supported on this macine")` contains the typo "macine" (should be "machine"). This string appears in the HTML report and is visible to users.
+Severity rationale: Typo in a user-visible string; cosmetic but incorrect.
+Suggested fix: `__("AHCI ALPM Residency Statistics - Not supported on this machine")`
+
+### Low item #2 : `links.size() == 0` should use `.empty()`
+
+Location: src/devices/ahci.cpp : 276
+Description: `if (links.size() == 0)` tests emptiness by comparing the size to zero. The idiomatic and slightly more efficient C++ expression is `links.empty()`.
+Severity rationale: Style / best practice; STL guideline prefers `.empty()` for emptiness checks.
+Suggested fix: `if (links.empty()) {`
+
+### Low item #3 : `end_devslp` not clamped to `start_devslp` unlike the other three counters
+
+Location: src/devices/ahci.cpp : 156–163
+Description: In `ahci::end_measurement`, counter underflow is guarded for `end_active`, `end_partial`, and `end_slumber` (lines 156–162), but `end_devslp` has no corresponding clamp. If the sysfs counter wraps or is reset between `start_measurement` and `end_measurement`, `end_devslp - start_devslp` will be a large negative number. While the subsequent `if (p < 0) p = 0` guard prevents a negative percentage, the unclamped value also distorts `total`, which is used as the divisor for all four percentages.
+Severity rationale: Inconsistent defensive logic; can skew all four reported percentages on counter reset/wrap.
+Suggested fix: Add `if (end_devslp < start_devslp) end_devslp = start_devslp;` after line 161.
+
+### Low item #4 : Untranslated user-visible strings in thinkpad-fan.h
+
+Location: src/devices/thinkpad-fan.h : 47 and 50
+Description: `device_name()` returns `"Fan-1"` and `util_units()` returns `" rpm"`. Both strings may be displayed to the user (device name column, utilisation unit column). Neither is wrapped in `_()`. Per rules.md all user-visible strings must be translatable.
+Severity rationale: i18n violation for strings that appear in the device table.
+Suggested fix: `return _("Fan-1");` and `return _(" rpm");`
+
+### Low item #5 : Untranslated default `device_name` and `class_name` in device.h
+
+Location: src/devices/device.h : 58–59
+Description: The base class `device` returns `"abstract device"` for both `class_name()` and `device_name()`. Should a concrete subclass fail to override these methods, the bare English strings would be displayed to the user without translation.
+Severity rationale: Latent i18n risk; currently only triggered if a subclass forgets to override.
+Suggested fix: `{ return _("abstract device"); }`
+
+### Low item #6 : Index-based loops should use range-for
+
+Location: src/devices/device.cpp : 107–108, 113–115, 119–122, 187–214, 274–310, 331–334
+Description: Multiple loops over `all_devices` use `unsigned int i` index variables and manual `size()` comparisons. Modern C++20 idiom prefers range-for (`for (auto *dev : all_devices) { … }`) which is clearer and avoids potential signed/unsigned comparison warnings.
+Severity rationale: Style / best practice; not a functional issue.
+Suggested fix: Convert to range-for where the index is not used for anything other than element access.
+## Review of src/devices/devfreq.cpp, src/devices/devfreq.h, src/devices/alsa.h, src/devices/alsa.cpp, src/devices/runtime_pm.cpp — batch 24
+
+### Low item #1 : Global `DIR *dir` held open unnecessarily between create and clear
+
+Location: src/devices/devfreq.cpp : 44, 237-253, 325-328
+Description: `dir` is opened in `create_all_devfreq_devices()` only to count directory entries and is then left open until `clear_all_devfreq()` is called — potentially hours later. There is no functional reason to keep this handle open; the directory enumeration is done by `process_directory()` which opens the directory independently. Holding the file descriptor wastes a system resource and means the kernel cannot release the dentry.
+Severity rationale: Unnecessary resource hold; no correctness benefit.
+Suggested fix: Close `dir` with `closedir(dir); dir = NULL;` immediately after the `num == 2` early-exit or right after the counting loop completes; remove the close in `clear_all_devfreq()`.
+
+### Low item #2 : Magic number `7` in `alsa::register_power_with_devlist()`
+
+Location: src/devices/alsa.cpp : 163
+Description: `if (name.length() > 7) register_devpower(name.substr(7), ...)` uses the literal `7` to strip a prefix from `name`. The name is formatted as `"alsa:{}"` (prefix length 5). The value 7 corresponds to `"alsa:hw"` (stripping the `alsa:hw` prefix from an ALSA hwCxDy identifier). This is undocumented and error-prone; if the name format ever changes, this silently breaks.
+Severity rationale: Unmaintainable magic number; silent breakage risk on format change.
+Suggested fix: Define a named constant or use `name.starts_with("alsa:hw") ? name.substr(7) : name` with a clear comment.
+
+### Low item #3 : Duplicate `#include <unistd.h>`
+
+Location: src/devices/alsa.cpp : 30, 41
+Description: `<unistd.h>` is included twice. While harmless due to include guards, it is dead code noise.
+Severity rationale: Minor code quality issue.
+Suggested fix: Remove the second occurrence at line 41.
+
+### Low item #4 : `!all_devfreq.size()` should use `.empty()`
+
+Location: src/devices/devfreq.cpp : 282
+Description: `if (!all_devfreq.size())` tests emptiness via the size. The idiomatic and potentially more efficient form is `if (all_devfreq.empty())`.
+Severity rationale: Style/best-practice issue; `.empty()` is semantically clearer.
+Suggested fix: `if (all_devfreq.empty())`
+
+### Low item #5 : Mixed tabs/spaces indentation in `display_devfreq_devices()`
+
+Location: src/devices/devfreq.cpp : 271-275
+Description: Lines 271–275 (`if (!win) return;`, `wclear(win);`, `wmove(win, 2,0);`) use 8 spaces for indentation while the surrounding code uses tabs. style.md §1.1 mandates tabs-only indentation.
+Severity rationale: Style violation; inconsistent indentation in a single function.
+Suggested fix: Replace the leading 8-space sequences with a single tab character.
+
+### Low item #6 : Mixed tabs/spaces indentation in `runtime_pmdevice::start_measurement()`
+
+Location: src/devices/runtime_pm.cpp : 64
+Description: Line 64 (`after_suspended_time = 0;`) uses 8 spaces while the adjacent lines use tabs. style.md §1.1 mandates tabs-only indentation. A similar issue appears at line 97 inside `power_usage()`.
+Severity rationale: Style violation.
+Suggested fix: Replace the leading spaces with a single tab.

--- a/logs.1/medium.md
+++ b/logs.1/medium.md
@@ -1,0 +1,1379 @@
+# PowerTOP Medium Severity Review Findings
+
+## Review of calibrate.cpp, calibrate.h, lib.cpp, devlist.cpp, main.cpp — batch 01
+
+### Medium item #1 : `using namespace std;` in calibrate.cpp
+
+Location: src/calibrate/calibrate.cpp : 48
+
+Description:
+`using namespace std;` is present at file scope. The project style guide (style.md §4.2) explicitly prohibits this; all standard-library elements must be referenced via the `std::` prefix. Code earlier in the same file already uses `std::string` and `std::format` correctly, making the `using` directive redundant and inconsistent.
+
+Severity rationale: Namespace pollution can cause silent name collisions with POSIX and project symbols; it is a banned construct per the project coding rules.
+
+Suggested fix: Remove `using namespace std;` and qualify any bare `string`, `map`, `vector`, `ifstream`, etc. with `std::`.
+
+---
+
+### Medium item #2 : `using namespace std;` in lib.cpp
+
+Location: src/lib.cpp : 109
+
+Description:
+`using namespace std;` appears after a block of code that already uses explicit `std::` prefixes, and before code that mixes both styles. This is prohibited by style.md §4.2 and general-c++.md.
+
+Severity rationale: Same as Medium item #1 — namespace pollution and banned construct.
+
+Suggested fix: Remove the directive; qualify all standard-library identifiers with `std::`.
+
+---
+
+### Medium item #3 : `using namespace std;` in devlist.cpp
+
+Location: src/devlist.cpp : 43
+
+Description:
+`using namespace std;` at file scope, prohibited by the project style guide.
+
+Severity rationale: Same as Medium items #1 and #2.
+
+Suggested fix: Remove and add `std::` qualifiers throughout.
+
+---
+
+### Medium item #4 : Error message in `burn_disk` not translatable
+
+Location: src/calibrate/calibrate.cpp : 232
+
+Description:
+```cpp
+printf("Error: %s\n", strerror(errno));
+```
+The string literal `"Error: %s\n"` is not wrapped in `_()`. All user-visible strings must be internationalised (rules.md, style.md §5). The message is also emitted to `stdout` instead of `stderr`.
+
+Severity rationale: Violates the project i18n requirement; non-English users will always see the untranslated string.
+
+Suggested fix:
+```cpp
+fprintf(stderr, _("Error writing calibration file: %s\n"), strerror(errno));
+```
+
+---
+
+### Medium item #5 : `pthread_create` return value not checked in calibration functions
+
+Location: src/calibrate/calibrate.cpp : 248, 264, 369
+
+Description:
+`cpu_calibration`, `wakeup_calibration`, and `disk_calibration` all call `pthread_create` without checking the return value. If thread creation fails, `stop_measurement` is still set to 0 and `one_measurement` is called, but there is no thread to drive CPU/wakeup/disk load. Calibration data collected in that phase will be silently invalid.
+
+Severity rationale: Silent calibration failure leads to incorrect power model parameters being saved to `saved_parameters.powertop`.
+
+Suggested fix: Check the return value of `pthread_create`; log an error and return early if it fails.
+
+---
+
+### Medium item #6 : `burn_cpu_wakeups` — undefined behaviour casting pointer to `long`
+
+Location: src/calibrate/calibrate.cpp : 210, 264
+
+Description:
+```cpp
+tm.tv_nsec = (unsigned long)dummy;   // dummy is void *
+...
+pthread_create(&thr, NULL, burn_cpu_wakeups, (void *)interval);
+```
+Converting a pointer to `unsigned long` and then storing it in `tv_nsec` (which is of type `long`) is a round-trip pointer → integer → integer that is undefined behaviour in C++. Although it works on most 64-bit Linux targets, it is technically UB and violates general-c++.md ("Undefined behavior language constructs are a violation of coding style").
+
+Severity rationale: Technically undefined behaviour; a cleaner approach avoids the risk of miscompilation under aggressive optimisers.
+
+Suggested fix: Pass the interval via a heap-allocated struct or a file-scope variable rather than through the thread argument pointer.
+
+---
+
+### Medium item #7 : `one_measurement` — workload thread creation error not translatable
+
+Location: src/main.cpp : 239
+
+Description:
+```cpp
+fprintf(stderr, "ERROR: workload measurement thread creation failed\n");
+```
+The string literal is not wrapped in `_()`, violating the i18n requirement.
+
+Severity rationale: Violates mandatory i18n rule for all user-visible strings.
+
+Suggested fix:
+```cpp
+fprintf(stderr, _("ERROR: workload measurement thread creation failed\n"));
+```
+
+---
+
+### Medium item #8 : Debug message not translatable
+
+Location: src/main.cpp : 545
+
+Description:
+```cpp
+printf("Learning debugging enabled\n");
+```
+User-visible string not wrapped in `_()`.
+
+Severity rationale: Violates i18n requirement.
+
+Suggested fix:
+```cpp
+printf(_("Learning debugging enabled\n"));
+```
+
+---
+
+### Medium item #9 : Case `'c'` (calibrate) does not exit after calibration
+
+Location: src/main.cpp : 471–474
+
+Description:
+```cpp
+case 'c':
+    powertop_init(0);
+    calibrate();
+    break;
+```
+After the `break`, the `getopt` loop ends and `powertop_init(auto_tune)` is called again (line 539), followed by a potential interactive display mode or report generation. There is no `exit()` after `calibrate()`. If a user runs `powertop --calibrate`, the tool silently starts the interactive or report mode immediately after calibration completes, which is likely unintended.
+
+Severity rationale: Incorrect program flow; calibration is a standalone operation and should terminate the process.
+
+Suggested fix: Add `exit(0);` after `calibrate();`.
+
+---
+
+### Medium item #10 : `load_parameters` called twice in `powertop_init`
+
+Location: src/main.cpp : 407, 422
+
+Description:
+`load_parameters("saved_parameters.powertop")` is called at line 407 (before parameter registration) and again at line 422 (after). The second call overrides the default registered parameters with saved values, which may be the intent; but calling it before registration at line 407 loads values that are then immediately overwritten by `register_parameter` calls, making the first call a no-op. At minimum this is wasteful; it also suggests a latent ordering bug.
+
+Severity rationale: Redundant call with unclear intent; first call is ineffective and may mask a future ordering bug.
+
+Suggested fix: Remove the first `load_parameters` call (line 407), keeping only the one after all `register_parameter` calls.
+
+## Review of src/test_framework.h, src/test_framework.cpp, src/display.cpp, src/display.h, src/lib.h — batch 02
+
+### Medium item #1 : `using namespace std;` in test_framework.cpp
+
+Location: src/test_framework.cpp : 18
+Description: `using namespace std;` is present at file scope in the .cpp implementation file. While less dangerous than in a header, it still violates style rule 4.2 and general-c++.md ("deprecated construct"). All subsequent unqualified STL identifiers (`string`, `vector`, `ofstream`, `getline`, etc.) rely on this directive.
+Severity rationale: Style/rules violation; medium because it only affects this translation unit.
+Suggested fix: Remove `using namespace std;` and prefix all STL types with `std::`.
+
+---
+
+### Medium item #2 : `using namespace std;` in display.cpp
+
+Location: src/display.cpp : 36
+Description: Same issue as medium item #1 — `using namespace std;` at file scope in a .cpp file. All bare `string`, `vector`, and `map` references in this file rely on it.
+Severity rationale: Style/rules violation; medium because it only affects this translation unit.
+Suggested fix: Remove `using namespace std;` and use `std::` prefix throughout.
+
+---
+
+### Medium item #3 : `#ifndef`/`#define` guard instead of `#pragma once` in test_framework.h
+
+Location: src/test_framework.h : 11
+Description: The file uses an old-style `#ifndef _INCLUDE_GUARD_TEST_FRAMEWORK_H_` / `#define` / `#endif` guard. Style rule 4.1 mandates `#pragma once`.
+Severity rationale: Style violation; also the guard name uses a reserved double-underscore prefix (`_INCLUDE_GUARD_…_H_`), which is UB in C++ (names starting with `_` followed by upper-case are reserved).
+Suggested fix: Replace lines 11–12 and 104 with a single `#pragma once`.
+
+---
+
+### Medium item #4 : `#ifndef` guard instead of `#pragma once` in display.h
+
+Location: src/display.h : 25
+Description: Same issue — old `#ifndef __INCLUDE_GUARD_DISPLAY_H_` guard. The guard name also uses the reserved `__` prefix.
+Severity rationale: Style violation + reserved identifier usage.
+Suggested fix: Replace with `#pragma once`.
+
+---
+
+### Medium item #5 : `#ifndef` guard instead of `#pragma once` in lib.h
+
+Location: src/lib.h : 25
+Description: `#ifndef INCLUDE_GUARD_LIB_H` guard. While the guard name itself is not reserved here, `#pragma once` is the project standard.
+Severity rationale: Style violation.
+Suggested fix: Replace with `#pragma once`.
+
+---
+
+### Medium item #6 : Use of deprecated `resetterm()` in `reset_display()`
+
+Location: src/display.cpp : 87
+Description: `resetterm()` is an obsolete ncurses function (removed in newer ncurses versions). The correct modern API is `endwin()`, which restores the terminal state after curses use. Using `resetterm()` may fail to link against current ncurses or produce wrong terminal behaviour.
+Severity rationale: Deprecated/removed API that can break on modern systems.
+Suggested fix:
+```cpp
+endwin();
+```
+
+---
+
+### Medium item #7 : Hardcoded 120-column width in `show_tab()`
+
+Location: src/display.cpp : 118, 123
+Description: `mvwprintw(tab_bar, 0,0, "%120s", "")` and the same pattern for `bottom_line` pad the line to exactly 120 characters regardless of the actual terminal width (`COLS`). On narrower terminals this overflows the window; on wider terminals the bar is not filled. This is also a printf format-string that doesn't respect COLS.
+Severity rationale: Functional display bug on any terminal not exactly 120 columns wide.
+Suggested fix: Use `COLS` dynamically:
+```cpp
+mvwprintw(tab_bar, 0, 0, "%*s", COLS, "");
+```
+
+---
+
+### Medium item #8 : Hardcoded tab-name string comparisons in `cursor_down()`
+
+Location: src/display.cpp : 247
+Description: `tab_names[current_tab] == "Tunables" || tab_names[current_tab] == "WakeUp"` hardcodes internal tab key names in the cursor navigation logic. This breaks if the tab name is ever changed and creates a fragile coupling between display.cpp and any code that creates those tabs. `init_display()` itself does not create "Tunables" or "WakeUp" tabs, so this comparison is already stale relative to the tabs initialised in this file.
+Severity rationale: Fragile design; logic depends on magic string literals scattered in separate code.
+Suggested fix: Introduce a flag or virtual method on `tab_window` to indicate that the tab uses cursor-tracking, rather than comparing by name.
+
+---
+
+### Medium item #9 : User-visible error strings in test_framework.cpp not wrapped in `_()`
+
+Location: src/test_framework.cpp : 75, 81–84, 120, 144
+Description: Strings such as `"TEST FAIL: Unexpected write to: "`, `"Failed to open record file: "`, and `"Failed to open replay file: "` are printed to `stderr` where they are visible to users running the tool. Per rules.md and style.md §5, all user-visible strings must be wrapped in `_()` for gettext internationalisation.
+Severity rationale: i18n rule violation; strings will not be translatable.
+Suggested fix: Wrap each string literal: e.g. `cerr << _("Failed to open record file: ") << ...`.
+
+---
+
+### Medium item #10 : C-style `typedef` for callback type in lib.h
+
+Location: src/lib.h : 102
+Description: `typedef void (*callback)(const std::string&);` uses the C-style `typedef` syntax. In C++11 and later (the project uses C++20) the preferred form is a `using` alias.
+Severity rationale: Style / C++ best-practice violation.
+Suggested fix:
+```cpp
+using callback = void (*)(const std::string&);
+```
+
+---
+
+### Medium item #11 : `newpad(1000, 1000)` with hardcoded magic numbers in `create_tab()`
+
+Location: src/display.cpp : 51
+Description: Each tab's pad is created with a fixed 1000×1000 cell size. This magic number is repeated in the scroll-limit guards in `cursor_down()` and `cursor_right()` (lines 246, 301) without any shared constant. Using the actual content size or a named constant would make the intent clear and prevent the limit checks from getting out of sync if the pad size is ever changed.
+Severity rationale: Magic number; creates a latent inconsistency between pad allocation and scroll boundary guards.
+Suggested fix: Define `constexpr int PAD_MAX = 1000;` and use it in `newpad` and all guard comparisons.
+
+## Review of src/tuning/tunable.h, src/tuning/tunable.cpp, src/tuning/runtime.h, src/tuning/runtime.cpp — batch 03
+
+### Medium item #1 : Duplicate and malformed `<unistd.h>` include in runtime.cpp
+
+Location: src/tuning/runtime.cpp : 28, 34
+Description: `unistd.h` is included twice. The first occurrence at line 28 uses quotes (`#include "unistd.h"`), which is incorrect for a system header — it causes the compiler to search project directories first. The second occurrence at line 34 uses the correct angle-bracket form (`#include <unistd.h>`). The first include should be removed.
+Severity rationale: Using quotes for system headers can cause subtle include-path issues and is a misuse of the include syntax. Having duplicate includes is also wasteful.
+Suggested fix: Remove line 28 (`#include "unistd.h"`), keep line 34 (`#include <unistd.h>`).
+
+### Medium item #2 : Missing `override` specifier on virtual methods in `runtime_tunable`
+
+Location: src/tuning/runtime.h : 39–41
+Description: `good_bad()` and `toggle()` override virtual methods from `tunable` but do not use the `override` keyword. Without `override`, a typo in the method signature would silently create a new virtual function instead of overriding the base class method.
+Severity rationale: Missing `override` is a C++11+ best-practice violation. It prevents the compiler from catching signature mismatches.
+Suggested fix:
+```cpp
+virtual int good_bad(void) override;
+virtual void toggle(void) override;
+```
+
+### Medium item #3 : C header `<limits.h>` used instead of C++ header `<climits>`
+
+Location: src/tuning/runtime.h : 29
+Description: The C header `<limits.h>` is included. In C++ code, the corresponding C++ header `<climits>` should be used, which places all declarations in the `std` namespace.
+Severity rationale: Using C headers in C++ code is a style violation per general-c++.md (C++20 standard compliance).
+Suggested fix: Replace `#include <limits.h>` with `#include <climits>`. Also applies to runtime.cpp line 37.
+
+### Medium item #4 : C header `<string.h>` used instead of C++ header `<cstring>`
+
+Location: src/tuning/tunable.cpp : 28 ; src/tuning/runtime.cpp : 30
+Description: Both files include `<string.h>` (C header) instead of `<cstring>` (C++ header). Additionally, given that these files use `std::string` throughout and do not appear to call any `string.h` functions, this include may be unnecessary entirely.
+Severity rationale: Same as Medium #3 — C-style headers in C++ code.
+Suggested fix: Replace `#include <string.h>` with `#include <cstring>` in both files, or remove if unused.
+
+### Medium item #5 : Raw owning pointers in `all_tunables` / `all_untunables` vectors
+
+Location: src/tuning/tunable.h : 89–90 ; src/tuning/runtime.cpp : 151–156, 169–171, 187–190
+Description: `all_tunables` and `all_untunables` hold `class tunable *` raw owning pointers. Objects allocated with `new` in `add_runtime_tunables()` are pushed into these vectors and are never deleted. This is a memory leak. The same pattern was noted for other vectors in batch 02.
+Severity rationale: Repeated memory allocation without deallocation; affects every device enumeration run. Using raw owning pointers is a C++ best-practice violation.
+Suggested fix: Change the vector types to `std::vector<std::unique_ptr<tunable>>` and update all push_back calls and consumers to use `std::move` / `.get()` as appropriate.
+
+### Medium item #6 : Block-device scan logic runs only once; devices associated with arbitrary PCI entry
+
+Location: src/tuning/runtime.cpp : 127, 173–192
+Description: The `count` variable (initialized to 0, set to 1 after the first outer-while iteration) causes the block-device `for (char blk...)` loop to execute only on the first PCI device encountered in the directory. Subsequent PCI device iterations skip it entirely. Furthermore, the `runtime_tunable` for each disk is constructed with `entry->d_name` (the current PCI device's name) as the `dev` argument, which is the PCI device at an arbitrary iteration order — not necessarily the one the disk is attached to. The `count` variable name gives no indication of its intended purpose.
+Severity rationale: Functional correctness issue and confusing code. Disk tunables may be silently skipped or associated with the wrong PCI device.
+Suggested fix: If the intent is to scan block devices only once (since their paths are global, not per-PCI-device), move the block-device loop outside the `while` directory-iteration loop entirely. Replace `count` with a clearly named boolean such as `bool block_devices_scanned = false`.
+
+### Medium item #7 : Unused includes in runtime.cpp
+
+Location: src/tuning/runtime.cpp : 32–33
+Description: `#include <utility>` and `#include <iostream>` are present but nothing from `<utility>` (e.g., `std::move`, `std::pair`) or `<iostream>` (`std::cout`, `std::cin`) appears to be used in the file.
+Severity rationale: Unused includes increase compile time and obscure actual dependencies.
+Suggested fix: Remove `#include <utility>` and `#include <iostream>` from runtime.cpp.
+
+## Review of ethernet.cpp, ethernet.h, wifi.cpp, wifi.h, tuningusb.h — batch 04
+
+### Medium item #1 : `#ifndef` include guard instead of `#pragma once` in ethernet.h
+
+Location: src/tuning/ethernet.h : 25–26
+Description: The header uses a traditional `#ifndef _INCLUDE_GUARD_ETHERNET_TUNE_H` / `#define` guard. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style guide violation; `#pragma once` is simpler and less error-prone.
+Suggested fix: Replace lines 25–27 and the closing `#endif` with `#pragma once`.
+
+### Medium item #2 : `#ifndef` include guard instead of `#pragma once` in wifi.h
+
+Location: src/tuning/wifi.h : 25–26
+Description: Same issue as Medium item #1 — `#ifndef _INCLUDE_GUARD_WIFI_TUNE_H` guard should be `#pragma once`.
+Severity rationale: Same as Medium item #1.
+Suggested fix: Replace with `#pragma once`.
+
+### Medium item #3 : `#ifndef` include guard instead of `#pragma once` in tuningusb.h
+
+Location: src/tuning/tuningusb.h : 25–26
+Description: Same issue — `#ifndef _INCLUDE_GUARD_USB_TUNE_H` guard should be `#pragma once`.
+Severity rationale: Same as Medium items #1 and #2.
+Suggested fix: Replace with `#pragma once`.
+
+### Medium item #4 : Duplicate and incorrectly-quoted `#include "unistd.h"` in wifi.cpp
+
+Location: src/tuning/wifi.cpp : 28 and 34
+Description: `unistd.h` is included twice: first as `#include "unistd.h"` (using quotes, which searches project-local directories first — incorrect for a system header), and again as the correct `#include <unistd.h>` (with angle brackets) at line 34. The first inclusion uses the wrong quoting style and is entirely redundant.
+Severity rationale: Wrong quoting for a system header (could accidentally pick up a local file shadowing unistd.h); duplicate include is dead code.
+Suggested fix: Remove the `#include "unistd.h"` at line 28 entirely; keep `#include <unistd.h>` at line 34.
+
+### Medium item #5 : Unchecked `ioctl` return values in `toggle()`
+
+Location: src/tuning/ethernet.cpp : 123 and 126
+Description: Both `ioctl(sock, SIOCETHTOOL, &ifr)` calls in `toggle()` — the ETHTOOL_GWOL read (line 123) and the ETHTOOL_SWOL write (line 126) — have their return values discarded. If ETHTOOL_GWOL fails, the subsequent ETHTOOL_SWOL write will use zeroed (unread) WoL data. If ETHTOOL_SWOL fails silently, the user receives no indication that the toggle had no effect.
+Severity rationale: Silent failure of a user-visible action (toggling WoL), and write based on potentially uninitialised data.
+Suggested fix: Check both return values; on failure for ETHTOOL_GWOL abort the toggle; log or surface ETHTOOL_SWOL failure.
+
+### Medium item #6 : readdir loop does not explicitly skip `.` and `..` entries
+
+Location: src/tuning/wifi.cpp : 86–95
+Description: The `readdir` loop in `add_wifi_tunables()` does not explicitly skip the "." and ".." directory entries. While the `strstr(entry->d_name, "wlan")` filter happens to exclude them (since "." and ".." do not contain "wlan"), the project rules (rules.md) require that all `opendir`/`readdir` code explicitly skip `.` and `..`. If the filter condition is ever relaxed or changed, the rule violation could become a real bug.
+Severity rationale: Explicit rule violation from rules.md; also fragile — depends on an incidental property of the filter rather than a deliberate guard.
+Suggested fix:
+```cpp
+if (entry->d_name[0] == '.')
+    continue;
+```
+
+## Review of tuningusb.cpp, tuning.cpp, tuning.h, bluetooth.cpp, bluetooth.h — batch 05
+
+### Medium item #1 : Dangling pointer comparison after `closedir()`
+
+Location: src/tuning/tuningusb.cpp : 112–125
+Description: The loop assigns `entry = readdir(dir)` on each iteration. When the loop exits via `break` (an interface without autosuspend support is found), `entry` holds a pointer into the DIR's internal buffer. `closedir(dir)` is then called on line 120, freeing that buffer. The comparison `if (entry)` on line 123 reads a dangling pointer. While comparing a dangling pointer to NULL is not a dereference and works in practice on Linux (the pointer value itself is still on the stack), it is undefined behaviour per the C++ standard and relies on the freed memory not having been immediately reused.
+Severity rationale: Undefined behaviour; correct only by coincidence on current Linux/glibc. A future allocator or sanitizer will flag this.
+Suggested fix: Use a boolean flag:
+```cpp
+bool has_non_autosuspend = false;
+while ((entry = readdir(dir))) {
+    if (!isdigit(entry->d_name[0]))
+        continue;
+    filename = std::format("...", d_name, entry->d_name);
+    if (access(filename.c_str(), R_OK) == 0 && read_sysfs(filename) == 0) {
+        has_non_autosuspend = true;
+        break;
+    }
+}
+closedir(dir);
+if (has_non_autosuspend)
+    return;
+```
+
+### Medium item #2 : `last_check_time` cache not updated on several error paths
+
+Location: src/tuning/bluetooth.cpp : 141–162
+Description: The 60-second cache for the expensive `popen` check is guarded by `if (time(NULL) - last_check_time > 60)`. Inside that block, `last_check_time = time(NULL)` is only reached if popen succeeds AND the first `fgets` succeeds AND the second `fgets` succeeds AND `strlen(line) == 0`. Every other path hits `goto out` without updating `last_check_time`. Consequently, if the first `fgets` returns NULL (empty file from hcitool), `popen` is called on every single invocation of `good_bad()` rather than being throttled to once per minute. This defeats the stated "this check is expensive" comment entirely.
+Severity rationale: Performance regression — an intentionally throttled system call is called at full rate on a common code path.
+Suggested fix: Update `last_check_time` at the top of the block, before the popen call, so that the 60-second window is always honoured regardless of outcome.
+
+### Medium item #3 : Fixed-size `char` buffer used for parsing popen output
+
+Location: src/tuning/bluetooth.cpp : 146–159
+Description: `char line[2048]` is used with `fgets(line, 2047, file)`. This is a C-idiom in C++ code. The size 2047 (instead of `sizeof(line)`) also means the buffer is read one byte short of its capacity without explanation. Beyond the style concern, a hypothetically long hcitool output line could be silently truncated, causing the `strlen(line) > 0` check to incorrectly conclude a connection exists.
+Severity rationale: Poor C++ practice; the buffer-size mismatch is an off-by-one that could produce incorrect results on long output lines.
+Suggested fix: Use `std::string line; std::getline(...)` after wrapping the FILE* in a `std::unique_ptr` or using `__gnu_cxx::stdio_filebuf`, or at minimum change `fgets(line, 2047, file)` to `fgets(line, sizeof(line), file)`.
+
+### Medium item #4 : Unsigned underflow when `all_tunables` is empty
+
+Location: src/tuning/tuning.cpp : 85
+Description: `w->cursor_max = all_tunables.size() - 1;` — `size()` returns `size_t` (unsigned). If `all_tunables` is empty (all tunable-detection functions found nothing), `0 - 1` wraps to `SIZE_MAX` (typically 2^64−1 on 64-bit). `cursor_max` is typed `int` in `tab_window`, so the assignment truncates, but the result is still a large positive number. The cursor can then be moved far beyond the end of the vector, causing undefined behaviour when `all_tunables[cursor_pos]` is later dereferenced.
+Severity rationale: Potential out-of-bounds vector access if the system has no tunables (e.g., in a restricted container environment).
+Suggested fix:
+```cpp
+w->cursor_max = all_tunables.empty() ? 0 : static_cast<int>(all_tunables.size()) - 1;
+```
+
+### Medium item #5 : Outdated `hci_usb` kernel module check
+
+Location: src/tuning/bluetooth.cpp : 128–130
+Description: The condition `access("/sys/module/hci_usb", F_OK)` checks for the `hci_usb` kernel module, which was replaced by `btusb` in Linux kernel 2.6.24 (circa 2008). On all modern kernels this path never exists, so `access()` always returns −1 (non-zero). The full guard `(devinfo.flags & 1) == 0 && access("/sys/module/hci_usb", F_OK)` therefore always evaluates to true when the interface is down, and `goto out` is taken, setting result to TUNE_GOOD. While this happens to be the correct result (BT down = power-efficient), the dead check makes the code misleading and could mask future logic errors.
+Severity rationale: Dead code that obscures the actual logic; the module it checks has not existed for 15+ years.
+Suggested fix: Remove the `access("/sys/module/hci_usb", F_OK)` part of the condition. If the intent is "interface is down → TUNE_GOOD", express it directly:
+```cpp
+if ((devinfo.flags & 1) == 0)  /* interface is down */
+    goto out;
+```
+
+### Medium item #6 : Use of `system()` for Bluetooth toggle
+
+Location: src/tuning/bluetooth.cpp : 180–185
+Description: `bt_tunable::toggle()` calls `system("/usr/sbin/hciconfig hci0 up &> /dev/null &")` and `system("/usr/sbin/hciconfig hci0 down &> /dev/null")` to toggle the interface. `system()` forks a shell, making the implementation dependent on `/bin/sh`, subject to environment variable manipulation, and unable to safely capture errors. The return value check only tests the shell's own exit code, not hciconfig's. Furthermore, hciconfig is deprecated (same issue as hcitool).
+Severity rationale: Use of deprecated tool; `system()` is considered poor practice for programmatic invocation of system commands.
+Suggested fix: Use the `HCIDEVDOWN`/`HCIDEVUP` ioctl directly on the already-opened socket, matching the pattern used in `good_bad()` and `add_bt_tunable()`.
+
+## Review of src/tuning/tuningsysfs.cpp, src/tuning/tuningsysfs.h, src/tuning/nl80211.h, src/tuning/iw.h, src/tuning/iw.c — batch 06
+
+### Medium item #1 : Non-thread-safe global variable enable_power_save
+
+Location: src/tuning/iw.c : 124
+Description: `static int enable_power_save;` is a file-scoped global that is written by `set_wifi_power_saving()` (before calling `__handle_cmd`) and by the netlink callback `print_power_save_handler`, and read by `set_power_save()` and `get_wifi_power_saving()`. Both public API functions are non-reentrant: if two threads (or two interfaces) invoke `get_wifi_power_saving` or `set_wifi_power_saving` concurrently, the results are unpredictable. Additionally, `get_wifi_power_saving` returns `1` on both an nl80211 init error *and* on a genuine "power saving enabled" state, making callers unable to distinguish the two outcomes.
+Severity rationale: Non-reentrant API using shared global state; incorrect result when called concurrently or when initialisation fails.
+Suggested fix: Pass the power-save state as an output parameter (or return value), eliminating the global. For the ambiguous-return issue, return a tri-state (`-1` = error, `0` = disabled, `1` = enabled).
+
+### Medium item #2 : User-visible error strings not wrapped in _() for i18n
+
+Location: src/tuning/iw.c : 86, 91, 97, 215, 221, 262
+Description: Six `fprintf(stderr, ...)` error messages are not wrapped in the gettext `_()` macro, making them untranslatable. Per `rules.md` and `style.md`, all user-visible strings must use `_()`. Affected strings include "Failed to allocate netlink socket.\n", "Failed to connect to generic netlink.\n", "Failed to allocate generic netlink cache.\n", "failed to allocate netlink message\n", "failed to allocate netlink callbacks\n", and "building message failed\n".
+Severity rationale: i18n rule violation; error messages presented to users are not translatable.
+Suggested fix: Wrap each string: `fprintf(stderr, _("Failed to allocate netlink socket.\n"));` etc.
+
+### Medium item #3 : `string` used without std:: prefix in tuningsysfs.cpp constructor
+
+Location: src/tuning/tuningsysfs.cpp : 39
+Description: The constructor signature uses the bare name `string` three times: `sysfs_tunable::sysfs_tunable(const string &str, const string &_sysfs_path, const string &target_content)`. This compiles only because `tuningsysfs.h` (included earlier) contains the banned `using namespace std;`. Per `style.md` and `general-c++.md`, `std::string` must always be used with its fully qualified name.
+Severity rationale: Relies on the `using namespace std` that is itself a rule violation; will break if the namespace pollution is removed.
+Suggested fix: Replace all three occurrences of `string` with `std::string` in the constructor signature.
+
+### Medium item #4 : Non-portable kernel header <asm/errno.h> included in userspace code
+
+Location: src/tuning/iw.c : 49
+Description: `#include <asm/errno.h>` pulls in an architecture-specific kernel header. Userspace code should use `<errno.h>` (already included at line 32) to access `errno` and the `E*` constants. The kernel `<asm/errno.h>` is not guaranteed to be available or consistent across all build environments and toolchain configurations.
+Severity rationale: Non-portable include; `<errno.h>` already provides everything needed.
+Suggested fix: Remove line 49 (`#include <asm/errno.h>`); `<errno.h>` on line 32 already provides all needed error constants.
+
+### Medium item #5 : Non-idiomatic empty-check: length() > 0 instead of !empty()
+
+Location: src/tuning/tuningsysfs.cpp : 67
+Description: `if (bad_value.length() > 0)` tests whether a `std::string` is non-empty by comparing its length to zero. The idiomatic C++ way is `if (!bad_value.empty())`. The `empty()` call is O(1)-guaranteed by the standard (whereas `length()` is also O(1) in practice for `std::string` but `empty()` expresses intent more clearly) and is the canonical form preferred by `general-c++.md` which says "Strongly prefer STL constructs".
+Severity rationale: Non-idiomatic use of std::string API; minor correctness gap.
+Suggested fix: `if (!bad_value.empty())`
+
+## Review of tuningi2c.h, tuningi2c.cpp, powerconsumer.h, powerconsumer.cpp, processdevice.h — batch 07
+
+### Medium item #1 : `using namespace std;` in tuningi2c.h
+
+Location: src/tuning/tuningi2c.h : 28
+Description: `using namespace std;` appears at file scope in a header. This injects the entire `std` namespace into every translation unit that includes this header, causing silent name collisions and making it impossible for includers to opt out.
+Severity rationale: Per style.md §4.2 this is explicitly forbidden in headers; it pollutes the namespace of all downstream TUs.
+Suggested fix: Remove the `using namespace std;` line. Replace any bare `string`, `vector`, etc. in the header with their fully-qualified `std::string`, `std::vector` equivalents.
+
+### Medium item #2 : `using namespace std;` in powerconsumer.h
+
+Location: src/process/powerconsumer.h : 33
+Description: Same problem as Medium item #1 above — `using namespace std;` at file scope in a header, polluting all includers.
+Severity rationale: Same as item #1.
+Suggested fix: Remove the `using namespace std;` line and qualify all standard-library names with `std::`.
+
+### Medium item #3 : Unqualified `vector` in `all_power` declaration
+
+Location: src/process/powerconsumer.h : 72
+Description: `extern vector <class power_consumer *> all_power;` uses the bare unqualified `vector` name, which only works because of the `using namespace std;` on line 33.  When that `using` is removed (as it should be), this declaration will fail to compile.
+Severity rationale: Directly coupled to the `using namespace std` violation; would become a compile error on cleanup.
+Suggested fix: `extern std::vector<class power_consumer *> all_power;`
+
+### Medium item #4 : Unqualified `vector` in `all_proc_devices` declaration
+
+Location: src/process/processdevice.h : 50
+Description: `extern vector<class device_consumer *> all_proc_devices;` similarly relies on the inherited `using namespace std;` from `powerconsumer.h`.
+Severity rationale: Same as item #3.
+Suggested fix: `extern std::vector<class device_consumer *> all_proc_devices;`
+
+### Medium item #5 : Non-translatable `"abstract"` strings in `name()` and `type()`
+
+Location: src/process/powerconsumer.h : 60, 61
+Description: The default implementations of `name()` and `type()` return bare string literals `"abstract"` without wrapping them in `_()`. If these base-class defaults are ever displayed to the user (e.g. as a fallback when a subclass doesn't override), the strings will be untranslatable.
+Severity rationale: Per rules.md, all user-visible strings must use the `_()` gettext pattern.
+Suggested fix: Return `_("abstract")` from both methods, or return an empty string if they are truly meant to be abstract placeholders that should never reach the UI.
+
+### Medium item #6 : Non-translatable `"Device"` string in `type()`
+
+Location: src/process/processdevice.h : 42
+Description: `virtual std::string type(void) { return "Device"; }` returns a bare untranslated string literal.
+Severity rationale: Per rules.md, all user-visible strings must use `_()`.
+Suggested fix: `return _("Device");`
+
+### Medium item #7 : Non-translatable unit strings in `usage_units()`
+
+Location: src/process/powerconsumer.cpp : 95, 97, 99
+Description: `" µs/s"`, `" us/s"`, and `" ms/s"` are returned as plain string literals. These unit strings are displayed in the PowerTOP UI and are not wrapped in `_()`, making them untranslatable.
+Severity rationale: Per rules.md, all user-visible strings must use `_()`.
+Suggested fix: Wrap each string in `_()`, e.g. `return _(" ms/s");`.
+
+### Medium item #8 : Unqualified `string` in constructor definition
+
+Location: src/tuning/tuningi2c.cpp : 35
+Description: The constructor definition `i2c_tunable::i2c_tunable(const string &path, const string &name, ...)` uses the unqualified `string` type, relying on the `using namespace std;` injected by included headers. This makes the code fragile and non-portable.
+Severity rationale: Violates style.md §4.2 (always use `std::` prefix); directly depends on the namespace pollution from the header.
+Suggested fix: Change to `const std::string &path, const std::string &name`.
+
+## Review of processdevice.cpp, process.h, process.cpp, work.cpp, work.h — batch 08
+
+### Medium item #1 : Debug printf left in production code, unlocalized, wrong output stream
+
+Location: src/process/process.cpp : 66-67
+Description: `printf("%llu time    %llu since \n", ...)` is a diagnostic trace that was never removed. It writes to stdout (not stderr), uses a non-localized format string, and fires on every measurement interval where an out-of-order timestamp is detected. The double-space in the format string also suggests it is unfinished debug output.
+Severity rationale: Any user-visible diagnostic string must use `_()` per rules.md; stdout is the wrong stream for error messages; leftover debug output is confusing and noisy in production.
+Suggested fix: Remove the printf entirely, or replace with `fprintf(stderr, _("..."), ...)` if the diagnostic is intentional, after first fixing the ordering bug (High item #1).
+
+### Medium item #2 : Explicit `using namespace std;` in work.cpp
+
+Location: src/process/work.cpp : 36
+Description: `using namespace std;` is explicitly declared at file scope. This is prohibited by style.md ("Avoid `using namespace std;`") and general-c++.md ("`using namespace std;` is a deprecated construct").
+Severity rationale: Direct violation of the project's stated coding rules; also masks which names come from `std::` versus the project.
+Suggested fix: Remove the `using namespace std;` line and qualify all standard library names with `std::` (e.g., `std::map`, `std::pair`, `std::for_each`).
+
+### Medium item #3 : `NULL` instead of `nullptr` in C++ code
+
+Location: src/process/process.cpp : 89-90
+Description: `last_waker = NULL;` and `waker = NULL;` use the C macro `NULL` instead of the C++ keyword `nullptr`. In C++11 and later (this project targets C++20), `nullptr` is the correct null-pointer constant.
+Severity rationale: Minor correctness issue — `NULL` is typically defined as `0` or `(void*)0`, both of which can cause subtle type issues. C++20 code should use `nullptr`.
+Suggested fix: Replace both with `nullptr`.
+
+### Medium item #4 : Narrowing conversion from `unsigned long long` to `int` for tgid
+
+Location: src/process/process.cpp : 104
+Description: `tgid = std::stoull(line.substr(pos + 1));` assigns an `unsigned long long` result to the `int` field `tgid`. On systems where PIDs approach `INT_MAX` (or if the file contains an unexpected large value) this silently truncates or produces undefined behavior prior to C++20 (implementation-defined in C++20).
+Severity rationale: Narrowing implicit conversion; `std::stoi` or a range-checked conversion is more appropriate. Medium because large PIDs are rare in practice but the root cause is incorrect.
+Suggested fix: Use `std::stoi` (which already returns `int`) and wrap in the existing try/catch:
+```cpp
+tgid = std::stoi(line.substr(pos + 1));
+```
+
+### Medium item #5 : `#ifndef` header guard instead of `#pragma once` in process.h
+
+Location: src/process/process.h : 25-27
+Description: The file uses a traditional `#ifndef _INCLUDE_GUARD_PROCESS_H` / `#define` guard. style.md §4.1 mandates `#pragma once`.
+Severity rationale: Direct violation of the project style guide.
+Suggested fix: Replace lines 25–27 and line 95 (`#endif`) approach with `#pragma once` at the top of the file.
+
+### Medium item #6 : `#ifndef` header guard instead of `#pragma once` in work.h
+
+Location: src/process/work.h : 25-27
+Description: Same as Medium item #5 — `#ifndef _INCLUDE_GUARD_WORK_H` guard instead of `#pragma once`.
+Severity rationale: Direct violation of the project style guide.
+Suggested fix: Replace with `#pragma once`.
+
+### Medium item #7 : User-facing description strings not wrapped in `_()` for i18n
+
+Location: src/process/process.cpp : 116, 122, 125
+Description: The three `std::format` calls that compose the process description strings (`"[PID {}] {}"`, `"[PID {}] [{}]"`) produce user-visible output but are not wrapped with `_()` / `pt_format(_(...), ...)`. rules.md requires all user-visible strings to be translatable.
+Severity rationale: Internationalization regression; any non-English-speaking user will see English-only process descriptions.
+Suggested fix: Change to `pt_format(_("[PID {}] {}"), pid, comm)` etc., using the `pt_format` helper required by style.md §4.3.
+
+### Medium item #8 : Unqualified `vector` in header process.h
+
+Location: src/process/process.h : 71
+Description: `extern vector <class process *> all_processes;` uses `vector` without the `std::` prefix. This compiles only because `powerconsumer.h` pollutes the global namespace via `using namespace std;`, but the declaration itself should be `std::vector`.
+Severity rationale: Header files should never rely on namespace pollution from transitively-included headers; this makes the declaration fragile and violates style.md §4.2.
+Suggested fix: Change to `extern std::vector<class process *> all_processes;`.
+
+## Review of interrupt.h, interrupt.cpp, timer.cpp, timer.h, do_process.cpp — batch 09
+
+### Medium item #1 : Header guards use #ifndef instead of #pragma once
+
+Location: src/process/interrupt.h : 25  /  src/process/timer.h : 25
+Description: Both headers use the old-style `#ifndef _INCLUDE_GUARD_XXX` / `#define` / `#endif` header guards. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style violation; inconsistent with the rest of the codebase.
+Suggested fix: Replace with `#pragma once` and remove the `#ifndef`/`#define`/`#endif` triplet.
+
+### Medium item #2 : Unqualified vector in interrupt.h extern declarations
+
+Location: src/process/interrupt.h : 54
+Description: The two `extern` declarations use unqualified `vector` instead of `std::vector`. They compile only because `powerconsumer.h` (transitively included) contains `using namespace std;`. The style guide forbids relying on implicit namespace injection.
+Severity rationale: Violates `std::` qualification rule; fragile — any reordering of includes could break compilation.
+Suggested fix: Change to `extern std::vector<class interrupt *> all_interrupts;` and `extern const std::vector<std::string> softirqs;`.
+
+### Medium item #3 : string::npos used without std:: prefix
+
+Location: src/process/do_process.cpp : 382
+Description: `string::npos` is written without the `std::` prefix. It resolves today only via the transitive `using namespace std;` from `powerconsumer.h`. This is a style violation per both style.md §4.2 and general-c++.md.
+Severity rationale: Style violation; implicit namespace injection should not be relied upon.
+Suggested fix: Change to `std::string::npos`.
+
+### Medium item #4 : timer_list class in timer.h appears to be dead/unused code
+
+Location: src/process/timer.h : 53
+Description: `class timer_list` with members `timer_address` and `timer_func` is declared but never referenced in the codebase. Shipping dead class definitions increases maintenance burden and may confuse readers.
+Severity rationale: Dead code; no functional impact but adds noise.
+Suggested fix: Remove `class timer_list` unless it is intentionally reserved for future use, in which case add a comment.
+
+### Medium item #5 : Type mismatch — find_create_timer(uint64_t) vs map<unsigned long, ...>
+
+Location: src/process/timer.cpp : 71
+Description: `all_timers` is declared `map<unsigned long, class timer *>` but `find_create_timer` accepts a `uint64_t` argument and the `timer` constructor takes `unsigned long`. On a 32-bit Linux kernel (where `unsigned long` is 32 bits), passing a 64-bit kernel function address silently truncates it, producing wrong lookups and spurious duplicate timers.
+Severity rationale: Incorrect behaviour on 32-bit systems; type mismatch is a latent bug.
+Suggested fix: Change `all_timers` to `std::map<uint64_t, class timer *>` and the constructor argument to `uint64_t`.
+
+### Medium item #6 : stderr diagnostic messages not wrapped in _()
+
+Location: src/process/do_process.cpp : 408, 445, 457
+Description: Three `fprintf(stderr, ...)` calls emit literal English strings without the `_()` gettext macro. The project rules (rules.md) require all user-visible strings to be translatable. While these are diagnostic/debug messages, they can appear on user terminals and should be translatable.
+Severity rationale: i18n policy violation.
+Suggested fix: Wrap each string in `_()`.
+
+### Medium item #7 : usage_units_summary returns "%" literal not wrapped in _()
+
+Location: src/process/interrupt.cpp : 89  /  src/process/timer.cpp : 107
+Description: Both `usage_units_summary()` implementations return the literal `"%"` without wrapping in `_()`. This string is user-visible (it appears in the overview display and reports). Even if `%` itself needs no translation, the method's contract is to return a units string, and as a pattern this sets a bad precedent for strings that do need translation.
+Severity rationale: i18n policy violation (rules.md).
+Suggested fix: Return `_("%")` or, if the percent sign is definitively not localised, document that explicitly.
+
+### Medium item #8 : Summary wprintw uses fragmented translated strings — untranslatable as a sentence
+
+Location: src/process/do_process.cpp : 846
+Description: The summary display line is built with multiple independent `_()` fragments embedded in a single C format string:
+```cpp
+wprintw(win, "%s: %3.1f %s,  %3.1f %s, %3.1f %s %3.1f%% %s\n\n",
+    _("Summary"), total_wakeups(), _("wakeups/second"), ...);
+```
+The structural word ordering is fixed by the C format string and cannot be changed by translators. Different languages require different word orders. This pattern makes a correct translation impossible.
+Severity rationale: Fundamental i18n correctness issue; directly affects all non-English users.
+Suggested fix: Combine into a single complete translatable sentence using `pt_format` with named arguments, or use a single `_()` string that contains all the labels and format specifiers.
+
+## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
+
+### Medium item #1 : `using namespace std;` in header perf.h
+
+Location: src/perf/perf.h : 37
+Description: `using namespace std;` is used in a header file. This pollutes the global namespace for every translation unit that includes this header, directly or transitively. The style guide and general-c++ rules both explicitly prohibit this. All standard-library names should be qualified with `std::`.
+Severity rationale: A `using namespace std;` in a header is a project-wide namespace pollution violation. Any identifier in `std::` can silently shadow or conflict with user identifiers in any file that includes this header.
+Suggested fix: Remove `using namespace std;` and use `std::string`, `std::vector`, etc. explicitly.
+
+### Medium item #2 : `using namespace std;` in header perf_bundle.h
+
+Location: src/perf/perf_bundle.h : 32
+Description: Same issue as Medium item #1 above. `using namespace std;` is used in a header file, polluting the namespace for all includers.
+Severity rationale: Same as above.
+Suggested fix: Remove `using namespace std;` and qualify `vector` and `map` usages with `std::`.
+
+### Medium item #3 : Non-translatable kernel configuration strings printed to stderr
+
+Location: src/perf/perf.cpp : 105
+Description: The string `"CONFIG_PERF_EVENTS=y\nCONFIG_PERF_COUNTERS=y\nCONFIG_TRACEPOINTS=y\nCONFIG_TRACING=y\n"` is a user-visible message printed to stderr but is not wrapped in `_()`. All user-visible strings must be translatable per the project rules.
+Severity rationale: User-facing strings not wrapped in `_()` will never be translated.
+Suggested fix: Wrap in `_()` or split into separate `fprintf` calls each wrapped in `_()`.
+
+### Medium item #4 : Non-translatable mmap failure message
+
+Location: src/perf/perf.cpp : 120
+Description: `fprintf(stderr, "failed to mmap with %d (%s)\n", ...)` — user-visible string not wrapped in `_()`.
+Severity rationale: Same as Medium item #3.
+Suggested fix: `fprintf(stderr, _("failed to mmap perf buffer: %d (%s)\n"), errno, strerror(errno));`
+
+### Medium item #5 : Non-translatable perf enable failure message
+
+Location: src/perf/perf.cpp : 127
+Description: `fprintf(stderr, "failed to enable perf \n");` — user-visible string not wrapped in `_()`.
+Severity rationale: Same as Medium item #3.
+Suggested fix: `fprintf(stderr, _("failed to enable perf\n"));`
+
+### Medium item #6 : Error output via `cout` instead of `stderr`, non-translatable
+
+Location: src/perf/perf.cpp : 221
+Description: `cout << "stop failing\n";` sends an error message to stdout rather than stderr, and the string is not wrapped in `_()` for translation. The project style guide requires `fprintf(stderr, ...)` for error reporting.
+Severity rationale: Error messages on stdout can be lost in automated pipelines; the string is also not translatable.
+Suggested fix: `fprintf(stderr, _("perf stop failed\n"));`
+
+### Medium item #7 : Non-translatable `printf` error in `handle_trace_point`
+
+Location: src/perf/perf_bundle.cpp : 282
+Description: `printf("UH OH... abstract handle_trace_point called\n")` is a user-visible diagnostic message that is not wrapped in `_()`, and uses `printf` instead of `fprintf(stderr, ...)`.
+Severity rationale: User-visible string not wrapped in `_()` will never be translated; sending to stdout also violates the error-reporting style.
+Suggested fix: `fprintf(stderr, _("abstract handle_trace_point called\n"));`
+
+### Medium item #8 : `perf_event::stop()` calls `ioctl` on potentially invalid file descriptor
+
+Location: src/perf/perf.cpp : 218
+Description: `stop()` unconditionally calls `ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0)` without first checking whether `perf_fd` is valid (>= 0). If an event was never started (or mmap failed leaving the fd valid but unusable), this can produce unexpected ioctl errors or act on an unintended fd.
+Severity rationale: Calling ioctl on fd -1 is safe (returns EBADF) but calling it on a leaked/stale fd could affect unrelated resources.
+Suggested fix:
+```cpp
+void perf_event::stop(void)
+{
+    if (perf_fd < 0)
+        return;
+    int ret = ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0);
+    if (ret)
+        fprintf(stderr, _("perf stop failed\n"));
+}
+```
+
+### Medium item #9 : `trace_type` is `unsigned int` but is assigned `-1` as a sentinel value
+
+Location: src/perf/perf.h : 54, src/perf/perf.cpp : 159, src/perf/perf_bundle.cpp : 112
+Description: `trace_type` is declared as `unsigned int` but `set_event_name` assigns `trace_type = -1` (which wraps to `UINT_MAX`), and `perf_bundle::add_event` then checks `(int)ev->trace_type >= 0` to detect this. This is a confusing misuse of an unsigned type as a signed sentinel, relying on implementation-defined signed/unsigned cast behavior.
+Severity rationale: The pattern is error-prone and reliant on cast behavior. Using `int` or an explicit `bool valid` flag would be clearer and correct.
+Suggested fix: Change `trace_type` to `int` (signed), or add a separate `bool valid` flag, and remove the cast in the add_event check.
+
+## Review of persistent.cpp, parameters.cpp, parameters.h, learn.cpp, report-formatter.h — batch 11
+
+### Medium item #1 : False null-check after `new` in `clone_results` and `clone_parameters`
+
+Location: src/parameters/parameters.cpp : 297 ; src/parameters/parameters.cpp : 318
+Description: Both `clone_results` and `clone_parameters` allocate with `new` and then check `if (!b2) return NULL;`. In standard C++, `new` either succeeds or throws `std::bad_alloc`; it never returns a null pointer. The null check therefore never triggers, giving the reader a false sense of safety. If `bad_alloc` is thrown the callers do not handle it, and the function's declared contract (returning nullptr on failure) is not fulfilled. Callers that do check the return value for null will not be protected from an allocation failure.
+Severity rationale: The guard is misleading and never executes, making it a latent correctness issue.
+Suggested fix: Either remove the null checks and let `std::bad_alloc` propagate, or use `new (std::nothrow)` and keep the null-check if null-return semantics are actually required by callers.
+
+### Medium item #2 : `get_param_directory` returns an empty string when no writable directory exists
+
+Location: src/parameters/parameters.cpp : 459
+Description: `get_param_directory` checks two candidate directories and returns `tempfilename`. If neither `/var/cache/powertop` nor `/data/local/powertop` is writable, `tempfilename` is never set and the function returns an empty string. Every caller (`save_parameters`, `load_parameters`, `save_all_results`, `load_results`) then attempts to open a file whose name is `""`, which will fail silently with a confusing empty-pathname error message. There is no fallback (e.g. the current directory or a user home-directory path).
+Severity rationale: Silent data loss / confusing errors in a common deployment scenario (e.g. container, read-only /var).
+Suggested fix: Return an error indicator or fall back to a default path, and have callers check for an empty return value explicitly.
+
+### Medium item #3 : User-facing string in `global_power_valid` not wrapped in `_()`
+
+Location: src/parameters/parameters.cpp : 450
+Description: The `printf` call `printf("To show power estimates do %ld measurement(s) connected to battery only\n", …)` is not wrapped in the `_()` gettext macro. This string is displayed directly to the user but will not be translated. All user-visible strings must use `_()` per rules.md and style.md.
+Severity rationale: Breaks internationalisation; message is never translated.
+Suggested fix: Change to `printf(_("To show power estimates do %ld measurement(s) connected to battery only\n"), …);`
+
+### Medium item #4 : Error/informational messages written to `cout` (stdout) instead of `stderr`
+
+Location: src/parameters/persistent.cpp : 47, 89, 183, 184
+Description: Four diagnostic messages use `cout <<` which writes to stdout. Per style.md ("Use `fprintf(stderr, ...)` for error reporting"), error and warning messages should go to stderr. Writing errors to stdout mixes them with program output and breaks piping / scripting.
+Severity rationale: Incorrect output stream for error messages; violates project style.
+Suggested fix: Replace `cout << _("…") << …` with `fprintf(stderr, "%s %s\n", _("…"), pathname.c_str());` (or equivalent).
+
+### Medium item #5 : `#include "string.h"` uses quotes and a C header in parameters.h
+
+Location: src/parameters/parameters.h : 33
+Description: The inclusion `#include "string.h"` uses double-quotes instead of angle-brackets for a system header, which causes the compiler to search the project include path first. Additionally, `string.h` is the C header; the C++ equivalent is `<cstring>`. In a C++20 project the C header should not be used directly.
+Severity rationale: Wrong include style for a system header and wrong header choice for C++.
+Suggested fix: Replace with `#include <cstring>` (angle brackets, C++ header) — or remove entirely if not needed.
+
+### Medium item #6 : Final `result_bundle` allocated in `load_results` is always leaked
+
+Location: src/parameters/persistent.cpp : 121
+Description: After the last `:` separator line is processed, the code allocates a new `result_bundle` (`bundle = new struct result_bundle;`) in preparation for the next record. If no further records follow (end of file), `bundle_saved` remains `1` from the previous record, so the `if (bundle_saved == 0) delete bundle;` guard at line 139 does NOT delete this final empty allocation. One empty `result_bundle` is leaked on every successful `load_results` call that processes at least one record.
+Severity rationale: Memory leak on every load of a non-empty results file.
+Suggested fix: After the loop, unconditionally `delete bundle;` (the empty partially-filled bundle should never be kept):
+```cpp
+delete bundle;   // always discard the last-allocated but unsaved bundle
+if (bundle_saved == 0)
+    return;      // or keep existing logging
+```
+
+## Review of report-formatter-html.h, report.cpp, report.h, report-formatter-csv.h, report-maker.cpp — batch 12
+
+### Medium item #1 : `using namespace std` in implementation file
+
+Location: report.cpp : 43
+Description: `using namespace std;` appears at file scope in the implementation file. While less harmful than in a header, the coding guidelines label this a deprecated construct and the style guide prohibits it. All standard-library names should be qualified with `std::`.
+Severity rationale: Explicit style violation; introduces risk of silent name collisions.
+Suggested fix: Remove the `using namespace std;` line and add `std::` prefixes throughout the file.
+
+### Medium item #2 : Old-style `#ifndef` include guards instead of `#pragma once`
+
+Location: report.h : 26, report-formatter-html.h : 27, report-formatter-csv.h : 26
+Description: All three headers use the legacy `#ifndef / #define / #endif` triple instead of `#pragma once` as required by the style guide (§4.1).
+Severity rationale: Style-guide violation; `#pragma once` is simpler, less error-prone, and universally supported.
+Suggested fix: Replace the guard triple in each header with a single `#pragma once`.
+
+### Medium item #3 : Fixed-size `char buf[128]` for `strftime` output
+
+Location: report.cpp : 104
+Description: `get_time_string` uses a 128-byte stack buffer for the `strftime` result. With certain locales and format strings (especially `%c`) the formatted date/time can exceed 127 characters. If it does, `strftime` returns 0 and the function returns an empty string silently rather than producing a truncated or complete result. Per the C++ guidelines, fixed-size buffer usage "must be provably correct to not overflow".
+Severity rationale: Not provably safe; an unusually verbose locale `%c` format could produce an empty field in the report without any diagnostic.
+Suggested fix: Use a `std::string` with a `strftime`-in-a-loop pattern or a sufficiently large initial estimate:
+```cpp
+static std::string get_time_string(const std::string &fmt, time_t t)
+{
+    struct tm *tm_info = localtime(&t);
+    if (!tm_info) return "";
+    std::string buf(256, '\0');
+    size_t n = strftime(buf.data(), buf.size(), fmt.c_str(), tm_info);
+    buf.resize(n);
+    return buf;
+}
+```
+
+### Medium item #4 : `private:` access specifier on the same line as a method declaration
+
+Location: report-formatter-html.h : 63, report-formatter-csv.h : 65
+Description: In both headers the `private:` label is appended to the end of the last `public` method declaration on the same source line, e.g. `void add_table(...);private:`. This is a formatting error: access specifiers must appear on their own line, consistent with the K&R/Linux-kernel brace style used throughout the project.
+Severity rationale: Style violation; degrades readability and makes the visibility boundary easy to miss in diffs.
+Suggested fix: Place `private:` on a new line after the semicolon.
+
+### Medium item #5 : Unqualified `string` (and `vector`) in report-maker.cpp
+
+Location: report-maker.cpp : 114, 140
+Description: `report-maker.cpp` does not declare `using namespace std` itself; the identifier `string` resolves only because `report-formatter-csv.h` (included earlier) leaks `using namespace std` into the translation unit. The style guide mandates `std::string` everywhere. The same applies to `vector` in signatures that take `const vector<std::string> &`.
+Severity rationale: Style violation that silently depends on an indirect `using` from a header; will break if that header is ever cleaned up.
+Suggested fix: Replace `const string &` and `const vector<...> &` with `const std::string &` and `const std::vector<...> &` throughout report-maker.cpp.
+
+## Review of report-maker.h, report-data-html.cpp, report-data-html.h, report-formatter-base.cpp, report-formatter-base.h — batch 13
+
+### Medium item #1 : Uninitialized `title_mod` field in `init_tune_table_attr`
+
+Location: src/report/report-data-html.cpp : 96–104
+Description: `init_tune_table_attr` sets all fields of `table_attributes` except `title_mod`, which is left at whatever value is in the caller's struct. Every other `init_*_table_attr` function explicitly sets `title_mod = 0`. If the struct is used after partial re-initialisation (i.e. was previously used for a TC/TLC table), `title_mod` will hold a stale non-zero value and may produce incorrect column-span or title-positioning output.
+Severity rationale: Uninitialized field that can silently corrupt table rendering.
+Suggested fix: Add `table_css->title_mod = 0;` before the `rows`/`cols` assignments.
+
+### Medium item #2 : Uninitialized `title_mod` field in `init_wakeup_table_attr`
+
+Location: src/report/report-data-html.cpp : 106–114
+Description: Same issue as Medium item #1 — `title_mod` is not initialized. All other table-attribute initializer functions set this field.
+Severity rationale: Same as Medium item #1.
+Suggested fix: Add `table_css->title_mod = 0;` to `init_wakeup_table_attr`.
+
+### Medium item #3 : Missing copyright/license header
+
+Location: src/report/report-data-html.h : 1  and  src/report/report-data-html.cpp : 1
+Description: Neither file contains the standard project copyright and GPL-2 license header required by style.md §3.1. All other files in the `src/report/` directory carry the header.
+Severity rationale: License compliance; all project files are required to carry the copyright notice.
+Suggested fix: Add the standard Samsung/PowerTOP copyright header to both files.
+
+### Medium item #4 : `get_type()` is not `const`
+
+Location: src/report/report-maker.h : 112
+Description: `get_type()` is a pure accessor — it returns the private `type` field without modifying the object. It is not declared `const`, preventing its use on `const report_maker` references and violating the general C++ rule "use `const` when possible".
+Severity rationale: Const-correctness violation; the accessor is callable in contexts where a const reference would be appropriate.
+Suggested fix: `report_type get_type() const;`
+
+### Medium item #5 : Non-`const` pointer parameters for read-only struct access in `report_maker`
+
+Location: src/report/report-maker.h : 125, 127, 130
+Description: `add_div(struct tag_attr *div_attr)`, `add_title(struct tag_attr *att_title, ...)`, and `add_table(..., struct table_attributes *tb_attr)` all take non-const pointers even though the functions only read the pointed-to data. This prevents passing pointers to `const`-qualified structs and falsely implies mutation.
+Severity rationale: Const-correctness rule violation; callers with `const`-qualified objects cannot call these methods.
+Suggested fix: Change all three parameter types to `const struct tag_attr *` / `const struct table_attributes *`.
+
+### Medium item #6 : `#ifndef` header guards use reserved identifiers; should use `#pragma once`
+
+Location: src/report/report-maker.h : 26–27  and  src/report/report-formatter-base.h : 26–27
+Description: Both files use `#ifndef _REPORT_MAKER_H_` / `#ifndef _REPORT_FORMATTER_BASE_H_`. Identifiers beginning with an underscore followed by an uppercase letter are reserved to the implementation in C++ (per \[lex.name\]), making these macro names technically undefined behaviour. The project style guide (style.md §4.1) mandates `#pragma once` instead.
+Severity rationale: Style guide violation; also uses reserved identifiers.
+Suggested fix: Replace both `#ifndef`/`#define`/`#endif` guard triples with `#pragma once`.
+
+### Medium item #7 : Virtual overrides in `report_formatter_string_base` lack `override` specifier
+
+Location: src/report/report-formatter-base.h : 34–38
+Description: `get_result()`, `clear_result()`, and `add()` are declared `virtual` in `report_formatter` and overridden in `report_formatter_string_base`, but none carry the `override` keyword. Without `override`, a signature mismatch (e.g., from a future base-class refactor) silently creates a new virtual function rather than overriding the intended one.
+Severity rationale: C++11 best practice; omitting `override` undermines static verification of virtual dispatch.
+Suggested fix: Replace each `virtual Ret method(...)` with `Ret method(...) override` (drop the `virtual` keyword in the derived class).
+
+## Review of report-formatter-csv.cpp, report-formatter-html.cpp, dram_rapl_device.cpp, dram_rapl_device.h, cpu_linux.cpp — batch 14
+
+### Medium item #1 : HTML table/title/summary data inserted without escaping
+
+Location: src/report/report-formatter-html.cpp : 305, 319-320, 351-369
+Description: `add_title()`, `add_summary_list()`, and `add_table()` all insert dynamic data (device names, power values, system strings) directly into the HTML output via `add_exact()`, which does **not** call `escape_string()`. The class defines a proper `escape_string()` that handles `<`, `>`, and `&` — but it is only invoked through the base class `add()` method, which none of these formatting methods use. If any device name or power label contains `<`, `>`, or `&` characters, the output HTML will be malformed or contain injected markup.
+Severity rationale: Output HTML corruption for any system with device names containing special characters. The class has the right tool (`escape_string`) but consistently fails to use it for dynamic content.
+Suggested fix: Replace direct use of `add_exact(std::format(..., data))` with `add_exact(std::format(..., escape_string(data)))` for all dynamic data fields in these methods.
+
+### Medium item #2 : `using namespace std` in a header file
+
+Location: src/cpu/dram_rapl_device.h : 31
+Description: `using namespace std;` appears at file scope in the header `dram_rapl_device.h`. This is explicitly prohibited by the style guide ("Avoid `using namespace std;`") and the C++ rules ("'using namespace std;' is a deprecated construct"). Placing it in a header silently forces the `std` namespace on every translation unit that includes this header, potentially causing name collisions in code that has no relation to this class.
+Severity rationale: Header-file namespace pollution affects all includers in the entire project, not just this file.
+Suggested fix: Remove `using namespace std;` and use `std::string`, `std::vector` etc. explicitly throughout the header.
+
+### Medium item #3 : `parse_cstates_start` / `parse_cstates_end` do not explicitly skip `.` and `..` entries
+
+Location: src/cpu/cpu_linux.cpp : 64, 143
+Description: Both `parse_cstates_start` and `parse_cstates_end` use `if (strlen(entry->d_name) < 3) continue;` as an implicit way to skip `.` and `..`. The PowerTOP-specific rules explicitly require: "When using opendir/readdir or equivalent, the code must skip the '.' and '..' entries in the directory and not process them as normal." The current check only works incidentally because both `.` and `..` happen to have lengths less than 3; it is not a deliberate skip, and the intent is not clear to a reader. A future refactor of the minimum-length check could inadvertently re-expose `.`/`..` processing.
+Severity rationale: Violates an explicit project rule. The implicit skip is fragile and unclear.
+Suggested fix: Add an explicit check before or instead of the length check:
+```cpp
+if (entry->d_name[0] == '.')
+    continue;
+```
+
+### Medium item #4 : `add_quotes()` declared but never defined
+
+Location: src/report/report-formatter-csv.h : 66
+Description: `add_quotes()` is declared as a private member of `report_formatter_csv` but has no definition anywhere in the codebase. It is also never called. This represents dead/incomplete code: the method cannot be linked if ever called, and the related state variables (`csv_need_quotes`, `text_start`) are orphaned. This suggests a feature was partially sketched and never completed or was deleted without cleaning up the declaration.
+Severity rationale: Dead declaration paired with uninitialized state variables indicates incomplete implementation that could cause a linker error if the function is ever invoked.
+Suggested fix: Either implement `add_quotes()` properly (initializing `csv_need_quotes` and `text_start`), or remove the declaration, the member variables, and the assignment in `escape_string()`.
+
+## Review of src/cpu/cpu_core.cpp, src/cpu/cpudevice.h, src/cpu/cpudevice.cpp, src/cpu/abstract_cpu.cpp, src/cpu/cpu_rapl_device.cpp — batch 15
+
+### Medium item #1 : Error reporting via `std::cout` instead of `fprintf(stderr, ...)`
+
+Location: src/cpu/abstract_cpu.cpp : 275, 375
+Description: Two error conditions — an invalid C-state finalize and an invalid P-state finalize —
+are reported by writing to `std::cout` (stdout). The project style guide (style.md §6) mandates
+`fprintf(stderr, ...)` for all error reporting. Using stdout means these messages are silently
+swallowed when the user redirects output (e.g. `powertop > report.txt`) and they also intermix
+with normal output in the ncurses UI.
+Severity rationale: Violates the explicit error-reporting rule; errors can be lost in typical
+usage scenarios.
+Suggested fix: Replace both `cout << "Invalid C state finalize ..."` and
+`cout << "Invalid P state finalize ..."` with `fprintf(stderr, "Invalid C state finalize %s\n", linux_name.c_str())` and `fprintf(stderr, "Invalid P state finalize %" PRIu64 "\n", freq)` respectively.
+
+### Medium item #2 : `std::stoull` result silently narrowed to `int line_level`
+
+Location: src/cpu/abstract_cpu.cpp : 220, 247
+Description: `state->line_level` is declared as `int` (see cpu.h `struct idle_state`).
+Both call sites use `std::stoull()` which returns `unsigned long long`, then assign it directly
+to the `int` field. This is a narrowing conversion: if the parsed number is larger than
+`INT_MAX` the result is implementation-defined (effectively UB in C++20 for values outside
+the destination range). The correct function to use for an `int` target is `std::stoi`.
+Severity rationale: Silent narrowing / potential UB; `std::stoi` is the semantically correct
+choice and any out-of-range value will throw `std::out_of_range` which is already caught by
+the surrounding `catch (...)` block.
+Suggested fix: Replace both occurrences of `std::stoull(...)` with `std::stoi(...)`.
+
+### Medium item #3 : User-visible strings `"CPU core"` not wrapped in `_()` for translation
+
+Location: src/cpu/cpu_rapl_device.h : 48, 49
+Description: `device_name()` and `human_name()` both return the hard-coded string `"CPU core"`.
+Both methods are virtual overrides in the device hierarchy whose return values are displayed
+to the user. The project rule (rules.md, style.md §5) requires all user-visible strings to be
+wrapped in the `_()` gettext macro to be translatable.
+Severity rationale: User-visible strings that are not wrapped in `_()` cannot be localised;
+this is an explicit project rule violation.
+Suggested fix: Change both return statements to `return _("CPU core");`.
+Note: since these are inline definitions in the header, `libintl.h` / the gettext macro must
+be available at the include site; consider moving the definitions to `cpu_rapl_device.cpp`.
+
+## Review of src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp — batch 16
+
+### Medium item #1 : Missing negative-cpunr check in handle_trace_point
+
+Location: src/cpu/cpu.cpp : 948
+Description: The bounds check `if (cpunr >= (int)all_cpus.size())` only guards the
+upper bound. If `cpunr` is negative (e.g. due to perf data corruption or an
+unexpected event), the check passes (negative < positive) and
+`all_cpus[cpunr]` accesses memory before the vector's buffer — undefined
+behaviour that can corrupt heap metadata or crash.
+Severity rationale: While perf normally gives non-negative CPU numbers, the
+defensive check is trivial and its absence is a latent safety issue.
+Suggested fix: `if (cpunr < 0 || cpunr >= (int)all_cpus.size()) return;`
+
+### Medium item #2 : User-facing strings in cpu_rapl_device.h not wrapped in _()
+
+Location: src/cpu/cpu_rapl_device.h : 48-49
+Description: Both `device_name()` (returns `"CPU core"`) and `human_name()`
+(returns `"CPU core"`) return string literals without the gettext `_()` macro.
+These strings are displayed to the user in the device list and power report.
+Per the project rules, all user-visible strings must be wrapped in `_()`.
+Severity rationale: Untranslatable user-visible strings; breaks i18n for all locales.
+Suggested fix: `return _("CPU core");` in both methods.
+
+### Medium item #3 : `#ifndef` header guards instead of `#pragma once`
+
+Location: src/cpu/cpu_rapl_device.h : 25-26  and  src/cpu/cpu.h : 26-27
+Description: Both headers use traditional `#ifndef`/`#define`/`#endif` include
+guards. The project style guide mandates `#pragma once` for all header files.
+Severity rationale: Style violation explicitly called out in style.md §4.1.
+Suggested fix: Replace the `#ifndef ... #define ... #endif` guards with a single `#pragma once`.
+
+### Medium item #4 : `#include <format>` placed mid-file
+
+Location: src/cpu/cpu_package.cpp : 41  and  src/cpu/intel_cpus.cpp : 345
+Description: The `#include <format>` directive appears after several other
+includes and function definitions. The project style guide requires all includes
+to appear at the top of the file, grouped as standard library headers first then
+project headers.
+Severity rationale: Style violation; also makes the dependency on `<format>` easy to miss.
+Suggested fix: Move `#include <format>` to the top-of-file include block in both files.
+
+### Medium item #5 : Error output via `cout` instead of `fprintf(stderr, ...)`
+
+Location: src/cpu/cpu.cpp : 949
+Description: `cout << "INVALID cpu nr in handle_trace_point\n"` uses C++ stream
+output to stdout for an error condition. The project style guide (§6) specifies
+`fprintf(stderr, ...)` for error reporting. Additionally the string is not wrapped
+in `_()` for translation.
+Severity rationale: Error goes to stdout (mixed with normal output), and is
+untranslatable; violates both the error-handling and i18n rules.
+Suggested fix: `fprintf(stderr, _("INVALID cpu nr in handle_trace_point\n"));`
+
+### Medium item #6 : `NULL` instead of `nullptr` in default parameter
+
+Location: src/cpu/cpu_rapl_device.h : 46
+Description: The constructor default parameter uses `NULL` (`class abstract_cpu *_cpu = NULL`).
+C++20 code should use `nullptr` for null pointer constants.
+Severity rationale: `NULL` is a C-style macro; `nullptr` is the C++11+ type-safe alternative and the correct form for C++20 code.
+Suggested fix: `class abstract_cpu *_cpu = nullptr`
+
+### Medium item #7 : `core_num` variable is always zero — dead-code branch
+
+Location: src/cpu/cpu.cpp : 436, 613
+Description: `core_num` is declared and initialised to `0` at line 436 and is
+never incremented anywhere in `report_display_cpu_cstates`. The branch
+`if (core_num > 0)` on line 613 is therefore permanently dead code; the title
+normalisation that was presumably intended never executes.
+Severity rationale: Logic bug; the title-row calculation is silently wrong for packages with multiple cores.
+Suggested fix: Either increment `core_num` alongside `num_cores` or remove the dead branch and unify the title computation.
+
+### Medium item #8 : TSC divide-by-zero in residency ratio computation
+
+Location: src/cpu/intel_cpus.cpp : 313, 604, 684
+Description: In `nhm_core::measurement_end`, `nhm_package::measurement_end`, and
+`nhm_cpu::measurement_end` the ratio is computed as:
+`ratio = 1.0 * time_delta / (tsc_after - tsc_before);`
+If `tsc_after == tsc_before` (possible on some hypervisors or immediately after
+system resume where TSC is reset), the denominator is zero. For double division
+this yields `Inf` or `NaN` which then silently propagates into all
+`duration_delta`/`usage_delta` values, corrupting the displayed data.
+Severity rationale: Silent data corruption on hypervisors or post-resume; no
+user-visible error is produced.
+Suggested fix: Guard with `if (tsc_after != tsc_before) { ratio = ...; }` and
+skip the loop or set deltas to zero otherwise.
+
+## Review of src/cpu/intel_gpu.cpp, src/cpu/rapl/rapl_interface.cpp, src/cpu/rapl/rapl_interface.h, src/wakeup/wakeup.h — batch 17
+
+### Medium item #1 : `using namespace std` in a header file
+
+Location: src/wakeup/wakeup.h : 33
+Description: The header declares `using namespace std;` at global scope. This injects the entire `std` namespace into every translation unit that includes `wakeup.h`, directly and transitively, causing potential name collisions and bypassing the project rule (style.md §4.2) that forbids `using namespace std`. Any downstream `.cpp` file that includes this header loses the protection of explicit namespace qualification.
+Severity rationale: Header-level `using namespace std` is an explicit project style violation that silently affects all includers and can hide naming conflicts throughout the codebase.
+Suggested fix: Remove the `using namespace std;` directive from the header and use `std::string`, `std::vector` explicitly throughout the file.
+
+### Medium item #2 : `string` used without `std::` qualifier in function parameter (intel_gpu.cpp)
+
+Location: src/cpu/intel_gpu.cpp : 57
+Description: The function definition `std::string i965_core::fill_cstate_line(int line_nr, const string &separator __unused)` uses the unqualified `string` for the parameter type, while the corresponding declaration in `intel_cpus.h` correctly uses `std::string`. This relies on `using namespace std` being injected transitively (likely from `wakeup.h`), which is itself a style violation.
+Severity rationale: Direct style violation per style.md §4.2/4.3; introduces implicit dependency on transitive namespace pollution.
+Suggested fix: Replace `const string &separator` with `const std::string &separator`.
+
+### Medium item #3 : `string` used without `std::` qualifier in class member declarations (rapl_interface.h)
+
+Location: src/cpu/rapl/rapl_interface.h : 32–34
+Description: Member variables `powercap_core_path`, `powercap_uncore_path`, and `powercap_dram_path` are declared as plain `string` without the `std::` prefix. The constructor declaration on line 54 in the same header correctly uses `std::string`. The unqualified `string` will only compile if `using namespace std` is brought in by a previously included header, creating a fragile implicit dependency.
+Severity rationale: Style violation per style.md §4.2/4.3; the header has no `#include <string>` of its own, relying entirely on transitive pollution.
+Suggested fix: Qualify all three as `std::string` and add `#include <string>` to the header.
+
+### Medium item #4 : Missing `#include <string>` and `#include <cstdint>` in rapl_interface.h
+
+Location: src/cpu/rapl/rapl_interface.h : 24 (after header guard)
+Description: `rapl_interface.h` uses `string` (lines 32–34) and `uint64_t` (lines 43–44, 64–82) but includes neither `<string>` nor `<stdint.h>` / `<cstdint>`. The file compiles only because other headers included before it in the translation unit happen to bring in these symbols. Any change to include ordering could silently break compilation.
+Severity rationale: Self-contained headers are a fundamental correctness requirement; missing includes create brittle build dependencies.
+Suggested fix: Add `#include <string>` and `#include <cstdint>` to `rapl_interface.h`.
+
+### Medium item #5 : `atof()` used without error detection for sysfs energy values
+
+Location: src/cpu/rapl/rapl_interface.cpp : 376, 467, 554
+Description: Three call sites convert sysfs energy strings to `double` using `atof(str.c_str())`. `atof` returns 0.0 on invalid input with no error indication, meaning a corrupt or unexpected sysfs value (e.g., an empty re-read race, or a kernel change to the format) would silently be treated as zero energy. This causes the downstream power-watt computation to report 0 W without any diagnostic.
+Severity rationale: Silent failure mode for a core measurement path; `stod` or `strtod` would allow error detection.
+Suggested fix: Replace `atof(str.c_str())` with `std::stod(str)` wrapped in a try/catch, or use `strtod` with an end-pointer check, and log/return an error on failure.
+
+### Medium item #6 : Redundant MSR reads — `get_energy_status_unit()` called instead of cached member
+
+Location: src/cpu/rapl/rapl_interface.cpp : 300, 390, 481, 569
+Description: Each of the four energy-status read functions (`get_pkg_energy_status`, `get_dram_energy_status`, `get_pp0_energy_status`, `get_pp1_energy_status`) calls `get_energy_status_unit()` to scale the raw MSR value. This method re-reads `MSR_RAPL_POWER_UNIT` on every invocation, performing a redundant MSR read. The constructor already reads and caches this value into the `energy_status_units` member variable (line 181). The cached value is never actually used for energy scaling.
+Severity rationale: Unnecessary MSR reads on every measurement cycle; using the cached `energy_status_units` member is both more efficient and more consistent.
+Suggested fix: Replace `get_energy_status_unit()` at those four sites with the cached `energy_status_units` member variable.
+
+## Review of wakeup_usb.h, wakeup_ethernet.h, waketab.cpp, wakeup_ethernet.cpp, wakeup.cpp — batch 18
+
+### Medium item #1 : `using namespace std` in wakeup.cpp and waketab.cpp
+
+Location: src/wakeup/wakeup.cpp : 32  and  src/wakeup/waketab.cpp : 16
+Description: Both .cpp files contain `using namespace std;` at file scope. The project style guide explicitly prohibits this construct, and the code already uses fully-qualified `std::` names for most things. It also creates confusion: `string` on line 59 of `wakeup_ethernet.cpp` is resolved only because wakeup.h (transitively) injects `std::`.
+Severity rationale: Medium — direct violation of the style guide; in .cpp files the blast radius is confined to that translation unit, but it is still explicitly prohibited.
+Suggested fix: Remove the `using namespace std;` lines and use `std::` everywhere.
+
+### Medium item #2 : TOCTOU race between counting and writing disabled-device rows in report_show_wakeup
+
+Location: src/wakeup/waketab.cpp : 131-159
+Description: `report_show_wakeup` calls `wakeup_value()` in a first loop to count disabled entries and dimension `wakeup_data`, then calls `wakeup_value()` again in a second loop to fill the vector. `wakeup_value()` reads from sysfs at runtime; if a device changes state between the two loops (hotplug, runtime PM, etc.) the second loop may write more rows than were allocated, causing an out-of-bounds `std::vector` access (undefined behaviour). Additionally the variable is named `tgb` in the first loop and `gb` in the second, making the relationship non-obvious.
+Severity rationale: Medium — the race is real and reachable (sysfs values can change at any time), and the consequence is UB that could corrupt heap or crash.
+Suggested fix: Capture all wakeup values once into a local `std::vector<int>` before either loop, then use the cached values for both counting and writing.
+
+### Medium item #3 : spaces used instead of tabs for indentation in wakeup.cpp
+
+Location: src/wakeup/wakeup.cpp : 39-50
+Description: The body of both `wakeup` constructors uses leading spaces (4-space indent) for the member assignments (`desc =`, `wakeup_enable =`, etc.) instead of the required tabs. The rest of the codebase uses tabs exclusively.
+Severity rationale: Medium — direct violation of the mandatory indentation rule; makes diffs noisy and inconsistent with the rest of the file.
+Suggested fix: Replace the leading spaces with a single tab character on each affected line.
+
+## Review of src/measurement/acpi.cpp, src/measurement/opal-sensors.cpp — batch 19
+
+### Medium item #1 : `using namespace std;` in acpi.cpp
+
+Location: src/measurement/acpi.cpp : 36
+Description: `acpi.cpp` explicitly includes `using namespace std;` at file scope. The coding style guide explicitly forbids this construct. All standard library identifiers must be referenced with the `std::` prefix.
+Severity rationale: Medium — explicit style-guide violation; promotes hidden name collisions and makes code harder to read and maintain.
+Suggested fix: Remove `using namespace std;`. Replace bare `string`, `getline`, `istringstream` usages with their `std::` qualified forms.
+
+### Medium item #2 : Integer overflow risk in `opal_sensors_power_meter::power()`
+
+Location: src/measurement/opal-sensors.cpp : 39-45
+Description: `read_sysfs()` returns a plain `int` (32-bit signed integer). OPAL sensors report power in microwatts. For a system consuming more than ~2147 W (INT_MAX / 1,000,000), the raw sysfs value would overflow a 32-bit signed integer before the division by 1,000,000.0 is applied. IBM POWER systems targeted by this driver can easily have power supplies exceeding this threshold when considering total system power. The overflow produces undefined behaviour and an incorrect (potentially negative) power reading.
+Severity rationale: Medium — affects correctness on high-power POWER systems; produces UB from signed integer overflow.
+Suggested fix: Change `value` to `long` or `int64_t` and update `read_sysfs()` call accordingly, or use a string-based read and parse with `strtoll()`.
+
+## Review of sysfs.h, sysfs.cpp, measurement.h, measurement.cpp, extech.h — batch 20
+
+### Medium item #1 : `end_thread` flag not atomic in extech_power_meter
+
+Location: src/measurement/extech.h : 38
+Description: `int end_thread` is written by the main thread (`end_measurement` sets it to 1) and read by the sampling thread in the `while (!end_thread)` loop, with no synchronization. Without `std::atomic` or a memory barrier the compiler and CPU are free to cache the value in a register and the sampling thread may never observe the update, looping forever.
+Severity rationale: Can cause `pthread_join` in `end_measurement` to hang indefinitely, blocking the entire measurement cycle.
+Suggested fix: Change to `std::atomic<bool> end_thread{false};` and update all uses accordingly.
+
+### Medium item #2 : Missing `override` specifier on virtual overrides in sysfs.h
+
+Location: src/measurement/sysfs.h : 46-50
+Description: `start_measurement`, `end_measurement`, `power`, and `dev_capacity` all override virtual methods from `power_meter` but none use the `override` keyword. Without `override`, a signature mismatch silently creates a new virtual function instead of overriding the intended one.
+Severity rationale: Compiler cannot catch accidental signature mismatches; incorrect overrides go undetected.
+Suggested fix: Add `override` to all four declarations, e.g. `virtual void start_measurement(void) override;`.
+
+### Medium item #3 : Missing `override` specifier on virtual overrides in extech.h
+
+Location: src/measurement/extech.h : 41-47
+Description: `start_measurement`, `end_measurement`, `power`, and `dev_capacity` override `power_meter` methods but lack the `override` keyword.
+Severity rationale: Same as medium item #2 above.
+Suggested fix: Add `override` to all four method declarations.
+
+### Medium item #4 : `#pragma once` not used — old-style include guards in three headers
+
+Location: src/measurement/measurement.h : 25-26; src/measurement/sysfs.h : 25-26; src/measurement/extech.h : 25-26
+Description: All three headers use `#ifndef / #define / #endif` guards instead of `#pragma once` required by style.md §4.1. The guards also use double-underscore prefixes (`__INCLUDE_GUARD_*`) which are reserved identifiers in C++.
+Severity rationale: Style violation and use of reserved names; `#pragma once` is simpler and avoids reserved-name UB.
+Suggested fix: Replace each `#ifndef / #define / #endif` triple with `#pragma once` at the top of the file.
+
+### Medium item #5 : `extech_power_meter` allocated without `std::nothrow` and without null check
+
+Location: src/measurement/measurement.cpp : 183
+Description: `meter = new class extech_power_meter(devnode);` uses throwing `new`, unlike the three similar allocations on lines 144, 152, and 165 which use `new(std::nothrow)` and check for null before pushing to `power_meters`. If allocation fails here the unhandled exception terminates the process; if `meter` were somehow null it would be pushed into `power_meters` and later dereferenced.
+Severity rationale: Inconsistency with surrounding code; missing null check creates potential null-pointer dereference.
+Suggested fix: Change to `meter = new(std::nothrow) extech_power_meter(devnode); if (meter) power_meters.push_back(meter);`.
+
+## Review of src/measurement/extech.cpp, src/devices/backlight.h, src/devices/backlight.cpp, src/devices/rfkill.cpp — batch 21
+
+### Medium item #1 : `using namespace std;` in extech.cpp, backlight.cpp, rfkill.cpp
+
+Location: src/measurement/extech.cpp : 64 | src/devices/backlight.cpp : 34 | src/devices/rfkill.cpp : 35
+Description: All three `.cpp` files contain `using namespace std;`, which is explicitly prohibited by both style.md §4.2 and general-c++.md. This pollutes the global namespace and can cause silent name collisions. The codebase already uses `std::` prefixes consistently in other files.
+Severity rationale: Violation of two separate coding-style rules; potential for subtle naming conflicts in a project that mixes C and C++ headers.
+Suggested fix: Remove all three `using namespace std;` directives and prefix all standard-library names with `std::`.
+
+### Medium item #2 : `decode_extech_value` return type is `unsigned int` but returns -1 on error
+
+Location: src/measurement/extech.cpp : 145, 201
+Description: The function is declared as returning `unsigned int`, yet the error path does `return -1;`. Due to implicit conversion, -1 becomes `UINT_MAX`. The caller checks `if (ret)` which accidentally works because `UINT_MAX != 0`, but the interface is semantically incorrect, misleading, and fragile. Any caller that compares the return value to -1 directly will get the wrong result.
+Severity rationale: Incorrect return type; error-detection relies on accidental unsigned arithmetic, a silent API contract violation.
+Suggested fix: Change the return type to `int` (or return a negative constant like `-1` explicitly as `int`).
+
+### Medium item #3 : parse_packet inner decode loop runs only once instead of four times
+
+Location: src/measurement/extech.cpp : 222
+Description: `for (i = 0; i < 1; i++)` iterates exactly once (i=0 only), decoding only the first five-byte block. The outer loop confirms that four blocks are expected. If all four blocks carry measurement data, only one-quarter of the available information is decoded; the remaining three blocks are silently discarded.
+Severity rationale: Potential logic error that limits the measurement to only the first of four data blocks, possibly discarding the actual watts field if it lives in a later block.
+Suggested fix: Change the loop bound to match the outer loop: `for (i = 0; i < 4; i++)`. Verify the op[] buffer is large enough (currently 32 bytes; 4 × 8 = 32 bytes — exactly fits).
+
+### Medium item #4 : `human_name()` returns non-translated string "Display backlight"
+
+Location: src/devices/backlight.h : 52
+Description: The `human_name()` method returns the literal string `"Display backlight"` without wrapping it in the `_()` gettext macro, violating the project rule that all user-visible strings must be translatable.
+Severity rationale: User-visible device name is never translated; breaks i18n for all backlight entries.
+Suggested fix: `virtual std::string human_name(void) { return _("Display backlight"); };`
+
+### Medium item #5 : rfkill humanname fallback is not translated
+
+Location: src/devices/rfkill.cpp : 56
+Description: When the `readlink()` calls both fail, `humanname` remains set to `std::format("radio:{}", _name)`, a hard-coded non-translated string. The translated form is only used when readlink succeeds (lines 64, 69). The fallback is therefore never localized.
+Severity rationale: User-visible device label is untranslated for any rfkill device whose driver symlink cannot be resolved.
+Suggested fix: Use a translated fallback, e.g. `humanname = pt_format(_("Radio device: {}"), _name);`.
+
+### Medium item #6 : Error messages in parse_packet use printf() and are not translated
+
+Location: src/measurement/extech.cpp : 217, 227, 291
+Description: Three error messages use `printf()` to write to stdout rather than `fprintf(stderr, ...)` as required by style.md §6. None of the strings are wrapped in `_()`. The message at line 291 in `measure()` also uses `printf` instead of `fprintf(stderr,...)`.
+Severity rationale: Violates the project style rule for error output; strings are not translatable.
+Suggested fix: Replace with `fprintf(stderr, _("Invalid packet\n"));` etc. (or simply remove diagnostic noise for internal protocol errors and return the error code silently).
+
+### Medium item #7 : Hardcoded `/sys/class/drm/card0` in dpms_screen_on()
+
+Location: src/devices/backlight.cpp : 69, 80, 84
+Description: `dpms_screen_on()` opens `/sys/class/drm/card0` and then constructs paths under `/sys/class/drm/card0/…`. On systems with multiple GPUs or where the primary display adapter is not `card0` (e.g., discrete NVIDIA where Intel is `card1`), the function will always report the screen as off, causing backlight utilization to be reported as 0% regardless of actual state.
+Severity rationale: Directly causes incorrect backlight power estimates on a common class of multi-GPU laptops — a material impact on measurement accuracy.
+Suggested fix: Enumerate all `/sys/class/drm/card*` top-level directories and search for an enabled+On connector under each of them, rather than hardcoding `card0`.
+
+## Review of src/devices/usb.h, src/devices/usb.cpp, src/devices/gpu_rapl_device.h, src/devices/gpu_rapl_device.cpp, src/devices/ahci.h — batch 22
+
+### Medium item #1 : `consumed_power` is uninitialized in gpu_rapl_device constructor
+
+Location: src/devices/gpu_rapl_device.cpp : 31-41
+Description: The constructor initializes `device_valid(false)` explicitly but never initializes `consumed_power`. In C++, non-static member variables of POD types are left with indeterminate values unless explicitly initialized. If `power_usage()` is called before `end_measurement()` has ever run (which sets `consumed_power = 0.0`), and the RAPL domain is present, the function returns the indeterminate value — undefined behaviour. The fix is to initialize `consumed_power` to `0.0` in the member initializer list.
+Severity rationale: UB via use of uninitialized memory; could produce garbage power readings on the first call.
+Suggested fix: Add `consumed_power(0.0)` to the member initializer list: `gpu_rapl_device::gpu_rapl_device(i915gpu *parent) : i915gpu(), consumed_power(0.0), device_valid(false)`.
+
+### Medium item #2 : Non-translatable user-facing strings "GPU core" in gpu_rapl_device.h
+
+Location: src/devices/gpu_rapl_device.h : 47-49
+Description: The methods `class_name()`, `device_name()`, and `human_name()` all return the hard-coded string `"GPU core"` without the `_()` gettext macro. `human_name()` in particular is the string shown to the user in device listings. The project rules (`rules.md`, `style.md §5`) require that all user-visible strings be wrapped with `_()` for internationalization. The other devices (usb, ahci) already use `pt_format(_("..."), ...)` for their human-readable names.
+Severity rationale: Breaks i18n for all users with non-English locales; explicitly required by project rules.
+Suggested fix: Change the return expressions: `return _("GPU core");` for `human_name()`. `class_name()` and `device_name()` are internal identifiers — if they are truly user-visible, apply `_()` as well; otherwise document that they are internal.
+
+### Medium item #3 : Missing `override` specifier on virtual methods in derived classes
+
+Location: src/devices/usb.h : 50-62, src/devices/gpu_rapl_device.h : 47-53, src/devices/ahci.h : 53-66
+Description: All three derived-class headers redeclare base-class virtual methods using the `virtual` keyword but omit `override`. In C++11 and later, `override` causes a compile-time error if the function signature does not match a virtual function in the base class, catching accidental signature mismatches. Without `override`, silent shadowing bugs (e.g., a parameter type mismatch) compile without warning. The project uses C++20 where `override` is idiomatic.
+Severity rationale: Absence of `override` is a C++ best-practice violation that can hide real signature bugs silently.
+Suggested fix: Replace `virtual` with `override` (or add `override` after the parameter list) on every overriding method declaration. Remove the leading `virtual` keyword as it is redundant when `override` is present.
+
+### Medium item #4 : Fixed-size C-style buffer in `register_power_with_devlist`
+
+Location: src/devices/usb.cpp : 115-118
+Description: `char devfs_name[1024]` is used with `snprintf` to produce a path of the form `"usb/NNN/NNN"`. The project rules (`general-c++.md`) require preferring `std::string` over C-style strings and char arrays except when interfacing with C-only libraries. `register_devpower` accepts a `const char *` (C interface), but the intermediate buffer should be avoided. The buffer is far larger than necessary and is a maintenance hazard.
+Severity rationale: Style/rule violation; the buffer is not at risk of overflow in practice, but fixed-size buffers are explicitly discouraged and the project has the std::format infrastructure to do this without a buffer.
+Suggested fix: Replace with `std::string devfs_name = std::format("usb/{:03}/{:03}", busnum, devnum);` and pass `devfs_name.c_str()` to `register_devpower`.
+
+### Medium item #5 : `start_measurement` / `end_measurement` call RAPL API without checking `device_valid`
+
+Location: src/devices/gpu_rapl_device.cpp : 43-61
+Description: Both `start_measurement()` and `end_measurement()` unconditionally call `rapl.get_pp1_energy_status()` regardless of whether `device_valid` is true. If the RAPL pp1 domain is not present, the call is a no-op in benign implementations, but the code relies on that assumption. Additionally, `last_energy` is only initialized in the constructor's `if (rapl.pp1_domain_present())` branch; if the domain is absent, `last_energy` is uninitialized and `end_measurement` would compute a meaningless `consumed_power` before writing it back.
+Severity rationale: Can interact with the uninitialized `last_energy` issue (M1) to produce UB or incorrect readings.
+Suggested fix: Guard both methods: `if (!device_valid) return;` at the top of `start_measurement()` and `end_measurement()`.
+
+### Medium item #6 : Unqualified `string` in usb.cpp constructor signature
+
+Location: src/devices/usb.cpp : 41
+Description: The constructor definition uses `const string &_name, const string &path, const string &devid` — bare `string` without the `std::` prefix. This compiles only because some transitively-included header introduces `using namespace std` (likely `gpu_rapl_device.h` via the include chain, or some system header). The project style (`style.md §4.2`, `general-c++.md`) requires explicit `std::` qualification throughout. The header declaration at `usb.h:48` correctly uses `std::string`.
+Severity rationale: Code relies on namespace pollution from another header to compile; fragile and style non-compliant.
+Suggested fix: Change line 41 to `usbdevice::usbdevice(const std::string &_name, const std::string &path, const std::string &devid)`.
+
+
+## Review of src/devices/ahci.cpp, src/devices/thinkpad-fan.h, src/devices/thinkpad-fan.cpp, src/devices/device.h, src/devices/device.cpp — batch 23
+
+### Medium item #1 : `using namespace std;` in ahci.cpp and device.cpp
+
+Location: src/devices/ahci.cpp : 34 ; src/devices/device.cpp : 35
+Description: Both source files contain `using namespace std;` at file scope. While less harmful than the identical construct in device.h (it does not affect other translation units), it is still explicitly prohibited by style.md §4.2 ("Avoid `using namespace std;`") and general-c++.md. The rest of the codebase uses the `std::` prefix consistently.
+Severity rationale: Style and correctness violation in two files; does not affect other TUs but sets a bad example and can hide name conflicts within the file.
+Suggested fix: Remove the `using namespace std;` lines and add `std::` prefixes where needed (the existing code already uses `std::` for most calls, so the change is minimal).
+
+### Medium item #2 : User-visible string "Laptop fan" not wrapped with `_()`
+
+Location: src/devices/thinkpad-fan.h : 48
+Description: The `human_name()` virtual method returns the hard-coded string `"Laptop fan"`. This string is displayed directly to the user in the device power table (it becomes the "Device name" column entry). Per rules.md: "All user visible strings must be translatable and use the _() gettext pattern". The string is currently not translatable.
+Severity rationale: Direct i18n violation for a string that is always shown to users on ThinkPad systems.
+Suggested fix: `virtual std::string human_name(void) { return _("Laptop fan"); };`
+
+### Medium item #3 : Override virtual methods lack `override` specifier
+
+Location: src/devices/thinkpad-fan.h : 40–52
+Description: All virtual methods in `thinkpad_fan` that override `device` base-class methods (`start_measurement`, `end_measurement`, `utilization`, `class_name`, `device_name`, `human_name`, `power_usage`, `util_units`, `power_valid`, `grouping_prio`) are declared with `virtual` but without the C++11 `override` keyword. The `override` specifier lets the compiler catch signature mismatches between override and base.
+Severity rationale: Missing `override` is a C++ best practice violation; a future signature change in the base class would silently stop the override from working.
+Suggested fix: Replace `virtual void start_measurement(void);` with `void start_measurement(void) override;` (and similarly for all other overrides). Drop the redundant `virtual` when `override` is present.
+
+### Medium item #4 : Old-style `#ifndef` include guards instead of `#pragma once`
+
+Location: src/devices/thinkpad-fan.h : 25–26 ; src/devices/device.h : 25–26
+Description: Both headers use the traditional `#ifndef _INCLUDE_GUARD_…` / `#define` / `#endif` pattern. style.md §4.1 states: "Use `#pragma once`".
+Severity rationale: Style guide violation in two headers.
+Suggested fix: Replace the `#ifndef` / `#define` / `#endif` trio with a single `#pragma once` directive.
+
+### Medium item #5 : Duplicate `#include <unistd.h>` in thinkpad-fan.cpp and device.cpp
+
+Location: src/devices/thinkpad-fan.cpp : 32 and 44 ; src/devices/device.cpp : 32 and 56
+Description: `<unistd.h>` is included twice in each of these files. In thinkpad-fan.cpp it appears at lines 32 and 44; in device.cpp at lines 32 and 56. Duplicate includes are harmless due to include guards but indicate copy-paste errors and reduce readability.
+Severity rationale: Code quality / maintenance issue.
+Suggested fix: Remove the second occurrence of `#include <unistd.h>` in each file.
+
+### Medium item #6 : Unused includes `<iostream>` and `<fstream>` in thinkpad-fan.cpp
+
+Location: src/devices/thinkpad-fan.cpp : 25–26
+Description: `<iostream>` and `<fstream>` are included but neither `std::cout`, `std::cin`, `std::ifstream`, nor any other entity from these headers is used anywhere in thinkpad-fan.cpp. This increases compilation time and obscures the file's true dependencies.
+Severity rationale: Code clarity violation; may mislead future maintainers into thinking stream I/O is being used.
+Suggested fix: Remove lines 25–26 (`#include <iostream>` and `#include <fstream>`).
+
+### Medium item #7 : Override virtual methods in device.h lack `override` specifier
+
+Location: src/devices/device.h : 45–72
+Description: The base class `device` declares all its interface methods as `virtual`. While being the base class it is not required to use `override` itself, derived classes (e.g. `thinkpad_fan`, `ahci`) do not use `override` either. This is a pervasive issue across the hierarchy — noting it at the base class level for context.
+Severity rationale: Same rationale as Medium item #3; a pattern that should be adopted hierarchy-wide.
+Suggested fix: Add `override` to all override declarations in all derived device classes.
+
+### Medium item #8 : Unused variable `cols` and `rows` default-initialized to 0 then immediately overwritten
+
+Location: src/devices/ahci.cpp : 262–264
+Description: `int cols=0; int rows=0;` are declared with initializers, then two lines later unconditionally assigned `cols=5; rows=links.size()+1;`. The zero-initialization is dead code that can confuse the reader.
+Severity rationale: Minor code clarity issue; initializers 0 are never observable.
+Suggested fix: Declare and initialise at point of use:
+```cpp
+int cols = 5;
+int rows = static_cast<int>(links.size()) + 1;
+```
+## Review of src/devices/devfreq.cpp, src/devices/devfreq.h, src/devices/alsa.h, src/devices/alsa.cpp, src/devices/runtime_pm.cpp — batch 24
+
+### Medium item #1 : Old-style `#ifndef` header guards instead of `#pragma once`
+
+Location: src/devices/devfreq.h : 25, src/devices/alsa.h : 25, src/devices/runtime_pm.h : 25
+Description: All three headers use the `#ifndef _INCLUDE_GUARD_xxx` / `#define` / `#endif` idiom. style.md §4.1 mandates `#pragma once` for header guards in this project.
+Severity rationale: Style rule violation across all three headers reviewed.
+Suggested fix: Replace the `#ifndef`/`#define`/`#endif` triple in each header with a single `#pragma once` at the top.
+
+### Medium item #2 : User-visible string `"Idle"` not wrapped in `_()`
+
+Location: src/devices/devfreq.cpp : 97
+Description: `state->human_name = "Idle";` assigns a hard-coded English string that is displayed directly in the ncurses UI and reports. All user-visible strings must use the `_()` gettext macro per style.md §5 and rules.md.
+Severity rationale: String cannot be localised; violates mandatory i18n rule.
+Suggested fix: `state->human_name = _("Idle");`
+
+### Medium item #3 : Untranslated user-visible error messages sent to stderr
+
+Location: src/devices/devfreq.cpp : 239, 249
+Description: Two calls `fprintf(stderr, "Devfreq not enabled\n")` output English-only text. While these go to stderr, they are user-visible diagnostic messages that should be translatable per the project's i18n rules. Similarly, the ncurses string `" Devfreq is not enabled"` at line 278 is already correctly wrapped but the stderr counterpart is not.
+Severity rationale: Inconsistency; stderr messages are user-visible and must be localisable.
+Suggested fix: `fprintf(stderr, _("Devfreq not enabled\n"));`
+
+### Medium item #4 : `uint64_t` arithmetic underflow in `alsa::end_measurement()` numerator
+
+Location: src/devices/alsa.cpp : 107
+Description: `(end_active - start_active)` is computed as `uint64_t - uint64_t`. If `end_active < start_active` (e.g., after a counter reset, driver reload, or suspend/resume), the result silently wraps to a very large `uint64_t`. When this large value is then divided by the (correctly computed double) denominator, `p` becomes a huge number (>> 100%) which gets stored and displayed as the utilisation. The same pattern also appears in `alsa::utilization()` at line 116.
+Severity rationale: Silent data corruption on counter wrap produces wildly incorrect power accounting.
+Suggested fix: Cast to signed 64-bit before subtraction, or clamp: `double active_delta = (end_active >= start_active) ? (double)(end_active - start_active) : 0.0;`
+
+### Medium item #5 : `dstates` is a public member of `devfreq`
+
+Location: src/devices/devfreq.h : 48
+Description: `vector<class frequency *> dstates` is declared `public`, allowing any external code to modify the internal state vector directly. `display_devfreq_devices()` in devfreq.cpp iterates over it externally (`df->dstates`). Exposing the raw vector violates encapsulation and makes it harder to change the implementation.
+Severity rationale: Design defect that exposes memory-managed internals; coupled to at least one direct external use.
+Suggested fix: Make `dstates` private and add a `size_t freq_state_count()` and `const frequency* freq_state(size_t idx)` accessor pair.
+
+### Medium item #6 : `static int index = 0` lazy-init fails when `get_param_index` returns 0
+
+Location: src/devices/alsa.cpp : 146-150
+Description: `power_usage()` uses a static local `index` initialised to 0 as a sentinel for "not yet looked up". If `get_param_index("alsa-codec-power")` legitimately returns 0 (i.e., it is the first registered parameter), the guard `if (!index)` is always true and the index is re-fetched on every call. At worst this is an O(n) lookup on every power calculation; at best it is silently correct by accident.
+Severity rationale: Logic error with a subtle trigger condition; incorrect parameter lookup on every power calculation if index happens to be 0.
+Suggested fix: Use `static int index = -1;` as the sentinel, or initialise the index in the constructor.
+
+### Medium item #7 : `do_bus()` adds all bus devices to device list without runtime PM check
+
+Location: src/devices/runtime_pm.cpp : 130-174
+Description: `do_bus()` creates a `runtime_pmdevice` for every entry in `/sys/bus/{bus}/devices/` unconditionally, including devices that have no `power/runtime_suspended_time` or `power/runtime_active_time` sysfs files. The helper `device_has_runtime_pm()` exists precisely to detect this but is never called inside `do_bus()`. Consequences: (1) potentially dozens of ghost devices appear in the UI with permanently 0% utilisation; (2) a power parameter entry is registered for each via `register_parameter(humanname)`, bloating the parameter registry.
+Severity rationale: Functional correctness issue — non-PM devices are silently included and pollute the device list and parameter registry.
+Suggested fix: After constructing `dev`, check `device_has_runtime_pm(path)` and `delete dev; continue;` if false, before pushing to `all_devices`.
+
+### Medium item #8 : `active_time` accumulator compared against `sample_time` without overflow guard
+
+Location: src/devices/devfreq.cpp : 82
+Description: In `process_time_stamps()`, `dstates[i]->time_after` (type `uint64_t`) is assigned `sample_time - active_time` where `sample_time` is `double` (microseconds) and `active_time` is a `uint64_t` accumulation of nanosecond-domain values (line 79 multiplies by 1000). If measurement jitter or counter imprecision causes `active_time > sample_time`, the double subtraction yields a negative value which is then silently truncated to a very large `uint64_t` on assignment — corrupting the idle-time accounting for the device.
+Severity rationale: Unsigned underflow on double-to-uint64_t conversion produces invalid idle time displayed to the user.
+Suggested fix:
+```cpp
+double idle = sample_time - (double)active_time;
+dstates[i]->time_after = (idle > 0.0) ? (uint64_t)idle : 0;
+```

--- a/logs.1/nit.md
+++ b/logs.1/nit.md
@@ -1,0 +1,914 @@
+# PowerTOP Nit Severity Review Findings
+
+## Review of calibrate.cpp, calibrate.h, lib.cpp, devlist.cpp, main.cpp — batch 01
+
+### Nit item #1 : Mixed `cout` and `printf` in calibrate.cpp
+
+Location: src/calibrate/calibrate.cpp : 389, 412
+
+Description:
+`calibrate()` uses `cout << _("...")` at lines 389 and 412 while every other print in the file uses `printf`. The project uses `printf`-style I/O throughout. Mixing the two output mechanisms is a style inconsistency and can cause unexpected ordering on buffered streams.
+
+Suggested fix: Replace the two `cout <<` calls with `printf(_("..."))`.
+
+---
+
+### Nit item #2 : Space indentation instead of tabs in calibrate.cpp
+
+Location: src/calibrate/calibrate.cpp : 387, 415, 419–420
+
+Description:
+Several lines inside `calibrate()` use leading spaces instead of the project-mandated tabs (style.md §1.1):
+- Line 387: `        save_sysfs(...)` — 8 spaces
+- Line 415: `        learn_parameters(...)` — 8 spaces
+- Lines 419–420: `        save_all_results(...)` — 8 spaces
+
+Suggested fix: Replace leading spaces with a single tab on each affected line.
+
+---
+
+### Nit item #3 : Space indentation instead of tabs in main.cpp
+
+Location: src/main.cpp : 313–314, 422
+
+Description:
+- Lines 313–314 (`fprintf` calls inside `make_report`) use 2-space and 3-space indentation instead of tabs.
+- Line 422 (`load_parameters` call inside `powertop_init`) uses 8 spaces instead of a tab.
+
+Suggested fix: Replace leading spaces with tabs to match the rest of the file.
+
+---
+
+### Nit item #4 : Missing space before `!= 0` / `==0` comparisons
+
+Location: src/calibrate/calibrate.cpp : 173; src/devlist.cpp : 88, 164
+
+Description:
+```cpp
+if (access(filename.c_str(), R_OK)!=0)   // calibrate.cpp:173
+if (strncmp(link, "/dev", 4)==0) {        // devlist.cpp:164
+```
+The project style follows Linux kernel formatting conventions which require spaces around binary operators. These lines are missing spaces around `!=` and `==`.
+
+Suggested fix:
+```cpp
+if (access(filename.c_str(), R_OK) != 0)
+if (strncmp(link, "/dev", 4) == 0) {
+```
+
+---
+
+### Nit item #5 : `set_refresh_timeout` returns `0`/`1` instead of `false`/`true`
+
+Location: src/main.cpp : 123–124
+
+Description:
+```cpp
+if (!time) return 0;
+...
+return 1;
+```
+The function signature declares `bool` as the return type, but integer literals `0` and `1` are returned. Prefer `false` and `true` for boolean returns to match the declared type.
+
+Suggested fix:
+```cpp
+if (!time) return false;
+...
+return true;
+```
+
+## Review of src/test_framework.h, src/test_framework.cpp, src/display.cpp, src/display.h, src/lib.h — batch 02
+
+### Nit item #1 : Spaces instead of tabs in `base64_encode` and `base64_decode`
+
+Location: src/test_framework.cpp : 200–231
+Description: Both `base64_encode` and `base64_decode` are indented with 4 spaces instead of the project-mandated tabs. Every line inside these functions is affected.
+Severity rationale: Style guide §1.1 mandates tabs only.
+Suggested fix: Re-indent with tabs.
+
+---
+
+### Nit item #2 : Spaces instead of tabs in `show_prev_tab()`, `cursor_left()`, `cursor_right()`
+
+Location: src/display.cpp : 192–208, 282–292, 295–306
+Description: `show_prev_tab()` and the two cursor functions use spaces for indentation on several lines, inconsistent with the rest of the file and the project style guide.
+Severity rationale: Style guide §1.1.
+Suggested fix: Convert affected lines to tab indentation.
+
+---
+
+### Nit item #3 : Missing space after `if` in `cursor_up()`
+
+Location: src/display.cpp : 271
+Description: `if(w->ypad_pos > 0)` is missing the space between `if` and `(`. The project style (K&R/Linux kernel variant) requires a space.
+Severity rationale: Style nit.
+Suggested fix: `if (w->ypad_pos > 0)`
+
+---
+
+### Nit item #4 : Missing space around `=` in `tab_window` constructor
+
+Location: src/display.h : 59
+Description: `xpad_pos =0;` has a space before `=` but not after. Should be `xpad_pos = 0;` for consistency with the other assignments in the same constructor.
+Severity rationale: Style nit.
+Suggested fix: `xpad_pos = 0;`
+
+---
+
+### Nit item #5 : Redundant `extern` on function declarations in display.h
+
+Location: src/display.h : 35–47
+Description: `extern` on function declarations in a C++ header is implicit and redundant. The project's other headers (e.g., lib.h) also use `extern` inconsistently, but removing it from display.h would align with modern C++ practice.
+Severity rationale: Cosmetic / modern C++ idiom.
+Suggested fix: Remove `extern` from all function declarations.
+
+---
+
+### Nit item #6 : Signed/unsigned comparison warning in `show_tab()` loop
+
+Location: src/display.cpp : 136
+Description: `for (i = 0; i < tab_names.size(); i++)` — `i` is declared as `unsigned int` (matching `tab`'s type) but `tab_names.size()` returns `size_t`. On a 64-bit platform `unsigned int` is 32 bits while `size_t` is 64 bits, producing a comparison between differently-sized unsigned types and potentially a compiler warning.
+Severity rationale: Minor; no current runtime risk but indicates imprecision.
+Suggested fix: Declare `i` as `size_t` or use a range-for loop.
+
+---
+
+### Nit item #7 : Magic number `7` in `cursor_down()` scroll guard
+
+Location: src/display.cpp : 248
+Description: `if ((w->cursor_pos + 7) >= LINES)` uses the literal `7` with no explanation. This appears to be an offset related to the reserved top/bottom display rows, but without a comment or named constant the intent is opaque.
+Severity rationale: Readability nit.
+Suggested fix: Define `constexpr int DISPLAY_MARGIN = 7;` and document its meaning, or add an inline comment.
+
+## Review of src/tuning/tunable.h, src/tuning/runtime.cpp — batch 03
+
+### Nit item #1 : Extra semicolon after virtual destructor definition
+
+Location: src/tuning/tunable.h : 61
+Description: `virtual ~tunable() {};` has a spurious semicolon after the closing brace. While harmless, it is non-idiomatic.
+Severity rationale: Cosmetic.
+Suggested fix: `virtual ~tunable() {}`
+
+### Nit item #2 : Opening brace on separate line for `for` loop body
+
+Location: src/tuning/runtime.cpp : 174–175
+Description: The `for (char blk = 'a'; blk <= 'z'; blk++)` statement has its opening brace on a new line, violating the project's K&R brace style (style.md §1.2).
+Severity rationale: Style nit.
+Suggested fix: `for (char blk = 'a'; blk <= 'z'; blk++) {`
+
+### Nit item #3 : Inconsistent spacing around `=` in variable declarations
+
+Location: src/tuning/runtime.cpp : 127
+Description: `int max_ports = 32, count=0;` — `count=0` lacks spaces around the `=` operator, inconsistent with `max_ports = 32`.
+Severity rationale: Cosmetic style inconsistency.
+Suggested fix: `int max_ports = 32, count = 0;`
+
+### Nit item #4 : Inconsistent spacing in `for` loop init expression
+
+Location: src/tuning/runtime.cpp : 158
+Description: `for (int i=0; i < max_ports; i++)` — `i=0` lacks spaces around `=`.
+Severity rationale: Cosmetic style inconsistency.
+Suggested fix: `for (int i = 0; i < max_ports; i++)`
+
+### Nit item #5 : Duplicate constant values for `TUNE_UNKNOWN` and `TUNE_NEUTRAL`
+
+Location: src/tuning/tunable.h : 39–40
+Description: `TUNE_UNKNOWN` and `TUNE_NEUTRAL` are both defined as `0`. Having two names for the same sentinel makes the codebase ambiguous — it is unclear whether the result of `good_bad()` returning `0` means "unknown state" or "neutral/not applicable".
+Severity rationale: Cosmetic / readability issue; could cause confusion when reading code.
+Suggested fix: Keep only one name, or add a comment explaining the deliberate dual alias.
+
+### Nit item #6 : C-style `void` in no-argument virtual method declarations
+
+Location: src/tuning/tunable.h : 63, 78, 80, 82
+Description: Virtual methods such as `good_bad(void)`, `toggle(void)`, `description(void)`, `toggle_script(void)` and `result_string(void)` use C-style `void` parameter syntax. In C++, empty parentheses `()` are preferred.
+Severity rationale: C++ style preference; C-style `(void)` is idiomatic C, not modern C++.
+Suggested fix: Change all `method(void)` declarations to `method()`.
+
+### Nit item #7 : Unqualified `string::npos` usage in runtime.cpp relies on namespace pollution
+
+Location: src/tuning/runtime.cpp : 81, 85
+Description: `path.find("ata") != string::npos` and `path.find("block") != string::npos` use unqualified `string::npos`. This compiles only because `using namespace std;` is injected via the included `runtime.h`. Once the `using namespace std;` is removed (per High items #1/#2), these must be updated.
+Severity rationale: Consequential nit — will become a compile error once the HIGH items are fixed.
+Suggested fix: Use `std::string::npos` explicitly.
+
+## Review of ethernet.cpp, ethernet.h, wifi.cpp, wifi.h, tuningusb.h — batch 04
+
+### Nit item #1 : Missing spaces around `<` in comparisons in ethernet.cpp
+
+Location: src/tuning/ethernet.cpp : 71, 78, 107, 114
+Description: `sock<0` and `ret<0` are written without spaces around the `<` operator. The project style (K&R/Linux kernel style) requires spaces around binary operators: `sock < 0` and `ret < 0`.
+Severity rationale: Minor style inconsistency.
+Suggested fix: `if (sock < 0)` and `if (ret < 0)`.
+
+### Nit item #2 : Leading-underscore parameter name `_iface` in wifi_tunable constructor
+
+Location: src/tuning/wifi.cpp : 46
+Description: The constructor parameter is named `_iface`. Leading underscores are conventionally reserved for implementation-defined identifiers. The project uses `snake_case` without leading underscores for parameters (e.g., `iface` in ethernet_tunable). Using `_iface` is non-idiomatic and potentially confusing.
+Severity rationale: Minor naming convention violation.
+Suggested fix: Rename the parameter to `iface` (matching ethernet.cpp's pattern).
+
+### Nit item #3 : Space-indented lines (not tab) on `ioctl` calls in ethernet.cpp
+
+Location: src/tuning/ethernet.cpp : 87, 123, 126
+Description: The three `ioctl(sock, SIOCETHTOOL, &ifr);` lines are indented with 8 spaces rather than a tab character. The project style guide mandates tab-only indentation.
+Severity rationale: Style guide violation (indentation).
+Suggested fix: Replace the leading 8 spaces with a single tab on each of the three lines.
+
+### Nit item #4 : C-style headers used in ethernet.cpp instead of C++ equivalents
+
+Location: src/tuning/ethernet.cpp : 30–32, 37
+Description: `<stdio.h>`, `<stdlib.h>`, `<string.h>`, and `<errno.h>` are C-style headers. The C++ equivalents `<cstdio>`, `<cstdlib>`, `<cstring>`, and `<cerrno>` place their declarations in the `std::` namespace and are the idiomatic choice in C++20 code.
+Severity rationale: Minor — both forms are standard in practice, but C++ headers are preferred per the C++20 standard and the project's use of C++ idioms elsewhere.
+Suggested fix: Replace each C-style header with its C++ equivalent (`<c*>` form).
+
+## Review of tuningusb.cpp, tuning.cpp, tuning.h, bluetooth.cpp, bluetooth.h — batch 05
+
+### Nit item #1 : Bare `string` instead of `std::string`
+
+Location: src/tuning/tuningusb.cpp : 40, 73; src/tuning/tuning.cpp : 247
+Description: Several locations use `string` without the `std::` prefix (e.g., `const string &path` in the constructor signature, `string content;` in `good_bad`). This works only because `tunable.h` contains `using namespace std;`, which is itself a style violation. The style guide requires explicit `std::` qualification everywhere.
+Severity rationale: Style guide violation; depends on a transitive `using namespace std;`.
+Suggested fix: Replace all bare `string` with `std::string` throughout these files.
+
+### Nit item #2 : Redundant `class` keyword in object declaration
+
+Location: src/tuning/tuningusb.cpp : 98
+Description: `class usb_tunable *usb;` uses the `class` keyword in a variable declaration. In C++ this is unnecessary (unlike C where `struct` tags require the keyword). The pattern is idiomatic C but not idiomatic C++.
+Severity rationale: Style inconsistency; the `class` keyword is superfluous in a variable declaration.
+Suggested fix: `usb_tunable *usb;`
+
+### Nit item #3 : Commented-out code block left in production source
+
+Location: src/tuning/bluetooth.cpp : 199–201
+Description: A three-line block checking `/sys/module/bluetooth` is commented out with a note explaining the intent. Commented-out code should not remain in production source; either the check should be re-enabled (the concern about triggering autoload is valid) or removed with a commit message explaining the decision.
+Severity rationale: Code hygiene; also the original concern (autoloading the bluetooth module) may still be valid.
+Suggested fix: If the autoload concern still applies, restore the check. Otherwise remove the dead code entirely.
+
+### Nit item #4 : Redundant explicit `string()` conversion
+
+Location: src/tuning/tuning.cpp : 247
+Description: `tunable_data[idx] = string(all_tunables[i]->toggle_script());` — `toggle_script()` already returns `std::string`, so the explicit `string()` constructor call is a no-op copy. It also uses bare `string` instead of `std::string`.
+Severity rationale: Unnecessary copy; style violation.
+Suggested fix: `tunable_data[idx] = all_tunables[i]->toggle_script();`
+
+### Nit item #5 : Use of POSIX `strcasecmp` instead of a C++ equivalent
+
+Location: src/tuning/tuning.cpp : 177
+Description: `strcasecmp(i->description().c_str(), j->description().c_str()) < 0` uses `strcasecmp`, which is a POSIX extension not part of the C++20 standard. The project targets C++20, so a portable alternative should be used.
+Severity rationale: Non-standard API; reduces portability.
+Suggested fix: Use a locale-aware comparison or a simple case-folding lambda:
+```cpp
+auto ci_less = [](unsigned char a, unsigned char b){ return std::tolower(a) < std::tolower(b); };
+return std::ranges::lexicographical_compare(ia, ib, ci_less);
+```
+where `ia`/`ib` are the description strings.
+
+### Nit item #6 : Missing space after comma in `wmove` call
+
+Location: src/tuning/tuning.cpp : 110
+Description: `wmove(win, 2,0)` — the second comma is not followed by a space, inconsistent with the surrounding code style and with the argument formatting used elsewhere in the file.
+Severity rationale: Trivial formatting inconsistency.
+Suggested fix: `wmove(win, 2, 0);`
+
+## Review of src/tuning/tuningsysfs.cpp, src/tuning/tuningsysfs.h, src/tuning/nl80211.h, src/tuning/iw.h, src/tuning/iw.c — batch 06
+
+### Nit item #1 : Typo "blatently" in iw.h and iw.c comment headers
+
+Location: src/tuning/iw.h : 2  /  src/tuning/iw.c : 2
+Description: Both files contain `"This code has been blatently stolen from"`. The correct spelling is "blatantly".
+Severity rationale: Spelling typo in a comment.
+Suggested fix: Change "blatently" to "blatantly" in both files.
+
+### Nit item #2 : Missing blank line between last #include and first function definition
+
+Location: src/tuning/tuningsysfs.cpp : 38–39
+Description: `#include "../lib.h"` (line 38) is immediately followed by the `sysfs_tunable` constructor definition on line 39 with no separating blank line. Per the project's K&R-style layout convention, a blank line should separate the include block from the first declaration.
+Severity rationale: Minor formatting inconsistency.
+Suggested fix: Add a blank line between `#include "../lib.h"` and the constructor.
+
+### Nit item #3 : Double-underscore prefix on internal function __handle_cmd
+
+Location: src/tuning/iw.c : 200
+Description: The function is named `__handle_cmd`. Per the C and C++ standards, all identifiers beginning with two underscores (`__`) are reserved for the implementation (compiler/standard library). Using such a name in application/library code is technically undefined behaviour and may silently conflict with compiler builtins or future standard library additions.
+Severity rationale: Minor standards compliance issue; unlikely to cause practical problems in this codebase.
+Suggested fix: Rename to `handle_cmd_internal` or simply `do_handle_cmd`.
+
+## Review of tuningi2c.h, tuningi2c.cpp, powerconsumer.h, powerconsumer.cpp, processdevice.h — batch 07
+
+### Nit item #1 : Redundant `class` keyword in variable declaration and `new` expression
+
+Location: src/tuning/tuningi2c.cpp : 87, 96
+Description: `class i2c_tunable *i2c;` and `new class i2c_tunable(...)` use the redundant `class` keyword. In C++ the `class` elaborated-type-specifier is not needed when the type is already declared.
+Suggested fix: `i2c_tunable *i2c;` and `new i2c_tunable(...)`.
+
+### Nit item #2 : Redundant forward declaration of `power_consumer`
+
+Location: src/process/powerconsumer.h : 37
+Description: `class power_consumer;` is declared on line 37 and then immediately defined starting on line 39. The forward declaration is redundant.
+Suggested fix: Remove line 37.
+
+### Nit item #3 : Unused includes in tuningi2c.cpp
+
+Location: src/tuning/tuningi2c.cpp : 27, 28, 29
+Description: `<utility>`, `<iostream>`, and `<ctype.h>` are included but no symbols from these headers appear to be used in the file.
+Suggested fix: Remove the unused `#include` directives.
+
+### Nit item #4 : Mixed include order in tuningi2c.cpp
+
+Location: src/tuning/tuningi2c.cpp : 20-34
+Description: Per style.md §4.4, standard library headers should come first, followed by project-specific headers. Currently project headers (`"tuning.h"`, `"tunable.h"`, `"tuningi2c.h"`) are interleaved with system and C++ headers.
+Suggested fix: Reorder into two groups — (1) system/standard headers, (2) project headers — separated by a blank line.
+
+## Review of processdevice.cpp, process.h, process.cpp, work.cpp, work.h — batch 08
+
+### Nit item #1 : Trailing semicolons after closing brace of inline virtual methods
+
+Location: src/process/process.h : 63-64 ; src/process/work.h : 44-47
+Description: Inline virtual method definitions end with `};` (e.g., `virtual std::string name(void) { return "process"; };`). The semicolon after `}` is legal but redundant and inconsistent with the rest of the codebase.
+Severity rationale: Minor style nit.
+Suggested fix: Remove the trailing semicolons.
+
+### Nit item #2 : Unnecessary `class` keyword in `new` expressions and declarations
+
+Location: src/process/processdevice.cpp : 52, 79 ; src/process/process.cpp : 154, 161 ; src/process/work.cpp : 127
+Description: Expressions like `new class device_consumer(device)`, `class process *new_proc`, and `class work * work` use the `class` keyword redundantly. In C++ the `class` keyword is not needed when the class name is already in scope.
+Severity rationale: Style nit; no functional impact.
+Suggested fix: Remove the redundant `class` keyword: `new device_consumer(device)`, `process *new_proc`, etc.
+
+### Nit item #3 : Constructor implementation uses bare `string` instead of `std::string`
+
+Location: src/process/process.cpp : 83
+Description: The constructor definition `process::process(const string &_comm, ...)` uses the unqualified `string` while the declaration in `process.h` correctly uses `std::string`. This only compiles due to namespace pollution from `powerconsumer.h`.
+Severity rationale: Style inconsistency; should be `const std::string &_comm`.
+Suggested fix: Change to `process::process(const std::string &_comm, int _pid, int _tid)`.
+
+### Nit item #4 : `std::for_each` with a named helper function; range-for is more idiomatic
+
+Location: src/process/work.cpp : 89-97
+Description: `add_work` is a tiny static helper used only to bridge `std::for_each` into pushing to `all_power`. A range-based for loop is clearer and avoids the extra function:
+```cpp
+void all_work_to_all_power(void)
+{
+    for (auto &[key, w] : all_work)
+        all_power.push_back(w);
+}
+```
+Severity rationale: Readability nit.
+
+## Review of interrupt.h, interrupt.cpp, timer.cpp, timer.h, do_process.cpp — batch 09
+
+### Nit item #1 : Trailing semicolons after closing braces in inline method definitions
+
+Location: src/process/interrupt.h : 48, 49  /  src/process/timer.h : 46, 47
+Description: Inline method definitions end with `};` (a semicolon after the closing brace of the function body). This is valid C++ but the trailing semicolon is redundant and not present elsewhere in the codebase.
+Severity rationale: Minor style inconsistency.
+Suggested fix: Remove the trailing semicolons: `{ return "interrupt"; }` not `{ return "interrupt"; };`.
+
+### Nit item #2 : Mixed space+tab indentation on line 330
+
+Location: src/process/do_process.cpp : 330
+Description: Line 330 (`return;` inside the `sched_wakeup` handler's field check) starts with a space character followed by tabs, inconsistent with the tab-only indentation rule.
+Severity rationale: Trivial whitespace inconsistency.
+Suggested fix: Replace leading space+tabs with pure tabs.
+
+### Nit item #3 : Double space in static pointer declaration
+
+Location: src/process/do_process.cpp : 50
+Description: `static  class perf_bundle * perf_events;` has two consecutive spaces between `static` and `class`.
+Severity rationale: Trivial cosmetic issue.
+Suggested fix: `static class perf_bundle *perf_events;`
+
+### Nit item #4 : raw_count is int but is only ever incremented
+
+Location: src/process/interrupt.h : 39  /  src/process/timer.h : 36
+Description: `raw_count` is declared as `int` in both `interrupt` and `timer`. It is only ever incremented, never assigned a negative value, and compared/used as a count. Using `unsigned int` (or `uint32_t`) would better express the invariant that it is always non-negative.
+Severity rationale: Minor type-semantics mismatch.
+Suggested fix: Change to `unsigned int raw_count;` in both classes.
+
+## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
+
+### Nit item #1 : Old-style `#ifndef` include guards instead of `#pragma once`
+
+Location: src/perf/perf.h : 25, src/perf/perf_bundle.h : 25
+Description: Both headers use traditional `#ifndef/#define/#endif` include guards. The project style guide specifies `#pragma once`.
+Suggested fix: Replace the guard triplet with `#pragma once` at the top of each header.
+
+### Nit item #2 : `#include <errno.h>` duplicated in perf.cpp
+
+Location: src/perf/perf.cpp : 29, 33
+Description: `<errno.h>` is included twice. The second inclusion is redundant.
+Suggested fix: Remove the duplicate include on line 33.
+
+### Nit item #3 : `int event_added = false;` — wrong type for boolean
+
+Location: src/perf/perf_bundle.cpp : 98
+Description: `event_added` is used as a boolean flag but declared as `int` and initialized with `false`. Should be `bool`.
+Suggested fix: `bool event_added = false;`
+
+### Nit item #4 : `records.resize(0)` should be `records.clear()`
+
+Location: src/perf/perf_bundle.cpp : 162
+Description: `records.resize(0)` is a roundabout way to empty a vector. `records.clear()` is the idiomatic and more readable form.
+Suggested fix: `records.clear();`
+
+### Nit item #5 : Double semicolon in `struct trace_entry` declaration
+
+Location: src/perf/perf_bundle.cpp : 171
+Description: `} __attribute__((packed));;` — there are two semicolons ending the struct declaration. One is redundant.
+Suggested fix: Remove the extra semicolon: `} __attribute__((packed));`
+
+### Nit item #6 : Zero-length array `data[0]` is non-standard C++
+
+Location: src/perf/perf_bundle.cpp : 177
+Description: `unsigned char data[0];` is a GCC extension. In standard C99/C11 the flexible array member syntax is `unsigned char data[];`; in C++ flexible array members are not standard at all. Since this is a `__attribute__((packed))` kernel-ABI struct used only for casting, a comment explaining the situation would be helpful.
+Suggested fix: At minimum, change to `unsigned char data[];` for C99 conformance; add a comment noting this is a zero-length trailing array for direct pointer arithmetic into the mmap ring buffer.
+
+### Nit item #7 : `#if 0` dead debug code block
+
+Location: src/perf/perf_bundle.cpp : 188
+Description: A large `#if 0 ... #endif` block containing `printf` debug statements is left in the source. This should be removed.
+Suggested fix: Delete lines 188–212.
+
+### Nit item #8 : `#include <iostream>` in headers where it is unused
+
+Location: src/perf/perf.h : 28, src/perf/perf_bundle.h : 28
+Description: Both headers include `<iostream>` but do not use anything from it directly (no `std::cin`, `std::cout`, or `std::cerr` declarations). This header is heavy and slows compilation.
+Suggested fix: Remove `#include <iostream>` from both headers. Include it in `.cpp` files that actually use stream I/O.
+
+### Nit item #9 : Missing blank line between consecutive function definitions
+
+Location: src/perf/perf_bundle.cpp : 134
+Description: The `start()` and `stop()` function definitions are not separated by a blank line. Similarly `stop()` and `clear()` run together. Consistent blank lines between function definitions improve readability.
+Suggested fix: Add a blank line between the closing `}` of `start()` and the opening of `stop()`, and between `stop()` and `clear()`.
+
+### Nit item #10 : Unused `#include <map>` in perf_bundle.h
+
+Location: src/perf/perf_bundle.h : 31
+Description: `<map>` is included but `std::map` is not used anywhere in `perf_bundle.h` or `perf_bundle.cpp`.
+Suggested fix: Remove the `#include <map>` line.
+
+## Review of persistent.cpp, parameters.cpp, parameters.h, learn.cpp, report-formatter.h — batch 11
+
+### Nit item #1 : Typo "patameters" in `dump_parameter_bundle` declaration
+
+Location: src/parameters/parameters.h : 94
+Description: The function declaration reads `void dump_parameter_bundle(struct parameter_bundle *patameters = &all_parameters);` — the parameter name is misspelled "patameters" instead of "parameters".
+Severity rationale: Cosmetic typo in a parameter name.
+Suggested fix: Rename to `parameters`.
+
+### Nit item #2 : `int` used as boolean for `first` and `bundle_saved` in `load_results`
+
+Location: src/parameters/persistent.cpp : 79, 82
+Description: `int first = 1;` and `int bundle_saved = 0;` use plain `int` to represent boolean state. C++ has `bool` for this purpose.
+Severity rationale: Minor style issue.
+Suggested fix: Declare as `bool first = true;` and `bool bundle_saved = false;`.
+
+### Nit item #3 : Inconsistent indentation inside `if (debug_learning)` block in `learn_parameters`
+
+Location: src/parameters/learn.cpp : 254
+Description: The `printf("delta is %5.4f\n", delta);` line at line 254 has an extra level of indentation compared to the surrounding `printf` calls within the same `if` block, breaking the consistent tab-based indentation of the file.
+Severity rationale: Pure style nit.
+Suggested fix: Align the line with its neighbours inside the `if (debug_learning)` block.
+
+### Nit item #4 : Multiple blocks of commented-out code left in place
+
+Location: src/parameters/learn.cpp : 121–122, 199, 223, 280 ; src/parameters/persistent.cpp : 151
+Description: Several blocks of commented-out `printf` / debug statements and a commented-out early-return guard are left in production code. Dead code hurts readability.
+Severity rationale: Readability nit.
+Suggested fix: Remove all commented-out code. If debug dumps are sometimes needed, guard them with `if (debug_learning)` instead.
+
+## Review of report-formatter-html.h, report.cpp, report.h, report-formatter-csv.h, report-maker.cpp — batch 12
+
+### Nit item #1 : Space indentation instead of tabs on one line
+
+Location: report.cpp : 126
+Description: `        init_title_attr(&title_attr);` uses 8 spaces for indentation rather than a single tab. The style guide mandates tab-only indentation throughout.
+Severity rationale: Minor, single-line style inconsistency.
+Suggested fix: Replace the 8 leading spaces with a single tab character.
+
+### Nit item #2 : Missing braces and misaligned bodies on consecutive `if` statements
+
+Location: report.cpp : 153-155
+Description: Three `if` statements share a pattern where the body is on the same line as the condition with no braces and without indentation, e.g.:
+```cpp
+if (str.length() < 1)
+str = read_sysfs_string("/etc/redhat-release");
+```
+The K&R/Linux style used throughout the project requires braces for all multi-line control-flow blocks, and the body must be indented one level. Also, `str.length() < 1` is better written as `str.empty()`.
+Severity rationale: Style violation; the missing indentation could confuse a reader into thinking the body is unconditional.
+Suggested fix:
+```cpp
+if (str.empty())
+    str = read_sysfs_string("/etc/redhat-release");
+if (str.empty())
+    str = read_os_release("/etc/os-release");
+```
+(Use tabs for indentation.)
+
+## Review of report-maker.h, report-data-html.cpp, report-data-html.h, report-formatter-base.cpp, report-formatter-base.h — batch 13
+
+### Nit item #1 : Inconsistent indentation (spaces instead of tab) in `report-maker.h`
+
+Location: src/report/report-maker.h : 110
+Description: The destructor declaration `~report_maker();` is indented with 7 spaces instead of a single tab. Every other declaration in the class is tab-indented. Style guide mandates tabs only (style.md §1.1).
+Suggested fix: Replace the leading spaces with a single tab character.
+
+### Nit item #2 : Missing spaces around `=` in assignments in `report-data-html.cpp`
+
+Location: src/report/report-data-html.cpp : 5–6, 23–24, 29–35, and throughout
+Description: Many assignments lack spaces around the `=` operator, e.g. `div_attr->css_class=css_class;` and `str= dtmp.str();` (line 123). The project style follows standard K&R/Linux conventions that place spaces around binary operators.
+Suggested fix: Add spaces around `=` consistently, e.g. `div_attr->css_class = css_class;`.
+
+### Nit item #3 : `table_size` struct appears to be dead code
+
+Location: src/report/report-data-html.h : 27–30
+Description: The `table_size` struct (fields `rows` and `cols`) is declared but not referenced anywhere in the reviewed files or in the wider `src/report/` directory. It duplicates a subset of `table_attributes`.
+Suggested fix: Remove the unused `table_size` struct, or document its intended use.
+
+### Nit item #4 : Opening brace on same line as function parameter list in `report-data-html.cpp`
+
+Location: src/report/report-data-html.cpp : 10, 27, 37, 49, 61, 72, 85, 96, 106
+Description: Multiple function definitions place `{` on the same line as the closing `)` of the parameter list (e.g., `int rows, int cols){`). The project style guide (style.md §1.2) requires the opening brace of a function definition to be on its own line.
+Suggested fix: Move the `{` to the next line for each affected function.
+
+## Review of report-formatter-csv.cpp, report-formatter-html.cpp, dram_rapl_device.cpp, dram_rapl_device.h, cpu_linux.cpp — batch 14
+
+### Nit item #1 : Empty `init_markup()` body with placeholder comment
+
+Location: src/report/report-formatter-html.cpp : 61-63
+Description: `init_markup()` contains only the comment `/*here all html code*/` and is otherwise empty. It is called from the constructor but does nothing. This is dead placeholder code that adds noise without value.
+Severity rationale: Code quality nit; no functional impact.
+Suggested fix: Either populate the function or remove it and remove the call from the constructor.
+
+### Nit item #2 : C-style `(void)` parameter syntax in C++ code
+
+Location: src/cpu/dram_rapl_device.h : 52-53
+Description: `start_measurement(void)` and `end_measurement(void)` use the C-style explicit `void` parameter list. In C++, empty parentheses `()` are idiomatic and mean the same thing. This is a style inconsistency.
+Severity rationale: Purely cosmetic; no semantic difference in C++.
+Suggested fix:
+```cpp
+void start_measurement();
+void end_measurement();
+```
+
+### Nit item #3 : Trailing semicolons on method bodies in `dram_rapl_device.h`
+
+Location: src/cpu/dram_rapl_device.h : 48-49
+Description: The inline method definitions `{return "DRAM";}` are followed by an extra `;` after the closing brace (e.g., `virtual std::string device_name(void) {return "DRAM";};`). While harmless in C++, the trailing semicolons are unnecessary and inconsistent with the rest of the codebase.
+Severity rationale: Cosmetic nit.
+Suggested fix: Remove the trailing `;` after each method body's closing `}`.
+
+## Review of src/cpu/cpu_core.cpp, src/cpu/cpudevice.h, src/cpu/cpudevice.cpp, src/cpu/abstract_cpu.cpp, src/cpu/cpu_rapl_device.cpp — batch 15
+
+### Nit item #1 : Double semicolons `;;` in cpudevice.cpp constructor
+
+Location: src/cpu/cpudevice.cpp : 39-42
+Description: Each of the four index-initialisation lines ends with `;;` (double semicolons):
+e.g. `wake_index = get_param_index("cpu-wakeups");;`. This is a harmless no-op (an empty
+statement), but is clearly a typo and looks sloppy.
+Suggested fix: Remove the extra semicolons so each line ends with a single `;`.
+
+### Nit item #2 : Missing space around `==` operator in cpu_core.cpp
+
+Location: src/cpu/cpu_core.cpp : 78
+Description: `if (total_stamp ==0)` is missing a space before `==`. The project style (K&R /
+Linux kernel variant) requires spaces around binary operators.
+Suggested fix: Change to `if (total_stamp == 0)`.
+
+### Nit item #3 : `last_stamp = 0` assigned twice in `measurement_start`
+
+Location: src/cpu/abstract_cpu.cpp : 98, 127
+Description: `last_stamp = 0;` appears on line 98 and again on line 127 in the same function
+body with no intervening code that could change it. The second assignment is redundant.
+Suggested fix: Remove the duplicate assignment on line 127.
+
+### Nit item #4 : Unqualified `string` used in function signatures
+
+Location: src/cpu/cpu_core.cpp : 33; src/cpu/abstract_cpu.cpp : 262, 284, 343, 383
+Description: Several function signatures use unqualified `string` (e.g.
+`const string &linux_name`) rather than `std::string`. This only compiles because `cpu.h`
+contains `using namespace std;` (a separate violation). Style.md §4.3 and general-c++.md
+both require the `std::` prefix.
+Suggested fix: Use `const std::string &` consistently in all signatures.
+
+### Nit item #5 : Redundant loop-variable initialisation in destructor
+
+Location: src/cpu/abstract_cpu.cpp : 37-38
+Description: The destructor declares `unsigned int i=0;` and then immediately re-initialises
+it in the `for` statement (`for (i=0; ...)`). The separate declaration with `=0` is redundant.
+Suggested fix: Declare `i` inside the `for` statement: `for (unsigned int i = 0; i < cstates.size(); i++)`.
+
+## Review of src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp — batch 16
+
+### Nit item #1 : Missing spaces around operators and after commas
+
+Location: src/cpu/cpu_package.cpp : 88; src/cpu/cpu.cpp : 500, 708, 837, 466-468
+Description: Several places have missing spaces around operators and assignment:
+- `total_stamp ==0` (cpu_package.cpp:88, also intel_cpus.cpp:352, 484, 712)
+- `cpu_tbl_size.cols=(2 * ...` — no space around `=` (cpu.cpp:500)
+- `wmove(win, 2,0)` — no space after comma (cpu.cpp:837)
+- `idx1=0; idx2=0; idx3=0;` — no spaces around `=` (cpu.cpp:466-468)
+The project style uses spaces around operators consistently throughout other files.
+Severity rationale: Pure cosmetic style issue.
+Suggested fix: Add spaces to match project style: `total_stamp == 0`, `idx1 = 0`, etc.
+
+### Nit item #2 : Bare `string` without `std::` in .cpp files
+
+Location: src/cpu/cpu.cpp : 462, 661; src/cpu/cpu_package.cpp : 43
+Description: `string tmp_str;` (cpu.cpp:462, 661) and `const string &separator`
+(cpu_package.cpp:43) use unqualified `string` instead of `std::string`. These work
+only because of the `using namespace std;` in the included headers; once that is
+corrected these will need to be qualified.
+Severity rationale: Style issue that will become a compile error once `using namespace std` is removed from headers.
+Suggested fix: Use `std::string` consistently.
+
+### Nit item #3 : Mixed indentation (spaces instead of tabs) in cpu.cpp
+
+Location: src/cpu/cpu.cpp : 461, 656, 837
+Description: Several lines use leading spaces instead of tabs for indentation
+(e.g. `       \tint idx1, idx2, idx3;` at line 461, `        report.add_div(...)` at line
+656, `        wmove(win, 2,0)` at line 837). The project style mandates tabs only.
+Severity rationale: Pure cosmetic style issue.
+Suggested fix: Convert leading spaces to tabs in these lines.
+
+## Review of src/cpu/intel_cpus.h, src/cpu/intel_gpu.cpp, src/cpu/rapl/rapl_interface.cpp, src/wakeup/wakeup.h — batch 17
+
+### Nit item #1 : Trailing semicolon after inline method closing brace
+
+Location: src/cpu/intel_cpus.h : 86, 109, 128
+Description: Three inline method definitions end with `{ return 0;};` — the trailing semicolon after `}` is redundant. Example: `virtual int can_collapse(void) { return 0;};`. In standard C++ the semicolon after a function body's `}` is only required for class/struct definitions, not for member function definitions.
+Severity rationale: Minor style noise; superfluous punctuation.
+Suggested fix: Remove the trailing semicolons: `virtual int can_collapse(void) { return 0; }`.
+
+### Nit item #2 : Typo in MSR define names — `ENERY` instead of `ENERGY`
+
+Location: src/cpu/rapl/rapl_interface.cpp : 50, 55, 60, 66
+Description: Four `#define` constants are misspelled: `MSR_PKG_ENERY_STATUS`, `MSR_DRAM_ENERY_STATUS`, `MSR_PP0_ENERY_STATUS`, `MSR_PP1_ENERY_STATUS`. The word "ENERGY" is missing its second 'G'.
+Severity rationale: Cosmetic typo in macro names; no functional impact since the names are used consistently.
+Suggested fix: Rename all four macros to use `ENERGY` and update all references.
+
+### Nit item #3 : Trailing whitespace in intel_gpu.cpp switch statement
+
+Location: src/cpu/intel_gpu.cpp : 68
+Description: The line `switch (line_nr) {` is followed by a trailing tab character, violating the "no trailing whitespace" rule from style.md §1.1.
+Severity rationale: Trailing whitespace style violation.
+Suggested fix: Remove the trailing tab.
+
+### Nit item #4 : Missing space in `#include<vector>` directive
+
+Location: src/wakeup/wakeup.h : 28
+Description: The include directive is written as `#include<vector>` without the conventional space between `#include` and the angle-bracket filename. All other includes in the project and file use `#include <...>`.
+Severity rationale: Minor inconsistency in formatting.
+Suggested fix: Change to `#include <vector>`.
+
+## Review of wakeup_usb.h, wakeup_ethernet.h, waketab.cpp, wakeup_ethernet.cpp, wakeup.cpp — batch 18
+
+### Nit item #1 : missing spaces around `=` and before `{` in report_show_wakeup
+
+Location: src/wakeup/waketab.cpp : 141-142
+Description: Line 141 has `if (rows > 0){` (missing space before `{`), and line 142 has `rows= rows + 1;` (missing space after `=`). Both are style violations per the K&R/Linux coding style used by the project.
+Severity rationale: Nit — purely cosmetic, but inconsistent with the surrounding code.
+Suggested fix:
+```cpp
+if (rows > 0) {
+    rows = rows + 1;
+```
+
+### Nit item #2 : redundant `string(...)` cast in report_show_wakeup
+
+Location: src/wakeup/waketab.cpp : 158
+Description: `wakeup_data[idx] = string(wakeup_all[i]->wakeup_toggle_script())` — the explicit `string()` constructor call is redundant because `wakeup_toggle_script()` already returns `std::string`, and the assignment operator would copy-assign it directly.
+Severity rationale: Nit — no functional issue; just unnecessary noise.
+Suggested fix:
+```cpp
+wakeup_data[idx] = wakeup_all[i]->wakeup_toggle_script();
+```
+
+### Nit item #3 : inconsistent loop variable names (tgb vs gb) in report_show_wakeup
+
+Location: src/wakeup/waketab.cpp : 133, 153
+Description: The first loop uses `int tgb` and the second loop uses `int gb` for the same logical value (result of `wakeup_value()`). The inconsistency makes the relationship between the two loops harder to see and suggests the code was written in separate passes.
+Severity rationale: Nit — no functional impact; purely a readability issue.
+Suggested fix: Use a consistent name, e.g., `val`, in both loops.
+
+### Nit item #4 : missing space after comma in wmove call
+
+Location: src/wakeup/waketab.cpp : 69
+Description: `wmove(win, 1,0)` is missing a space after the second comma. The rest of the codebase consistently puts a space after each comma in argument lists.
+Severity rationale: Nit — cosmetic style inconsistency.
+Suggested fix: `wmove(win, 1, 0);`
+
+## Review of src/wakeup/wakeup_usb.cpp, src/measurement/acpi.cpp, src/measurement/acpi.h, src/measurement/opal-sensors.cpp, src/measurement/opal-sensors.h — batch 19
+
+### Nit item #1 : Redundant `class` keyword in `new` expression
+
+Location: src/wakeup/wakeup_usb.cpp : 104
+Description: `usb = new class usb_wakeup(filename, d_name);` — the `class` keyword before the type name in a `new` expression is valid C++ but entirely redundant and unusual. This is a C-ism not needed in C++.
+Severity rationale: Nit — purely stylistic, no functional impact.
+Suggested fix: `usb = new usb_wakeup(filename, d_name);`
+
+### Nit item #2 : GCC `__unused` attribute instead of C++17 `[[maybe_unused]]`
+
+Location: src/wakeup/wakeup_usb.cpp : 48
+Description: The `path` constructor parameter uses the GCC-specific `__unused` macro instead of the standard C++17 (and C++20) attribute `[[maybe_unused]]`. The project targets C++20 and should use standard attributes.
+Severity rationale: Nit — non-portable; `[[maybe_unused]]` is the correct C++ idiom.
+Suggested fix: `usb_wakeup::usb_wakeup(const std::string &path [[maybe_unused]], const std::string &iface)`
+
+### Nit item #3 : Unprofessional comment in `acpi_power_meter::measure()`
+
+Location: src/measurement/acpi.cpp : 111
+Description: The comment reads `/* BIOS report random crack-inspired units. Lets try to get to the Si-system units */`. The phrase "crack-inspired" is unprofessional and inappropriate in a project codebase. Minor grammar issue: "Lets" should be "Let's".
+Severity rationale: Nit — code quality and professionalism.
+Suggested fix: Replace with: `/* BIOS firmware may report non-SI units; normalise to SI. */`
+
+### Nit item #4 : Old-style `#ifndef` header guard in acpi.h
+
+Location: src/measurement/acpi.h : 25-26
+Description: Uses `#ifndef __INCLUDE_GUARD_ACPI_H` / `#define __INCLUDE_GUARD_ACPI_H` instead of `#pragma once` as required by the project style guide (style.md §4.1).
+Severity rationale: Nit — direct style-guide violation; `#pragma once` is simpler and universally supported by all targeted compilers.
+Suggested fix: Replace lines 25-26 and 44 with a single `#pragma once`.
+
+### Nit item #5 : Old-style `#ifndef` header guard in opal-sensors.h
+
+Location: src/measurement/opal-sensors.h : 25-26
+Description: Same as Nit item #4 above — uses `#ifndef INCLUDE_GUARD_OPAL_SENSORS_H` instead of `#pragma once`.
+Severity rationale: Nit — same rationale.
+Suggested fix: Replace with `#pragma once`.
+
+### Nit item #6 : Trailing semicolon after empty function bodies in opal-sensors.h
+
+Location: src/measurement/opal-sensors.h : 34-35
+Description: `virtual void start_measurement(void) {};` and `virtual void end_measurement(void) {};` have a trailing `;` after the closing brace. While syntactically valid (it is an empty statement), this is not idiomatic C++ and is not used consistently elsewhere.
+Severity rationale: Nit — minor style inconsistency.
+Suggested fix: Remove the trailing `;` from both lines.
+
+### Nit item #7 : Unnecessary `#include <iostream>` in acpi.cpp
+
+Location: src/measurement/acpi.cpp : 27
+Description: `<iostream>` is included but no `std::cin`, `std::cout`, `std::cerr`, or any other iostream symbol is used anywhere in the file. This is a dead include.
+Severity rationale: Nit — dead include, minor readability issue.
+Suggested fix: Remove `#include <iostream>`.
+
+## Review of sysfs.h, sysfs.cpp, measurement.h, measurement.cpp, extech.h — batch 20
+
+### Nit item #1 : Redundant `this->` in sysfs_power_meter::measure
+
+Location: src/measurement/sysfs.cpp : 133, 139
+Description: `this->set_discharging(false)` and `this->set_discharging(true)` use an explicit `this->` that is unnecessary in non-template context. The calls are unambiguous without it.
+Severity rationale: Purely cosmetic; no functional impact.
+Suggested fix: Remove `this->` and write `set_discharging(false);` / `set_discharging(true);`.
+
+### Nit item #2 : Redundant default-initialization of `name` in power_meter default constructor
+
+Location: src/measurement/measurement.h : 38
+Description: `power_meter() : name("") {}` explicitly initializes `std::string name` to an empty string. `std::string` already default-initializes to `""`, so the explicit initializer is redundant.
+Severity rationale: Cosmetic/clarity.
+Suggested fix: `power_meter() = default;` or simply `power_meter() {}`.
+
+### Nit item #3 : Stray semicolons after closing brace `}` in class bodies
+
+Location: src/measurement/measurement.h : 39; src/measurement/extech.h : 47
+Description: Both `virtual ~power_meter() {};` and `virtual double dev_capacity(void) { return 0.0; };` have a trailing semicolon after the closing `}` of the inline body. The semicolon is syntactically harmless (empty declaration) but is not idiomatic and may confuse readers.
+Severity rationale: Cosmetic.
+Suggested fix: Remove the trailing semicolons.
+
+### Nit item #4 : `new class extech_power_meter` uses C-style `class` keyword
+
+Location: src/measurement/measurement.cpp : 183
+Description: `new class extech_power_meter(devnode)` prefixes the type name with `class`, which is a C-style elaborated type specifier. In idiomatic C++ the `class` keyword is omitted in expressions.
+Severity rationale: Cosmetic; compiles correctly but is non-idiomatic.
+Suggested fix: `new extech_power_meter(devnode)` (also apply `std::nothrow` per Medium item #5).
+
+### Nit item #5 : Local variable names shadow virtual method names in sysfs.cpp
+
+Location: src/measurement/sysfs.cpp : 72, 86, 102, 115
+Description: Local variable names `power`, `current`, `energy`, and `charge` shadow the inherited virtual method `power_meter::power()`. The code compiles correctly because C++ disambiguates method calls from variables, but the shadowing makes the code harder to read at a glance.
+Severity rationale: Readability; no functional impact.
+Suggested fix: Rename the locals to e.g. `power_uw`, `current_ua`, `energy_uwh`, `charge_uah` to reflect their units and avoid shadowing.
+
+## Review of src/measurement/extech.cpp, src/devices/backlight.cpp — batch 21
+
+### Nit item #1 : C-style cast and `return 0` instead of `nullptr` in thread_proc
+
+Location: src/measurement/extech.cpp : 321-323
+Description: `thread_proc` uses a C-style cast `(class extech_power_meter*)arg` instead of `static_cast<extech_power_meter*>(arg)`, and returns `0` instead of `nullptr` for a `void *` return type.
+Severity rationale: Style nit; C-style casts are discouraged in C++20.
+Suggested fix: `return static_cast<extech_power_meter*>(arg);` pattern plus `return nullptr;`.
+
+### Nit item #2 : `&p.buf` passed to read() instead of `p.buf`
+
+Location: src/measurement/extech.cpp : 258
+Description: `read(fd, &p.buf, 250)` takes the address of the array `p.buf`, yielding a `char (*)[256]` rather than a `char *`. Both decay to the same pointer value, so it works, but it is technically taking the address of the array object, not a pointer to the first element.
+Severity rationale: Cosmetic; no practical impact due to pointer equivalence.
+Suggested fix: Change to `read(fd, p.buf, 250)`.
+
+### Nit item #3 : `bl_boost_index80` and `bl_boost_index100` not explicitly zero-initialized
+
+Location: src/devices/backlight.cpp : 143
+Description: The static local variables `bl_boost_index80` and `bl_boost_index100` are declared without an explicit initializer in the same declaration that zero-initializes the other four variables. They are implicitly zero-initialized because they are `static`, but the omission is inconsistent and confusing.
+Severity rationale: Cosmetic inconsistency.
+Suggested fix: Add `= 0` to both: `static int bl_index = 0, blp_index = 0, bl_boost_index40 = 0, bl_boost_index80 = 0, bl_boost_index100 = 0;`.
+
+### Nit item #4 : Extra space before `<` operator in rfkill::utilization()
+
+Location: src/devices/rfkill.cpp : 97
+Description: `if (rfk <  start_hard+end_hard)` has two spaces before `start_hard`, and no spaces around the `+` operators. Inconsistent spacing.
+Severity rationale: Formatting nit.
+Suggested fix: `if (rfk < start_hard + end_hard)`.
+
+### Nit item #5 : `for (i = 0; i < 1; i++)` is an unnecessary loop for a single iteration
+
+Location: src/measurement/extech.cpp : 222
+Description: A `for` loop that always executes exactly once (bound of `< 1`) adds no value and obscures the intent. Either the bound is wrong (see Medium item #3) or the loop should be removed.
+Severity rationale: Clarity nit.
+Suggested fix: If only one iteration is intended, remove the loop and use `i = 0` directly. If four iterations are intended, fix the bound as noted in Medium item #3.
+
+## Review of src/devices/usb.h, src/devices/usb.cpp, src/devices/gpu_rapl_device.h, src/devices/gpu_rapl_device.cpp, src/devices/ahci.h — batch 22
+
+### Nit item #1 : Spaces instead of tabs on usb.cpp line 120
+
+Location: src/devices/usb.cpp : 120
+Description: The line `        register_devpower(devfs_name, power_usage(results, bundle), this);` uses 8 spaces for indentation instead of a tab character. Every other line in the file uses tabs. The project style (`style.md §1.1`) mandates tabs only.
+Severity rationale: Style nit; single inconsistent indentation character.
+Suggested fix: Replace the leading 8 spaces with a single tab.
+
+### Nit item #2 : C-style `(void)` parameter notation in method declarations
+
+Location: src/devices/usb.h : 50-61, src/devices/ahci.h : 53-56, src/devices/gpu_rapl_device.h : 47-53
+Description: Methods are declared with `(void)` to indicate no parameters (e.g., `virtual void start_measurement(void);`). In C++ the idiomatic form is empty parentheses `()`. The `(void)` form is a C90 convention to distinguish "no parameters" from "unspecified parameters" — a distinction that does not apply in C++.
+Severity rationale: Style nit; C idiom in C++ code.
+Suggested fix: Change all `(void)` parameter lists to `()` in method declarations.
+
+### Nit item #3 : Extra blank line inside usb.cpp constructor body
+
+Location: src/devices/usb.cpp : 63
+Description: There is a blank line between the `cached_valid = 0;` statement and the `/* root ports and hubs ... */` comment inside the constructor. While a single blank line for visual grouping is fine, the line at 63 is entirely redundant as line 62 already provides separation. Minor visual noise.
+Severity rationale: Style nit.
+Suggested fix: Remove the extra blank line.
+
+
+## Review of src/devices/ahci.cpp, src/devices/thinkpad-fan.h, src/devices/thinkpad-fan.cpp, src/devices/device.h, src/devices/device.cpp — batch 23
+
+### Nit item #1 : Space indentation instead of tabs in `report_devices`
+
+Location: src/devices/device.cpp : 155–156, 160–161
+Description: Lines `if (!win)`, `return;`, `wclear(win);`, and `wmove(win, 2,0);` are indented with 8 spaces instead of a tab. style.md §1.1 requires "Tabs only" for indentation.
+Severity rationale: Style inconsistency; does not affect behaviour.
+Suggested fix: Replace the leading spaces on those lines with a single tab character.
+
+### Nit item #2 : Missing spaces around `==` operator in character comparisons
+
+Location: src/devices/ahci.cpp : 61, 91
+Description: `d_name[0]=='.'` (line 61 and similarly line 91) omits spaces around the `==` operator. The project consistently uses spaces around binary operators elsewhere.
+Severity rationale: Minor style inconsistency.
+Suggested fix: `d_name[0] == '.'`
+
+### Nit item #3 : Missing space before `{` in `for` loop
+
+Location: src/devices/ahci.cpp : 299
+Description: `for (i = 0; i < links.size(); i++){` — the opening brace immediately follows `)` with no space. style.md §1.2 (K&R style) requires a space before `{`.
+Severity rationale: Style inconsistency.
+Suggested fix: `for (i = 0; i < links.size(); i++) {`
+
+### Nit item #4 : Extra semicolons after inline method definition closing braces in thinkpad-fan.h
+
+Location: src/devices/thinkpad-fan.h : 45–52
+Description: Inline methods such as `virtual std::string class_name(void) { return "fan";};` have a redundant `;` after the closing `}`. The `;` is not illegal (it is an empty declaration) but is unnecessary and inconsistent with common style.
+Severity rationale: Cosmetic; harmless.
+Suggested fix: Remove the trailing `;` after each inline method body's `}`.
+
+### Nit item #5 : String parameter `shortname` marked `__unused` but passed to recursive helper
+
+Location: src/devices/ahci.cpp : 47
+Description: `disk_name` accepts `const string &shortname __unused`, marking the parameter as unused. However, the function does use `shortname` conceptually (it was passed for fallback use); the `__unused` attribute suppresses the warning but also obscures intent. More precisely, the variable is genuinely unused inside `disk_name` — it was passed in but the code never reads it. Consider removing the parameter entirely and updating the call site in `model_name` at line 98 (`disk_name(pathname, d_name, shortname)` → `disk_name(pathname, d_name)`).
+Severity rationale: Interface clarity nit; unused parameter that is silently ignored.
+Suggested fix: Remove `shortname` from the `disk_name` signature and its call site.
+## Review of src/devices/devfreq.cpp, src/devices/devfreq.h, src/devices/alsa.h, src/devices/alsa.cpp, src/devices/runtime_pm.cpp — batch 24
+
+### Nit item #1 : Trailing semicolons after closing braces on inline virtual functions in devfreq.h
+
+Location: src/devices/devfreq.h : 59-65
+Description: Inline virtual method definitions end with `};` (semicolon after the closing brace), e.g. `virtual std::string class_name(void) { return "devfreq";};`. The trailing semicolon is not required and inconsistent with the rest of the codebase.
+Severity rationale: Minor style nit; not a correctness issue.
+Suggested fix: Remove the trailing semicolons: `virtual std::string class_name(void) { return "devfreq"; }`
+
+### Nit item #2 : Missing spaces around operators in `for` loop in devfreq.cpp
+
+Location: src/devices/devfreq.cpp : 76, 108, 164, 213, 220, 287, 292, 315, 318
+Description: Several `for` loops use compact forms like `for (i=0; i<all_devfreq.size(); i++)` without spaces around `=` and `<`. The project style follows Linux kernel conventions which use `i = 0`, `i < n`, `i++` with spaces.
+Severity rationale: Cosmetic style inconsistency.
+Suggested fix: `for (i = 0; i < all_devfreq.size(); i++)`
+
+### Nit item #3 : `parse_devfreq_trans_stat()` parameter `dname` is unused
+
+Location: src/devices/devfreq.cpp : 121
+Description: The function signature is `void devfreq::parse_devfreq_trans_stat(const string &dname __unused)` but the function always uses the member variable `dir_name` instead of the parameter. The `__unused` annotation confirms the parameter is never read. The parameter should either be removed or the function refactored to use it.
+Severity rationale: Dead parameter causes confusion about the function's interface.
+Suggested fix: Remove the `dname` parameter and update the declaration in devfreq.h accordingly; the function uses `dir_name` exclusively.
+
+### Nit item #4 : `update_devfreq_freq_state()` does not break early on match
+
+Location: src/devices/devfreq.cpp : 108-111
+Description: The loop in `update_devfreq_freq_state()` scans the entire `dstates` vector even after finding the matching frequency. A `break` after the assignment on line 110 would avoid unnecessary iterations.
+Severity rationale: Minor inefficiency; no correctness impact.
+Suggested fix: Add `break;` after `state = dstates[i];` inside the `if` branch.

--- a/logs.1/summary.md
+++ b/logs.1/summary.md
@@ -1,0 +1,60 @@
+# PowerTOP Code Review — Summary
+
+## Batch 01 — src/calibrate/calibrate.cpp, src/calibrate/calibrate.h, src/lib.cpp, src/devlist.cpp, src/main.cpp
+- Critical: 0  High: 5  Medium: 10  Low: 7  Nit: 5
+
+## Batch 02 — src/test_framework.h, src/test_framework.cpp, src/display.cpp, src/display.h, src/lib.h
+- Critical: 0  High: 4  Medium: 11  Low: 7  Nit: 7
+
+## Batch 03 — src/devlist.h, src/tuning/tunable.cpp, src/tuning/tunable.h, src/tuning/runtime.h, src/tuning/runtime.cpp
+- Critical: 0  High: 3  Medium: 7  Low: 7  Nit: 7
+
+## Batch 04 — src/tuning/ethernet.cpp, src/tuning/ethernet.h, src/tuning/wifi.cpp, src/tuning/wifi.h, src/tuning/tuningusb.h
+- Critical: 0  High: 6  Medium: 6  Low: 5  Nit: 4
+
+## Batch 05 — src/tuning/tuningusb.cpp, src/tuning/tuning.cpp, src/tuning/tuning.h, src/tuning/bluetooth.cpp, src/tuning/bluetooth.h
+- Critical: 0  High: 3  Medium: 6  Low: 8  Nit: 6
+
+## Batch 06 — src/tuning/tuningsysfs.cpp, src/tuning/tuningsysfs.h, src/tuning/nl80211.h, src/tuning/iw.h, src/tuning/iw.c
+- Critical: 0  High: 3  Medium: 5  Low: 8  Nit: 3
+
+## Batch 07 — src/tuning/tuningi2c.h, src/tuning/tuningi2c.cpp, src/process/powerconsumer.h, src/process/powerconsumer.cpp, src/process/processdevice.h
+- Critical: 0  High: 1  Medium: 8  Low: 7  Nit: 4
+
+## Batch 08 — src/process/processdevice.cpp, src/process/process.h, src/process/process.cpp, src/process/work.cpp, src/process/work.h
+- Critical: 0  High: 2  Medium: 8  Low: 4  Nit: 4
+## Batch 09 — src/process/interrupt.h, src/process/interrupt.cpp, src/process/timer.cpp, src/process/timer.h, src/process/do_process.cpp
+- Critical: 2  High: 7  Medium: 8  Low: 6  Nit: 4
+
+## Batch 10 — src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp
+- Critical: 3  High: 3  Medium: 9  Low: 7  Nit: 10
+
+## Batch 11 — src/parameters/persistent.cpp, src/parameters/parameters.cpp, src/parameters/parameters.h, src/parameters/learn.cpp, src/report/report-formatter.h
+- Critical: 0  High: 5  Medium: 6  Low: 5  Nit: 4
+
+## Batch 12 — src/report/report-formatter-html.h, src/report/report.cpp, src/report/report.h, src/report/report-formatter-csv.h, src/report/report-maker.cpp
+- Critical: 0  High: 3  Medium: 5  Low: 4  Nit: 2
+## Batch 13 — src/report/report-maker.h, src/report/report-data-html.cpp, src/report/report-data-html.h, src/report/report-formatter-base.cpp, src/report/report-formatter-base.h
+- Critical: 0  High: 2  Medium: 7  Low: 3  Nit: 4
+## Batch 14 — src/report/report-formatter-html.cpp, src/report/report-formatter-csv.cpp, src/cpu/dram_rapl_device.cpp, src/cpu/dram_rapl_device.h, src/cpu/cpu_linux.cpp
+- Critical: 0  High: 2  Medium: 4  Low: 7  Nit: 3
+## Batch 15 — src/cpu/cpu_core.cpp, src/cpu/cpudevice.h, src/cpu/cpudevice.cpp, src/cpu/abstract_cpu.cpp, src/cpu/cpu_rapl_device.cpp
+- Critical: 0  High: 2  Medium: 3  Low: 5  Nit: 5
+## Batch 16 — src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp
+- Critical: 1  High: 4  Medium: 8  Low: 5  Nit: 3
+## Batch 17 — src/cpu/intel_cpus.h, src/cpu/intel_gpu.cpp, src/cpu/rapl/rapl_interface.cpp, src/cpu/rapl/rapl_interface.h, src/wakeup/wakeup.h
+- Critical: 0  High: 2  Medium: 6  Low: 6  Nit: 4
+## Batch 18 — src/wakeup/wakeup_usb.h, src/wakeup/wakeup_ethernet.h, src/wakeup/waketab.cpp, src/wakeup/wakeup_ethernet.cpp, src/wakeup/wakeup.cpp
+- Critical: 0  High: 3  Medium: 3  Low: 5  Nit: 4
+## Batch 19 — src/wakeup/wakeup_usb.cpp, src/measurement/acpi.cpp, src/measurement/acpi.h, src/measurement/opal-sensors.cpp, src/measurement/opal-sensors.h
+- Critical: 0  High: 1  Medium: 2  Low: 4  Nit: 7
+## Batch 20 — src/measurement/sysfs.h, src/measurement/sysfs.cpp, src/measurement/measurement.h, src/measurement/measurement.cpp, src/measurement/extech.h
+- Critical: 0  High: 3  Medium: 5  Low: 4  Nit: 5
+## Batch 21 — src/measurement/extech.cpp, src/devices/backlight.h, src/devices/backlight.cpp, src/devices/rfkill.h, src/devices/rfkill.cpp
+- Critical: 1  High: 3  Medium: 7  Low: 5  Nit: 5
+## Batch 22 — src/devices/usb.h, src/devices/usb.cpp, src/devices/gpu_rapl_device.h, src/devices/gpu_rapl_device.cpp, src/devices/ahci.h
+- Critical: 0  High: 2  Medium: 6  Low: 7  Nit: 3
+## Batch 23 — src/devices/ahci.cpp, src/devices/thinkpad-fan.h, src/devices/thinkpad-fan.cpp, src/devices/device.h, src/devices/device.cpp
+- Critical: 0  High: 3  Medium: 8  Low: 6  Nit: 5
+## Batch 24 — src/devices/devfreq.cpp, src/devices/devfreq.h, src/devices/alsa.h, src/devices/alsa.cpp, src/devices/runtime_pm.cpp
+- Critical: 0  High: 3  Medium: 8  Low: 6  Nit: 4

--- a/logs/critical.md
+++ b/logs/critical.md
@@ -18,6 +18,7 @@ static void change_blame(unsigned int cpu, class power_consumer *consumer, int l
     cpu_level[cpu] = level;
 }
 ```
+Fixed-with: 52811c8
 
 ### Critical item #2 : perf_events dangling pointer after clear_process_data
 
@@ -25,6 +26,7 @@ Location: src/process/do_process.cpp : 1213
 Description: `clear_process_data()` calls `delete perf_events` but never sets `perf_events = nullptr`. The variable is a file-scope static and retains the stale pointer value. If `start_process_measurement()` is subsequently called (e.g., on a second measurement run), the guard `if (!perf_events)` evaluates to *false* because the pointer is non-null, the initialisation block is skipped entirely, and `perf_events->start()` is invoked on the freed object — a classic use-after-free leading to undefined behaviour / crash.
 Severity rationale: Directly causes a use-after-free on any second invocation of the measurement cycle, which is normal PowerTOP operation.
 Suggested fix: Add `perf_events = nullptr;` immediately after `delete perf_events;` in `clear_process_data()`.
+Fixed-with: 9d9b536
 
 ## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
 
@@ -42,13 +44,13 @@ if (!event) {
 }
 trace_type = event->id;
 ```
-
-### Critical item #2 : Null pointer dereference of `pc` after mmap failure in `process()`
+Fixed-with: e401353
 
 Location: src/perf/perf.cpp : 231
 Description: In `create_perf_event`, if `mmap()` fails the function returns early (line 122) without setting `pc` or `data_mmap`. However `perf_fd` has already been set to a valid file descriptor. The guard in `process()` only checks `if (perf_fd < 0)`, so when mmap has failed but `perf_fd` is valid, execution proceeds to `pc->data_tail` where `pc` is NULL (set only in the constructors, not explicitly initialized to NULL there either). This is an unconditional null pointer dereference.
 Severity rationale: Any call to `process()` after a mmap failure will crash the process. mmap failures are realistic (e.g. under low memory or file-descriptor pressure).
 Suggested fix: On mmap failure in `create_perf_event`, close and reset `perf_fd` to -1 before returning, so the guard in `process()` will correctly skip processing. Also initialize `pc = nullptr` and `data_mmap = nullptr` in both constructors.
+Fixed-with: 9bed143
 
 ### Critical item #3 : `malloc` return value unchecked before `memcpy` in `handle_event`
 

--- a/logs/critical.md
+++ b/logs/critical.md
@@ -1,0 +1,99 @@
+
+## Review of interrupt.h, interrupt.cpp, timer.cpp, timer.h, do_process.cpp — batch 09
+
+### Critical item #1 : change_blame accesses cpu_level/cpu_blame without bounds check
+
+Location: src/process/do_process.cpp : 144
+Description: `change_blame()` accesses `cpu_level[cpu]` and `cpu_blame[cpu]` directly without any bounds check. By contrast, `consume_blame()` (line 152) does check bounds before accessing the same vectors. Both vectors are resized in `process_process_data()` to `get_max_cpu()+1`, but a trace event may carry a CPU number larger than `get_max_cpu()` (e.g., due to CPU hotplug or late-arriving events). An out-of-bounds write to these vectors is undefined behaviour and will likely cause a crash or silent data corruption.
+Severity rationale: Direct, unconditional write to a potentially out-of-bounds vector index; the inconsistency with `consume_blame` shows the missing guard is an oversight rather than intentional design.
+Suggested fix:
+```cpp
+static void change_blame(unsigned int cpu, class power_consumer *consumer, int level)
+{
+    if (cpu_level.size() <= cpu || cpu_blame.size() <= cpu)
+        return;
+    if (cpu_level[cpu] >= level)
+        return;
+    cpu_blame[cpu] = consumer;
+    cpu_level[cpu] = level;
+}
+```
+
+### Critical item #2 : perf_events dangling pointer after clear_process_data
+
+Location: src/process/do_process.cpp : 1213
+Description: `clear_process_data()` calls `delete perf_events` but never sets `perf_events = nullptr`. The variable is a file-scope static and retains the stale pointer value. If `start_process_measurement()` is subsequently called (e.g., on a second measurement run), the guard `if (!perf_events)` evaluates to *false* because the pointer is non-null, the initialisation block is skipped entirely, and `perf_events->start()` is invoked on the freed object — a classic use-after-free leading to undefined behaviour / crash.
+Severity rationale: Directly causes a use-after-free on any second invocation of the measurement cycle, which is normal PowerTOP operation.
+Suggested fix: Add `perf_events = nullptr;` immediately after `delete perf_events;` in `clear_process_data()`.
+
+## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
+
+### Critical item #1 : Null pointer dereference in `set_event_name` after `parse_event_format` succeeds
+
+Location: src/perf/perf.cpp : 163
+Description: In `set_event_name`, after `parse_event_format` returns success (ret >= 0), `tep_find_event_by_name` is called a second time. If it still returns NULL (e.g. the event was parsed but the name lookup fails), execution falls through to `trace_type = event->id` on the very next line with a NULL `event` pointer. No null check is present after the second call.
+Severity rationale: This is a direct null pointer dereference that will crash the process whenever an event format is parseable but not findable by name — a realistic scenario for any unexpected trace event name.
+Suggested fix:
+```cpp
+event = tep_find_event_by_name(perf_event::tep, system_name.c_str(), event_name.c_str());
+if (!event) {
+    trace_type = -1;
+    return;
+}
+trace_type = event->id;
+```
+
+### Critical item #2 : Null pointer dereference of `pc` after mmap failure in `process()`
+
+Location: src/perf/perf.cpp : 231
+Description: In `create_perf_event`, if `mmap()` fails the function returns early (line 122) without setting `pc` or `data_mmap`. However `perf_fd` has already been set to a valid file descriptor. The guard in `process()` only checks `if (perf_fd < 0)`, so when mmap has failed but `perf_fd` is valid, execution proceeds to `pc->data_tail` where `pc` is NULL (set only in the constructors, not explicitly initialized to NULL there either). This is an unconditional null pointer dereference.
+Severity rationale: Any call to `process()` after a mmap failure will crash the process. mmap failures are realistic (e.g. under low memory or file-descriptor pressure).
+Suggested fix: On mmap failure in `create_perf_event`, close and reset `perf_fd` to -1 before returning, so the guard in `process()` will correctly skip processing. Also initialize `pc = nullptr` and `data_mmap = nullptr` in both constructors.
+
+### Critical item #3 : `malloc` return value unchecked before `memcpy` in `handle_event`
+
+Location: src/perf/perf_bundle.cpp : 63
+Description: `malloc(header->size)` is called and its return value is immediately passed to `memcpy` without any null check. If the allocation fails, `buffer` is NULL and `memcpy(NULL, ...)` is undefined behavior and will crash the process.
+Severity rationale: `malloc` is documented to return NULL on allocation failure. Writing to a NULL pointer is undefined behavior and will cause a segfault in practice.
+Suggested fix:
+```cpp
+buffer = (unsigned char *)malloc(header->size);
+if (!buffer) {
+    fprintf(stderr, _("Out of memory in perf handle_event\n"));
+    return;
+}
+memcpy(buffer, header, header->size);
+```
+
+## Review of src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp — batch 16
+
+### Critical item #1 : Null pointer dereference of `cpu` in handle_trace_point
+
+Location: src/cpu/cpu.cpp : 953
+Description: In `perf_power_bundle::handle_trace_point`, after the upper-bounds check
+`if (cpunr >= (int)all_cpus.size())`, the code assigns `cpu = all_cpus[cpunr]`.
+The `all_cpus` vector is populated with explicit NULL sentinels when resized
+(`all_cpus.resize(number + 1, NULL)`), so any slot not filled by `handle_one_cpu`
+(e.g., due to non-contiguous CPU numbering, CPU hot-unplug, or late
+enumeration) will be NULL. `cpu` is then used unconditionally at lines 973, 975,
+987, 991, and 993 (`cpu->go_unidle`, `cpu->go_idle`, `cpu->change_freq`) with no
+null check, causing an immediate null pointer dereference and crash whenever a
+perf event arrives for such a slot.
+Severity rationale: This directly and materially crashes powertop on systems
+with non-contiguous CPU numbers or after CPU hot-unplug, which are common on
+server platforms and any machine that has ever used CPU hotplug.
+Suggested fix:
+```cpp
+cpu = all_cpus[cpunr];
+if (!cpu)
+    return;
+```
+
+## Review of src/measurement/extech.cpp — batch 21
+
+### Critical item #1 : parse_packet validation loop uses `i * 0` instead of `i * 5`
+
+Location: src/measurement/extech.cpp : 216
+Description: The outer validation loop in `parse_packet` iterates `i` from 0 to 3, but uses `i * 0` as the index, which is always 0. Consequently all four iterations check only `buf[0] != 2` and `buf[0 + 4] != 3`, never validating the 2nd, 3rd, or 4th five-byte packet. Any corrupt or truncated packet that has valid bytes at positions 0 and 4 will silently pass validation. The intended expression is `i * 5` and `i * 5 + 4`.
+Severity rationale: The validation function is completely broken for all but the first packet block. Malformed packets can pass undetected, leading to incorrect power readings being reported to users — this directly and materially impacts the tool's core measurement function.
+Suggested fix: Change `p->buf[i * 0]` to `p->buf[i * 5]` and `p->buf[i * 0 + 4]` to `p->buf[i * 5 + 4]`.

--- a/logs/high.md
+++ b/logs/high.md
@@ -1,0 +1,894 @@
+# PowerTOP High Severity Review Findings
+
+## Review of calibrate.cpp, calibrate.h, lib.cpp, devlist.cpp, main.cpp — batch 01
+
+### High item #1 : Missing thread joins in calibration functions
+
+Location: src/calibrate/calibrate.cpp : 240–376
+
+Description:
+`cpu_calibration()` (line 248) calls `pthread_create` in a loop but re-uses the single `thr` variable, discarding all but the last thread handle. None of the calibration functions — `cpu_calibration`, `wakeup_calibration`, `disk_calibration` — call `pthread_join` before returning. The pattern used is `stop_measurement = 1; sleep(1);` and then returning. The calibration threads may still be running when the next calibration phase begins, or when `calibrate()` returns and the program proceeds. This is a race condition and resource leak.
+
+Severity rationale: Multiple threads reading and writing shared state (`stop_measurement`, I/O, power measurement data) without synchronization can corrupt results or cause crashes.
+
+Suggested fix: Store all created thread handles and call `pthread_join` on each after setting `stop_measurement = 1`. For the CPU calibration loop, store handles in a local `std::vector<pthread_t>`.
+
+---
+
+### High item #2 : `system()` return value check is inverted in calibration functions
+
+Location: src/calibrate/calibrate.cpp : 342–356
+
+Description:
+In both `backlight_calibration` and `idle_calibration`, the condition used is:
+```cpp
+if (!system("DISPLAY=:0 /usr/bin/xset dpms force off"))
+    printf("System is not available\n");
+```
+`system()` returns 0 on success. `!0` evaluates to `true`, so the message is printed when the command **succeeds**, not when it fails. The error message is thus never visible on a system where xset works, and no error is reported when it fails. Additionally, the message `"System is not available\n"` is not wrapped in `_()` and is therefore not translatable.
+
+Severity rationale: Inverted error checking means calibration silently proceeds even when the display power command failed. The user sees a confusing message on success instead.
+
+Suggested fix:
+```cpp
+if (system("DISPLAY=:0 /usr/bin/xset dpms force off") != 0)
+    printf(_("Failed to set display power state\n"));
+```
+
+---
+
+### High item #3 : `clean_open_devices()` leaves dangling pointers in vectors
+
+Location: src/devlist.cpp : 76–91
+
+Description:
+`clean_open_devices()` deletes all allocated `devuser` and `devpower` objects but never calls `.clear()` on the `one`, `two`, or `devpower` vectors. After the function returns, all three vectors contain dangling pointers. Any subsequent call to `collect_open_devices()` iterates `target` to delete its contents before refilling (lines 107–110), but if `clean_open_devices()` was called first, those deletes operate on already-freed memory — use-after-free.
+
+Severity rationale: Double-free / use-after-free is undefined behaviour and can cause crashes or memory corruption.
+
+Suggested fix: Add `.clear()` calls at the end of each delete loop in `clean_open_devices()`:
+```cpp
+one.clear();
+two.clear();
+devpower.clear();
+```
+
+---
+
+### High item #4 : `fmt_prefix` — no bounds check before indexing `prefixes[]`
+
+Location: src/lib.cpp : 351–413
+
+Description:
+```cpp
+static const char prefixes[] = "yzafpnum kMGTPEZY";  // indices 0..16
+...
+pfx = prefixes[npfx + 8];
+```
+`npfx` is derived as `((omag + 27) / 3) - 9`. For `omag = -27` → `npfx = -9` → index `-1` (before the array). For `omag >= 27` → index `>= 17` (past the null terminator). The SI prefix table only covers yocto (10⁻²⁴) to yotta (10²⁴), i.e., `omag` must stay in `[-24, +24]`. Any value outside that range — which can occur with very small denormalized or very large floating-point inputs — reads out of bounds.
+
+Severity rationale: Out-of-bounds read from a static array is undefined behaviour; on certain architectures this could return a garbage prefix character or trigger a fault.
+
+Suggested fix: Clamp `npfx` before use:
+```cpp
+npfx = std::clamp(npfx, -8, 8);
+```
+
+---
+
+### High item #5 : `freopen` return-value check is inverted for `-q` (quiet) mode
+
+Location: src/main.cpp : 512–514
+
+Description:
+```cpp
+case 'q':
+    if (freopen("/dev/null", "a", stderr))
+        fprintf(stderr, _("Quiet mode failed!\n"));
+    break;
+```
+`freopen` returns the stream pointer on **success** and `NULL` on failure. The condition is true when `freopen` succeeds (quiet mode worked), so the "Quiet mode failed!" message is printed to `/dev/null` (invisible). When `freopen` fails, nothing is printed and `stderr` is left in an indeterminate state (undefined behaviour per C standard). The `!` is missing.
+
+Severity rationale: A `freopen` failure leaves `stderr` in an undefined state; any subsequent `fprintf(stderr, …)` is undefined behaviour. The diagnostic message is also never actually shown.
+
+Suggested fix:
+```cpp
+case 'q':
+    if (!freopen("/dev/null", "a", stderr))
+        fprintf(stderr, _("Quiet mode failed!\n"));
+    break;
+```
+
+## Review of src/test_framework.h, src/test_framework.cpp, src/display.cpp, src/display.h, src/lib.h — batch 02
+
+### High item #1 : `using namespace std;` in display.h header
+
+Location: src/display.h : 33
+Description: `using namespace std;` appears in a header file. Because display.h is included by many translation units, this silently injects the entire `std` namespace into every includer's scope, leading to name collisions, ambiguous lookups, and hard-to-diagnose compilation failures. Style rule 4.2 and general-c++.md both explicitly forbid this. The impact in a header is far worse than in a .cpp file.
+Severity rationale: Header-file namespace pollution affects the entire build; violates an explicit project rule.
+Suggested fix: Remove the `using namespace std;` line and qualify all identifiers with `std::` (e.g., `std::map`, `std::string`).
+
+---
+
+### High item #2 : `using namespace std;` in lib.h header
+
+Location: src/lib.h : 78
+Description: Same issue as display.h but worse: lib.h is the project's most widely-included header (pulled in by virtually every translation unit). The `using namespace std;` inside the `#ifdef __cplusplus` block silently exposes the full `std` namespace everywhere. The function declarations on lines 80–84 already benefit from this (`string` instead of `std::string`), making them incorrect as well once the directive is removed.
+Severity rationale: Affects the entire codebase; any future std symbol added by a compiler upgrade can silently shadow application-level names.
+Suggested fix: Remove `using namespace std;`. Replace bare `string` with `std::string` on the affected `extern` declarations (lines 80–84). Qualified uses like `std::string` on lines 69–93 are already correct.
+
+---
+
+### High item #3 : Missing bounds check in `show_tab()` before indexing `tab_names`
+
+Location: src/display.cpp : 125
+Description: `show_tab(unsigned int tab)` immediately indexes `tab_names[tab]` at line 125 without verifying that `tab < tab_names.size()`. An out-of-bounds access invokes undefined behaviour; on a typical STL implementation it will read garbage memory or crash. The function is called directly from external code with a caller-supplied index, making the missing check a real risk.
+Severity rationale: Out-of-bounds vector access is undefined behaviour and can crash the process.
+Suggested fix:
+```cpp
+void show_tab(unsigned int tab)
+{
+if (!display || tab >= tab_names.size())
+return;
+```
+
+---
+
+### High item #4 : Tab position calculated from internal name length instead of translated name length
+
+Location: src/display.cpp : 143
+Description: Inside the loop in `show_tab()`, the rendered string is `tab_translations[tab_names[i]]` (the translated name), but the horizontal advance `tab_pos` is incremented by `tab_names[i].length()` — the length of the *internal* (English) key, not the displayed translation. When a translation is longer than the key, tabs will visually overlap or be misaligned; when shorter, there will be extra gaps. This is a functional display bug.
+Severity rationale: Produces incorrect on-screen layout for any locale where translation lengths differ from internal names.
+Suggested fix:
+```cpp
+tab_pos += 3 + tab_translations[tab_names[i]].length();
+```
+
+## Review of src/tuning/tunable.h, src/tuning/runtime.h, src/tuning/runtime.cpp — batch 03
+
+### High item #1 : `using namespace std;` in header file tunable.h
+
+Location: src/tuning/tunable.h : 34
+Description: `using namespace std;` appears at file scope in a header file. Every translation unit that includes `tunable.h` (directly or transitively) will have the entire `std` namespace injected into its global namespace, causing potential name collisions and violating the project's coding style.
+Severity rationale: Header-level namespace pollution is a HIGH issue per style.md §4.2 and general-c++.md — it affects all includers and cannot be undone by the including translation unit.
+Suggested fix: Remove the `using namespace std;` line. Replace all unqualified `string` usages in the header with `std::string` (already done for most; the `string` parameters in constructor declarations on line 55 rely on this directive).
+
+### High item #2 : `using namespace std;` in header file runtime.h
+
+Location: src/tuning/runtime.h : 32
+Description: Same violation as in tunable.h — `using namespace std;` at file scope in a header file pollutes every includer's namespace.
+Severity rationale: Same as item #1. Both `tunable.h` and `runtime.h` have this issue; `runtime.h` also includes `tunable.h`, compounding the pollution.
+Suggested fix: Remove the `using namespace std;` line. Qualify all bare `string` references with `std::string`.
+
+### High item #3 : Logic bug — `"on"` returns `TUNE_GOOD` in `good_bad()`
+
+Location: src/tuning/runtime.cpp : 102–103
+Description: In `runtime_tunable::good_bad()`, the control value `"on"` (which means the device is forced always-on, disabling runtime power management) incorrectly returns `TUNE_GOOD`. Only `"auto"` (kernel may auto-suspend the device) should be `TUNE_GOOD`; `"on"` should return `TUNE_BAD`. As a result, `toggle()` will always write `"on"` (since `good_bad()` returns `TUNE_GOOD` for both states) and will never write `"auto"`, making it impossible to enable runtime PM via PowerTOP's toggle. The generated `toggle_script()` also always returns the "turn on" script for the same reason.
+Severity rationale: This is a functional correctness bug. The core purpose of this class — enabling runtime power management — is broken. Devices stuck in `"on"` mode cannot be toggled to `"auto"` through PowerTOP.
+Suggested fix: Change line 102–103 to return `TUNE_BAD` for `"on"`:
+```cpp
+if (content == "on")
+    return TUNE_BAD;
+```
+
+## Review of ethernet.cpp, ethernet.h, wifi.cpp, wifi.h, tuningusb.h — batch 04
+
+### High item #1 : `using namespace std;` in header file ethernet.h
+
+Location: src/tuning/ethernet.h : 32
+Description: `using namespace std;` is present at file scope in a header. This pollutes the namespace of every translation unit that includes this header, which is explicitly forbidden by the style guide and general-c++ rules. Any file including ethernet.h will have the entire `std` namespace injected.
+Severity rationale: The style guide explicitly states "Avoid `using namespace std;`" and general-c++.md marks it as a deprecated construct. Headers are the worst place for this because the pollution is invisible to includers.
+Suggested fix: Remove the `using namespace std;` line. The class already correctly uses `std::string` for its members, so no other changes are needed.
+
+### High item #2 : `using namespace std;` in header file wifi.h
+
+Location: src/tuning/wifi.h : 34
+Description: Same issue as ethernet.h — `using namespace std;` at file scope in a header contaminates all includers. The constructor parameter already uses `std::string`, and the member uses `std::string`, so the `using` declaration is entirely unnecessary.
+Severity rationale: Same as High item #1; prohibited by both style.md and general-c++.md.
+Suggested fix: Remove the `using namespace std;` line from wifi.h.
+
+### High item #3 : `using namespace std;` in header file tuningusb.h
+
+Location: src/tuning/tuningusb.h : 33
+Description: Same issue — `using namespace std;` at file scope in a public header. All three affected headers (ethernet.h, wifi.h, tuningusb.h) share this violation.
+Severity rationale: Same as High items #1 and #2.
+Suggested fix: Remove the `using namespace std;` line from tuningusb.h.
+
+### High item #4 : Unchecked `ioctl` return value for `SIOCETHTOOL` in `good_bad()`
+
+Location: src/tuning/ethernet.cpp : 87
+Description: The `ioctl(sock, SIOCETHTOOL, &ifr)` call to fetch WoL info (`ETHTOOL_GWOL`) has its return value silently discarded. If the ioctl fails (e.g., the interface does not support ethtool, or an error occurs), `wol.wolopts` will remain zero (from the preceding memset), causing the function to silently return `TUNE_GOOD` — a false "good" result. The interface may actually have WoL enabled and the diagnostic will miss it.
+Severity rationale: Incorrect diagnostic result on ioctl failure; the code operates on stale/initialised-to-zero data rather than real device state. This is a logic correctness issue.
+Suggested fix:
+```cpp
+ret = ioctl(sock, SIOCETHTOOL, &ifr);
+if (ret < 0) {
+    close(sock);
+    return TUNE_UNKNOWN;
+}
+```
+
+### High item #5 : `new` without `std::nothrow` and no null check in `add_wifi_tunables()`
+
+Location: src/tuning/wifi.cpp : 91
+Description: `wifi = new class wifi_tunable(entry->d_name);` uses plain `new`, which throws `std::bad_alloc` on allocation failure. Unlike the analogous `ethtunable_callback()` in ethernet.cpp which correctly uses `new(std::nothrow)` followed by a null check, `add_wifi_tunables()` neither catches the exception nor uses the nothrow form. An allocation failure will propagate an unhandled exception, potentially crashing powertop.
+Severity rationale: Inconsistency with the established pattern and risk of unhandled exception causing a crash.
+Suggested fix:
+```cpp
+wifi = new(std::nothrow) wifi_tunable(entry->d_name);
+if (wifi)
+    all_tunables.push_back(wifi);
+```
+
+### High item #6 : Wi-Fi interface detection misses modern predictable interface names
+
+Location: src/tuning/wifi.cpp : 90
+Description: `strstr(entry->d_name, "wlan")` only matches interfaces whose name contains the substring "wlan" (e.g., `wlan0`). On systems using systemd's predictable network interface naming (the default on virtually all modern Linux distributions), wireless interfaces are named `wlp2s0`, `wlx001122334455`, etc. — none of which contain "wlan". Power saving will silently not be applied to any wireless interface on a modern system.
+Severity rationale: Functional regression on modern Linux — power-saving tunable is never created for the majority of real-world Wi-Fi interfaces.
+Suggested fix: Check the interface type via `/sys/class/net/<iface>/phy80211` or match using the `wl` prefix that all wireless interfaces share:
+```cpp
+if (strncmp(entry->d_name, "wl", 2) == 0) {
+```
+
+## Review of tuningusb.cpp, tuning.cpp, tuning.h, bluetooth.cpp, bluetooth.h — batch 05
+
+### High item #1 : `using namespace std;` in a header file
+
+Location: src/tuning/bluetooth.h : 32
+Description: `using namespace std;` appears at file scope in a public header. This injects the entire `std` namespace into every translation unit that includes bluetooth.h, which can silently cause name clashes or ambiguities that are hard to diagnose. The project style guide explicitly forbids this.
+Severity rationale: Header-level namespace pollution affects every consumer of the header. The style guide explicitly prohibits `using namespace std;`.
+Suggested fix: Remove the `using namespace std;` line. The only std type used in the class declaration is inherited indirectly via `tunable.h`; bluetooth.h itself does not need the directive.
+
+### High item #2 : Deprecated `hcitool` used to detect active Bluetooth connections
+
+Location: src/tuning/bluetooth.cpp : 144
+Description: `popen("/usr/bin/hcitool con 2> /dev/null", "r")` invokes the `hcitool` command, which was deprecated in BlueZ 5.x (circa 2014) and removed from many modern distributions. On systems where `/usr/bin/hcitool` is absent or a stub, popen still succeeds (the shell starts) but produces no useful output, meaning the second fgets call returns NULL immediately. The code then concludes there are no connections and returns `TUNE_GOOD` (BT interface is idle), potentially toggling BT off when it is in active use.
+Severity rationale: Silent functional regression on all modern Linux systems — Bluetooth may be disabled while connections are active. The hardcoded path also fails silently if moved.
+Suggested fix: Replace with a D-Bus query via the BlueZ 5 API (e.g., `org.bluez.Device1.Connected`), or use `/sys/class/bluetooth/hci0/` sysfs attributes, or at minimum check for `bluetoothctl` before falling back to `hcitool`.
+
+### High item #3 : Redefinition of implementation-reserved `__`-prefixed identifiers
+
+Location: src/tuning/bluetooth.cpp : 60–62
+Description: The file defines `#define __u16 uint16_t`, `#define __u8 uint8_t`, and `#define __u32 uint32_t`. All identifiers beginning with `__` (two underscores) are reserved for the C/C++ implementation. Redefining them is undefined behavior and can silently conflict with identically named macros or typedefs in `<stdint.h>`, kernel uapi headers, or glibc, leading to type mismatches or build failures depending on include order.
+Severity rationale: Undefined behavior; platform-specific headers already define these names; conflicts will manifest differently per toolchain version.
+Suggested fix: Replace the three macros with type aliases using non-reserved names, or simply use `uint8_t`, `uint16_t`, `uint32_t` directly in the struct definitions and remove the `#define` lines.
+
+## Review of src/tuning/tuningsysfs.cpp, src/tuning/tuningsysfs.h, src/tuning/nl80211.h, src/tuning/iw.h, src/tuning/iw.c — batch 06
+
+### High item #1 : Resource leak when NLA_PUT_U32 fails in __handle_cmd
+
+Location: src/tuning/iw.c : 234 / 261
+Description: The `NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, devidx)` macro expands to a `goto nla_put_failure` on failure. The `nla_put_failure:` label is placed at line 261, *after* the cleanup labels `out:` (which calls `nl_cb_put(cb)`) and `out_free_msg:` (which calls `nlmsg_free(msg)`). As a result, when `NLA_PUT_U32` fails, execution jumps directly to `nla_put_failure:`, bypassing both cleanup steps. Both `cb` (allocated at line 219) and `msg` (allocated at line 213) are leaked on every such failure path.
+Severity rationale: Confirmed resource leak bug on an error path; in a power-management tool that may call this for every wireless interface on every cycle, repeated nl80211 allocation failures could exhaust file descriptors or memory.
+Suggested fix: Move the `nla_put_failure:` label *before* `out:` so it falls through into the normal cleanup chain:
+```c
+ nla_put_failure:
+    fprintf(stderr, "building message failed\n");
+    err = -ENOBUFS;
+ out:
+    nl_cb_put(cb);
+ out_free_msg:
+    nlmsg_free(msg);
+    return err;
+```
+
+### High item #2 : `using namespace std` in a header file
+
+Location: src/tuning/tuningsysfs.h : 33
+Description: `using namespace std;` appears at file scope in the header. This injects the entire `std` namespace into every translation unit that includes `tuningsysfs.h`, including transitively included files. This is explicitly prohibited by both `style.md` ("Avoid `using namespace std;`") and `general-c++.md` ("`using namespace std;` is a deprecated construct"). The effect is especially harmful in a header because it cannot be undone by including files.
+Severity rationale: Namespace pollution in a header affects all consumers; can silently cause name collisions that are hard to diagnose.
+Suggested fix: Remove line 33 (`using namespace std;`). All uses of `string` in the header already use the fully qualified `std::string`, so no other changes are required.
+
+### High item #3 : Unchecked return value of nla_parse() in print_power_save_handler
+
+Location: src/tuning/iw.c : 150
+Description: `nla_parse(attrs, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL)` can return a negative error code if the attribute buffer is malformed. The return value is discarded. If parsing fails, the `attrs` array may be partially or incorrectly filled; accessing `attrs[NL80211_ATTR_PS_STATE]` on the next line then reads potentially uninitialised pointer data.  The practical consequence is that `enable_power_save` silently remains at its previous value rather than being updated to reflect the actual state returned by the kernel.
+Severity rationale: Unchecked return value of a function that can fail; leads to silent, incorrect power-save state reporting.
+Suggested fix:
+```c
+if (nla_parse(attrs, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
+              genlmsg_attrlen(gnlh, 0), NULL) < 0)
+    return NL_SKIP;
+```
+
+## Review of tuningi2c.h, tuningi2c.cpp, powerconsumer.h, powerconsumer.cpp, processdevice.h — batch 07
+
+### High item #1 : Division by zero risk on `measurement_time`
+
+Location: src/process/powerconsumer.cpp : 59, 83, 92 and src/process/powerconsumer.h : 68
+Description: `measurement_time` is used as a divisor in `Witts()` (line 59), `usage()` (lines 83, 92), and the inline `events()` method (powerconsumer.h:68) without any guard against it being zero. If `measurement_time == 0` (e.g. at startup before the first measurement interval completes, or due to a timing anomaly), these divisions produce `+Inf`, `-Inf`, or `NaN`. These silent bad values then propagate into power estimates and event-rate displays, corrupting every metric shown to the user without any indication that something is wrong.
+Severity rationale: Corrupts core power/event metrics silently; NaN values can also trigger undefined behaviour when compared or formatted.
+Suggested fix: Guard every division with a check, e.g.:
+```cpp
+if (measurement_time <= 0.0)
+    return 0.0;
+cost = cost / measurement_time;
+```
+Apply the same pattern in `usage()`, `usage_units()`, and `events()`.
+
+## Review of processdevice.cpp, process.h, process.cpp, work.cpp, work.h — batch 08
+
+### High item #1 : Unsigned wraparound before overflow guard corrupts accumulated_runtime
+
+Location: src/process/process.cpp : 63-71
+Description: In `process::deschedule_thread()`, `delta = time - running_since` (line 63) is computed *before* the guard `if (time < running_since)` (line 65). Because both `time` and `running_since` are `uint64_t`, when `time < running_since` the subtraction wraps around to a huge positive value. The `printf` on line 66–67 fires after `delta` has already been incorrectly set, and the corrupted `delta` is subsequently added to `accumulated_runtime` on line 71. This silently inflates per-process CPU accounting.
+Severity rationale: Produces incorrect measurements that propagate throughout the tool's power estimates; the bug is triggered by any measurement period where a thread's last scheduled-in time straddles a counter reset or wrap.
+Suggested fix: Move the overflow check before the subtraction:
+```cpp
+if (time < running_since) {
+    fprintf(stderr, "time %llu < running_since %llu\n",
+            (unsigned long long)time, (unsigned long long)running_since);
+    running = 0;
+    return 0;
+}
+delta = time - running_since;
+```
+
+### High item #2 : Logic error — kernel-process detection is dead code
+
+Location: src/process/process.cpp : 119-127
+Description: The outer `if (!cmdline.empty())` (line 119) ensures `cmdline.size() >= 1`, making the inner `if (cmdline.size() < 1)` (line 120) permanently false. The branch that sets `is_kernel = 1` and formats the bracketed description is therefore unreachable. Kernel threads (which have an empty `/proc/<pid>/cmdline`) are caught by the outer `if` being false, meaning neither `is_kernel` nor the bracketed `desc` is ever set from this code path.
+Severity rationale: Kernel processes are silently misidentified as user processes; `is_kernel` stays 0 for all processes, breaking any downstream logic that relies on that flag.
+Suggested fix: Invert the condition:
+```cpp
+if (cmdline.empty()) {
+    is_kernel = 1;
+    desc = std::format("[PID {}] [{}]", pid, comm);
+} else {
+    cmdline_to_string(cmdline);
+    desc = std::format("[PID {}] {}", pid, cmdline);
+}
+```
+
+## Review of interrupt.h, interrupt.cpp, timer.cpp, timer.h, do_process.cpp — batch 09
+
+### High item #1 : using namespace std in timer.cpp
+
+Location: src/process/timer.cpp : 39
+Description: `using namespace std;` is present at file scope in timer.cpp. The project style guide and general-c++ rules both explicitly prohibit this construct. All standard library identifiers must be qualified with the `std::` prefix.
+Severity rationale: Explicit prohibition in both style.md and general-c++.md; pollutes the global namespace.
+Suggested fix: Remove the `using namespace std;` line and add `std::` qualifiers wherever needed (e.g., `std::map`, `std::pair`, `std::string_view`, `std::string`, `std::for_each`, `std::getline`, `std::istringstream`).
+
+### High item #2 : cpu_idle event: tep_get_field_val return value ignored, val potentially uninitialised
+
+Location: src/process/do_process.cpp : 584
+Description: The `cpu_idle` event handler calls `tep_get_field_val(NULL, event, "state", &rec, &val, 0)` without checking the return value. Every other call to `tep_get_field_val` in this function guards on `ret < 0` and returns early. If this call fails, `val` retains an indeterminate value and the subsequent comparison `val == (unsigned int)-1` uses garbage, potentially triggering `set_wakeup_pending` or `consume_blame` incorrectly on every idle event.
+Severity rationale: Silently corrupts the wakeup-attribution state for every cpu_idle event when the field read fails; directly affects the accuracy of power-consumer accounting.
+Suggested fix:
+```cpp
+ret = tep_get_field_val(NULL, event, "state", &rec, &val, 0);
+if (ret < 0)
+    return;
+if (val == (unsigned int)-1)
+    ...
+```
+
+### High item #3 : Division by zero — measurement_time not guarded
+
+Location: src/process/do_process.cpp : 723
+Description: `measurement_time` (a global `double`) is zero-initialised and is only updated inside `handle_trace_point` when a trace event with `time > last_stamp` arrives. If no trace events are captured during a measurement cycle (e.g., on the very first run or on a system with all tracepoints disabled), `measurement_time` remains 0.0. All of `total_wakeups()`, `total_gpu_ops()`, `total_disk_hits()`, `total_hard_disk_hits()`, `total_xwakes()` (lines 716–784) and several inline divisions in `report_process_update_display()` (lines 963–973) divide by `measurement_time`, producing infinity or NaN values that propagate to display output and report data.
+Severity rationale: Directly corrupts displayed data on any measurement run that produces no events; NaN/Inf values can cause undefined behaviour in subsequent arithmetic.
+Suggested fix: Guard each division site, e.g.: `if (measurement_time > 0.0) total = total / measurement_time;`
+
+### High item #4 : static prev_time persists across measurement cycles
+
+Location: src/process/do_process.cpp : 631
+Description: `prev_time` is declared `static uint64_t` inside `handle_trace_point`, meaning it survives between complete measurement cycles. The `hard_disk_hits` logic fires when `(time - prev_time) > 1000000000`, but `prev_time` carries over from the previous measurement window. The first disk event in a new measurement cycle will almost always satisfy the condition because the gap since the last event in the prior cycle is typically > 1 second, inflating `hard_disk_hits` counts spuriously.
+Severity rationale: Directly corrupts `hard_disk_hits` accounting on every measurement cycle after the first; this is a primary metric shown to users.
+Suggested fix: Reset `prev_time = 0` at the start of each measurement cycle (e.g., in `start_process_measurement()` or `process_process_data()`), or store it in a per-measurement-cycle structure.
+
+### High item #5 : timer_is_deferred reads /proc/timer_stats which was removed in Linux 4.11
+
+Location: src/process/timer.cpp : 44
+Description: `timer_is_deferred()` attempts to read `/proc/timer_stats` to determine whether a timer uses the deferrable flag. This procfs file was removed in Linux kernel 4.11 (2017). On all modern kernels the file does not exist; `read_file_content` returns an empty string and the function always returns `false`. The `deferred` field is set in the constructor but is permanently `false`, and `is_deferred()` has no useful effect, yet it silently skips adding deferred timers in `timer_expire_entry` handling.
+Severity rationale: Functionality is permanently inoperative on any kernel >= 4.11 (essentially all current distributions); the silent no-op may mask accounting bugs.
+Suggested fix: Remove `timer_is_deferred()` and the `deferred` field, or replace with a mechanism that works on current kernels (or simply always return false explicitly and document the limitation).
+
+### High item #6 : Copy-paste error in error message — wrong event name
+
+Location: src/process/do_process.cpp : 457
+Description: Inside the `timer_expire_entry` handler, the error message reads `"softirq_entry event returned no timer ?"`. This is a copy-paste from the nearby `softirq_entry` block. The message is misleading for any developer debugging a missing timer field in a `timer_expire_entry` event.
+Severity rationale: Wrong diagnostic information emitted to stderr; impedes debugging of a real error.
+Suggested fix: Change to `"timer_expire_entry event returned no timer?\n"`.
+
+### High item #7 : all_timers_to_all_power adds all timers regardless of accumulated_runtime
+
+Location: src/process/timer.cpp : 117
+Description: `all_timers_to_all_power()` unconditionally pushes every timer from `all_timers` into `all_power`. By contrast, `all_interrupts_to_all_power()` (interrupt.cpp:117) filters on `accumulated_runtime > 0`. Zero-runtime timers will appear in the overview display and all accounting functions, distorting wakeup counts, sort order, and report tables.
+Severity rationale: Directly inflates the `all_power` list with zero-contribution entries that show in the user-visible overview, degrading display accuracy.
+Suggested fix:
+```cpp
+void all_timers_to_all_power(void)
+{
+    for (auto &[addr, t] : all_timers)
+        if (t->accumulated_runtime)
+            all_power.push_back(t);
+}
+```
+
+## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
+
+### High item #1 : `perf_fd` left open and `pc` left NULL on mmap failure in `create_perf_event`
+
+Location: src/perf/perf.cpp : 119
+Description: When `mmap()` fails, the function prints an error and returns, but `perf_fd` (already assigned a valid fd at line 95) is never closed, and `pc` / `data_mmap` are never set. This causes two problems: (1) a file descriptor leak on every mmap failure, and (2) a subsequent null pointer dereference in `process()` as described in Critical item #2.
+Severity rationale: File descriptor leaks accumulate over the lifetime of the program and can exhaust OS limits. The combination with the null pointer dereference makes this a high-severity resource management bug.
+Suggested fix:
+```cpp
+if (perf_mmap == MAP_FAILED) {
+    fprintf(stderr, _("failed to mmap perf buffer: %d (%s)\n"), errno, strerror(errno));
+    close(perf_fd);
+    perf_fd = -1;
+    return;
+}
+```
+
+### High item #2 : `perf_event` destructor does not call `clear()` in the else branch — resource leak
+
+Location: src/perf/perf.cpp : 167
+Description: The destructor only calls `clear()` when the last reference to `tep` is being released (i.e., `tep_get_ref() == 1`). In the `else` branch (more references exist), `tep_unref()` is called but `clear()` is never invoked. As a result, the `perf_fd` file descriptor and the `perf_mmap` memory mapping are leaked for every `perf_event` object that is destroyed while other `perf_event` objects still exist.
+Severity rationale: In normal operation, many `perf_event` objects share the `tep` handle, so the else branch is the common path. Every destroyed event except the very last will leak an fd and an mmap region.
+Suggested fix:
+```cpp
+perf_event::~perf_event(void)
+{
+    clear();
+    if (tep_get_ref(perf_event::tep) == 1) {
+        tep_free(perf_event::tep);
+        perf_event::tep = NULL;
+    } else {
+        tep_unref(perf_event::tep);
+    }
+}
+```
+
+### High item #3 : Missing memory barrier after reading `data_head` in `perf_event::process()`
+
+Location: src/perf/perf.cpp : 231
+Description: The `perf_event_mmap_page` documentation (present in `perf_event.h` lines 299-308) explicitly states: "User-space reading the @data_head value should issue an rmb(), on SMP capable platforms, after reading this value." The `process()` loop reads `pc->data_head` and immediately accesses ring buffer data without any read memory barrier (`rmb()` / `__sync_synchronize()` / `std::atomic_thread_fence`). On SMP systems the kernel may still be writing the data, causing the process to read stale or incomplete event data.
+Severity rationale: On any SMP machine (the typical PowerTOP target), this can silently corrupt perf event processing, leading to incorrect power analysis results.
+Suggested fix: Insert `__sync_synchronize()` (or `asm volatile("" ::: "memory")`) immediately after reading `pc->data_head` and before accessing `data_mmap`.
+
+## Review of persistent.cpp, parameters.cpp, parameters.h, learn.cpp, report-formatter.h — batch 11
+
+### High item #1 : `using namespace std` in header file parameters.h
+
+Location: src/parameters/parameters.h : 37
+Description: `using namespace std;` appears in parameters.h, which is a shared header included by most of the codebase. This silently injects the entire `std` namespace into every translation unit that includes parameters.h (directly or transitively). This is explicitly forbidden by both style.md ("Avoid `using namespace std;`") and general-c++.md ("`using namespace std;` is a deprecated construct"). In a header file the damage is amplified because the developer of any including .cpp file has no visible indication that `std` has been imported.
+Severity rationale: Header-level namespace pollution affects the entire codebase. It can cause silent name collisions and is an explicit rule violation.
+Suggested fix: Remove `using namespace std;` from parameters.h and qualify all unqualified `map`, `vector`, `string` etc. references with the `std::` prefix.
+
+### High item #2 : `using namespace std` in header file report-formatter.h
+
+Location: src/report/report-formatter.h : 32
+Description: Same violation as in parameters.h — `using namespace std;` in a header file forces the entire `std` namespace into every translation unit that includes this header.
+Severity rationale: Same as item #1. Header-level namespace pollution, explicit rule violation.
+Suggested fix: Remove `using namespace std;` and prefix all standard-library types with `std::`.
+
+### High item #3 : Acknowledged but unfixed memory leaks in `store_results` and `load_results`
+
+Location: src/parameters/parameters.cpp : 342 ; src/parameters/persistent.cpp : 117
+Description: In both `store_results` (parameters.cpp:342) and `load_results` (persistent.cpp:117), when `past_results` has reached `MAX_PARAM` capacity the code overwrites a slot with a new pointer without freeing the old one. Both sites are annotated with `/* memory leak, must free old one first */`. Because this path is taken on every new measurement after the buffer is full, the leak is unbounded over a long PowerTOP session. The correct fix is one additional `delete past_results[overflow_index];` before the assignment.
+Severity rationale: Unbounded memory growth during normal long-running operation.
+Suggested fix:
+```cpp
+// Before:
+past_results[overflow_index] = clone_results(&all_results);
+// After:
+delete past_results[overflow_index];
+past_results[overflow_index] = clone_results(&all_results);
+```
+Apply the same pattern in `load_results`.
+
+### High item #4 : `get_parameter_weight` has no bounds check — undefined behaviour
+
+Location: src/parameters/parameters.cpp : 129
+Description: `get_parameter_weight(int index, struct parameter_bundle *the_bundle)` directly returns `the_bundle->weights[index]` without checking that `index` is non-negative or that `index < the_bundle->weights.size()`. An out-of-range index causes undefined behaviour (likely a crash with debug iterators, silent data corruption otherwise). The neighbouring `get_parameter_value(unsigned int index, …)` at line 120 does perform this check and emits a "BUG:" message.
+Severity rationale: Silent UB / potential crash in production code; no bounds guard exists.
+Suggested fix:
+```cpp
+double get_parameter_weight(int index, struct parameter_bundle *the_bundle)
+{
+    if (index < 0 || (unsigned int)index >= the_bundle->weights.size()) {
+        fprintf(stderr, "BUG: requesting unregistered weight %d\n", index);
+        return 1.0;
+    }
+    return the_bundle->weights[index];
+}
+```
+
+### High item #5 : `utilization_power_valid(const std::string &u)` accesses `past_results[0]` without empty check
+
+Location: src/parameters/parameters.cpp : 401
+Description: The string-parameter overload of `utilization_power_valid` accesses `past_results[0]->utilization[index]` unconditionally. If `past_results` is empty this is an out-of-bounds vector access — undefined behaviour, typically a crash. The integer-parameter overload of the same function at line 420 does correctly guard with `if (past_results.size() == 0) return 0;`.
+Severity rationale: Missing guard that the sister overload has, leading to UB / crash if called before any results are stored.
+Suggested fix: Add `if (past_results.size() == 0) return 0;` immediately after the `if (index <= 0) return 0;` check on line 399.
+
+## Review of report-formatter-html.h, report.cpp, report.h, report-formatter-csv.h, report-maker.cpp — batch 12
+
+### High item #1 : `using namespace std` in header files pollutes all includers
+
+Location: report.h : 35, report-formatter-html.h : 35, report-formatter-csv.h : 46
+Description: All three header files contain `using namespace std;` at file scope. Per the C++ coding guidelines this is a deprecated construct, and placing it in a header is especially harmful: every translation unit that includes these headers (directly or transitively) has the entire `std` namespace injected, making it impossible for downstream code to keep the namespaces separate. The style guide also mandates the explicit `std::` prefix at all times.
+Severity rationale: In a header file the pollution is unconditional and affects all includers; it is a correctness hazard (silent name-hiding / ADL surprises) that is impossible for consumers to work around.
+Suggested fix: Remove the `using namespace std;` line from all three headers. Replace bare `string` with `std::string` where it appears in those headers (e.g., `report-formatter-html.h:68`, `report-formatter-csv.h:67`).
+
+### High item #2 : Non-translatable user-visible string in report output
+
+Location: report.cpp : 131
+Description: `system_data[1]` is built with `std::format("{} ran at {}", PACKAGE_VERSION, get_time_string("%c", now))`. The phrase "ran at" is directly visible in the generated report but is never passed through the gettext `_()` macro, so it will always appear in English regardless of the user's locale. The style guide requires that all user-visible strings be wrapped in `_()` and that user-facing formatted strings use `pt_format` rather than `std::format`.
+Severity rationale: Explicit rule: "All user visible strings must be translatable and use the `_()` gettext pattern." This affects all non-English users every time a report is produced.
+Suggested fix: Replace with `pt_format(_("{} ran at {}"), PACKAGE_VERSION, get_time_string("%c", now))`.
+
+### High item #3 : `localtime()` return value not checked before use
+
+Location: report.cpp : 105-106
+Description: `localtime(&t)` can return `NULL` (e.g., for an out-of-range `time_t` value). The return value is stored in `tm_info` but is passed directly to `strftime` without a null check. Passing a null pointer to `strftime` is undefined behaviour and will cause a crash.
+Severity rationale: Undefined behaviour / potential null-pointer dereference in code that runs on every report-generating invocation.
+Suggested fix:
+```cpp
+struct tm *tm_info = localtime(&t);
+if (!tm_info)
+    return "";
+if (strftime(buf, sizeof(buf), fmt.c_str(), tm_info))
+    return buf;
+return "";
+```
+
+## Review of report-maker.h, report-data-html.cpp, report-data-html.h, report-formatter-base.cpp, report-formatter-base.h — batch 13
+
+### High item #1 : `double_to_string` — unsigned wrap on `npos+2` produces single-character output for integer-valued doubles
+
+Location: src/report/report-data-html.cpp : 124
+Description: `str.find(".")` returns `std::string::npos` (the maximum `size_t` value) when the formatted double contains no decimal point (e.g., `100.0` formats as `"100"` via `ostringstream`). The expression `str.find(".")+2` then wraps around via unsigned arithmetic to `1`. Consequently `str.substr(0, 1)` is returned — only the first character of the number. For example, a power value of `100.0` W would display as `"1"` in the HTML report. Any integer-valued double triggers this bug.
+Severity rationale: Produces visibly wrong numeric data in the generated power report for any integer-valued measurement.
+Suggested fix:
+```cpp
+std::string double_to_string(double dval)
+{
+std::ostringstream dtmp;
+dtmp << dval;
+std::string str = dtmp.str();
+auto dot = str.find('.');
+if (dot != std::string::npos)
+str = str.substr(0, dot + 2);
+return str;
+}
+```
+
+### High item #2 : `using namespace std;` in header files
+
+Location: src/report/report-maker.h : 65  and  src/report/report-data-html.h : 7
+Description: Both headers contain `using namespace std;` at file scope. Because these are headers, every translation unit that includes them (directly or transitively) has the entire `std` namespace injected without opt-in. This can cause silent name collisions, ambiguous overload sets, and violates the project's own style guide (style.md §4.2) and the general C++ rules.
+Severity rationale: Namespace pollution that silently affects all includers, a first-class style violation in both the style guide and general-c++ rules.
+Suggested fix: Remove `using namespace std;` from both headers and qualify all standard-library names with `std::`.
+
+## Review of report-formatter-csv.cpp, report-formatter-html.cpp, dram_rapl_device.cpp, dram_rapl_device.h, cpu_linux.cpp — batch 14
+
+### High item #1 : `csv_need_quotes` member variable used uninitialized
+
+Location: src/report/report-formatter-csv.cpp : 67  (also src/report/report-formatter-csv.h : 68)
+Description: The `csv_need_quotes` bool member of `report_formatter_csv` is declared in the header but never initialized — not in the constructor, not in the member initializer list. The constructor body contains only `/* Do nothing special */`. When `escape_string()` sets `csv_need_quotes = true` on line 67, it only ever writes to it; any code that reads `csv_need_quotes` (e.g., the declared-but-unimplemented `add_quotes()`) would read garbage. Reading an uninitialized bool is undefined behavior in C++. The companion member `text_start` (size_t) suffers the same defect.
+Severity rationale: Uninitialized member variable read is undefined behavior. While `add_quotes()` is currently not implemented, the member is part of the class invariant and any future reader would encounter UB. It also signals incomplete/broken initialization.
+Suggested fix: Initialize both members in the constructor member initializer list:
+```cpp
+report_formatter_csv::report_formatter_csv()
+    : csv_need_quotes(false), text_start(0)
+{}
+```
+
+### High item #2 : Out-of-bounds access in `add_summary_list` for odd-length vectors
+
+Location: src/report/report-formatter-html.cpp : 318-320
+Description: `add_summary_list` iterates over a `std::vector<std::string>` in steps of 2 (`i+=2`) and unconditionally accesses both `list[i]` and `list[i+1]` inside the loop. If the caller passes a vector with an odd number of elements, the last iteration accesses `list[i+1]` which is one past the end — undefined behavior and likely a crash or memory corruption. There is no assertion or bounds check guarding this. The same pattern in `report-formatter-csv.cpp` line 129-131 partially guards with `if(i < (list.size() - 1))` but that check itself underflows when `list.size() == 0` (size_t wraps to SIZE_MAX) — though harmless because the loop doesn't execute.
+Severity rationale: Out-of-bounds vector access is undefined behavior that can cause crashes or silent memory corruption in normal program operation if any caller provides an odd-length list.
+Suggested fix:
+```cpp
+for (size_t i = 0; i + 1 < list.size(); i += 2) {
+    add_exact(std::format("...", list[i], list[i+1]));
+}
+```
+
+## Review of src/cpu/cpu_core.cpp, src/cpu/cpudevice.h, src/cpu/cpudevice.cpp, src/cpu/abstract_cpu.cpp, src/cpu/cpu_rapl_device.cpp — batch 15
+
+### High item #1 : `using namespace std` in header file cpudevice.h
+
+Location: src/cpu/cpudevice.h : 31
+Description: `using namespace std;` appears at file scope in a header file. This is explicitly
+forbidden by both style.md (§4.2) and general-c++.md. Placing it in a header silently pollutes
+the global namespace for every translation unit that includes this header directly or transitively,
+making it far worse than the same statement in a .cpp file.
+Severity rationale: Header-scope `using namespace std` is explicitly banned and causes broad,
+hard-to-diagnose name collision risks across the entire codebase.
+Suggested fix: Remove the `using namespace std;` line. All standard types used in the header
+already carry explicit `std::` prefixes (e.g. `std::string`, `std::vector`), so no further
+changes are needed to make the header compile correctly.
+
+### High item #2 : `using namespace std` in header file cpu_rapl_device.h
+
+Location: src/cpu/cpu_rapl_device.h : 31
+Description: Same violation as cpudevice.h — `using namespace std;` at file scope in a header.
+Every file that includes `cpu_rapl_device.h` (directly or via cpudevice.h) inherits this
+namespace pollution.
+Severity rationale: Same as item #1; header-scope `using namespace std` is explicitly banned.
+Suggested fix: Remove the `using namespace std;` line. All identifiers in the header already
+use `std::` qualifiers or are fully spelled out.
+
+## Review of src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp — batch 16
+
+### High item #1 : Division by zero in report_display_cpu_cstates when num_cores == 0
+
+Location: src/cpu/cpu.cpp : 500
+Description: `cpu_tbl_size.cols = (2 * (num_cpus / num_cores)) + 1` is computed after
+counting only children whose `get_type()` returns exactly `"Core"`. GPU cores
+(type `"GPU"`) are present in the same children vector (added by `new_i965_gpu`).
+If a package contains only a GPU child or all `_core` pointers happen to be NULL,
+`num_cores` stays 0 and the integer division causes a divide-by-zero crash.
+Severity rationale: Any system with an integrated GPU (the i965 path) combined
+with certain topology configurations will hit this.
+Suggested fix: Guard the division: `cpu_tbl_size.cols = num_cores > 0 ? (2 * (num_cpus / num_cores)) + 1 : 1;`
+
+### High item #2 : Division by zero in report_display_cpu_pstates when num_cores == 0
+
+Location: src/cpu/cpu.cpp : 708
+Description: Same pattern as High item #1 in `report_display_cpu_pstates`:
+`cpu_tbl_size.cols = (num_cpus / num_cores) + 1` when `num_cores == 0` is a
+divide-by-zero crash.
+Severity rationale: Same reasoning as High item #1; both report paths are
+reachable from normal operation.
+Suggested fix: Guard as above: `cpu_tbl_size.cols = num_cores > 0 ? (num_cpus / num_cores) + 1 : 1;`
+
+### High item #3 : Null pointer dereference of `_core` after inner loop in report_display_cpu_cstates
+
+Location: src/cpu/cpu.cpp : 620
+Description: `_core` is declared as `NULL` at line 437. Inside the `for (core = ...)` loop it is
+assigned `_core = _package->children[core]`; when the child is NULL the loop
+`continue`s. After the loop `_core` holds the value from the last *executed*
+assignment, which may itself be NULL (if the last child slot is a NULL sentinel).
+At line 620, `_core->can_collapse()` is then called unconditionally, causing a
+null pointer dereference. The same pointer is used at line 621 as well.
+Severity rationale: Any package whose last indexed child slot is a gap (NULL)
+triggers this; this can happen with non-contiguous core numbering.
+Suggested fix: Test before use: `if (_core && !_core->can_collapse()) { ... }`
+
+### High item #4 : `using namespace std;` in header files
+
+Location: src/cpu/cpu.h : 36  and  src/cpu/cpu_rapl_device.h : 31
+Description: Both header files contain `using namespace std;` at file scope.
+This is explicitly prohibited by the project style guide and the C++ coding
+guidelines ("'using namespace std;' is a deprecated construct"). Being in headers,
+this silently forces every translation unit that includes these widely-used headers
+to import the entire `std` namespace, creating hidden name-collision hazards and
+polluting the namespace of all downstream code.
+Severity rationale: Affects every file in the project that transitively includes
+these headers; a name conflict introduced by a future standard library addition
+would be extremely hard to diagnose.
+Suggested fix: Remove both `using namespace std;` lines and qualify all bare uses
+of `vector`, `string`, `cout` etc. with `std::`.
+
+## Review of src/cpu/rapl/rapl_interface.cpp — batch 17
+
+### High item #1 : readdir loop does not skip "." and ".." entries (first loop)
+
+Location: src/cpu/rapl/rapl_interface.cpp : 98
+Description: The `while ((entry = readdir(dir)) != NULL)` loop starting at line 98 iterates over all entries in `/sys/class/powercap/intel-rapl/` without skipping the special entries "." and "..". The code constructs paths such as `base_path + entry->d_name + "/name"`, which for "." yields `.../intel-rapl/./name` (resolves to the parent directory's `name` file) and for ".." yields `.../powercap/name`. While `read_sysfs_string` likely returns an empty string for these nonexistent paths, this is an explicit violation of the rules.md requirement and could potentially read unintended sysfs files if the filesystem layout changes.
+Severity rationale: Explicit violation of the rules.md directory-traversal rule. Low-probability but not zero risk of reading unintended paths.
+Suggested fix: Add a check at the top of the loop body: `if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;`
+
+### High item #2 : readdir loop does not skip "." and ".." entries (second loop)
+
+Location: src/cpu/rapl/rapl_interface.cpp : 116
+Description: The second `while ((entry = readdir(dir)) != NULL)` loop at line 116 iterates over a package subdirectory without skipping "." and "..". It constructs `path = package_path + entry->d_name` and then reads `path + "/name"`. For ".." this would resolve to the parent path `/sys/class/powercap/intel-rapl/<entry>/name`, potentially matching a domain name of "core", "dram", or "uncore" in unexpected locations if the sysfs tree structure were ever to include such files at the parent level.
+Severity rationale: Same rule violation as item #1; the second loop compounds the issue.
+Suggested fix: Same as item #1 — add a "." / ".." skip guard at the top of the loop body.
+
+## Review of wakeup_usb.h, wakeup_ethernet.h, waketab.cpp, wakeup_ethernet.cpp, wakeup.cpp — batch 18
+
+### High item #1 : stray semicolon at start of wakeup_ethernet.cpp
+
+Location: src/wakeup/wakeup_ethernet.cpp : 1
+Description: The file begins with `;/*` — a bare semicolon before the copyright comment. While C++11 permits empty declarations at namespace scope, this is clearly a typo/corruption that has no business being there. It confuses source tools, diff viewers, and static analysers, and is a latent sign of file-level editing damage.
+Severity rationale: High — it is an unambiguous file corruption that affects every build. It is only not critical because C++11 empty-declaration rules save it from a compile error.
+Suggested fix: Remove the leading `;` so the file starts with `/*`.
+
+### High item #2 : out-of-bounds vector access in cursor_enter when wakeup_all is empty
+
+Location: src/wakeup/waketab.cpp : 46, 105
+Description: `win->cursor_max` is assigned `wakeup_all.size() - 1`. When `wakeup_all` is empty, `size_t(0) - 1` wraps to `SIZE_MAX`; the implicit narrowing conversion to `int cursor_max` yields -1. The navigation guards (`cursor_pos < cursor_max`) therefore prevent moving the cursor, but `cursor_pos` is initialised to 0 and `cursor_enter()` is called unconditionally on Enter. Inside `cursor_enter`, `wakeup_all[cursor_pos]` (line 105) accesses `wakeup_all[0]` on an empty vector — undefined behaviour that in practice crashes.
+Severity rationale: High — any system with no wakeup-capable devices will crash on Enter in the WakeUp tab. The unsigned-to-signed truncation also silently suppresses any diagnostic.
+Suggested fix:
+```cpp
+win->cursor_max = wakeup_all.empty() ? 0 : (int)wakeup_all.size() - 1;
+```
+And add a bounds guard in `cursor_enter`:
+```cpp
+if ((size_t)cursor_pos >= wakeup_all.size())
+    return;
+```
+
+### High item #3 : `using namespace std` in headers
+
+Location: src/wakeup/wakeup_usb.h : 32  and  src/wakeup/wakeup_ethernet.h : 32
+Description: Both headers contain `using namespace std;` at file scope. This silently injects the entire `std` namespace into every translation unit that includes them, potentially causing name collisions or hiding bugs in unrelated code. The coding style guide explicitly forbids this.
+Severity rationale: High — namespace pollution from a header affects all includers and is a hard style-guide violation.
+Suggested fix: Remove both `using namespace std;` lines. The classes already use fully-qualified `std::string` everywhere they need it.
+
+## Review of src/measurement/acpi.cpp — batch 19
+
+### High item #1 : `/proc/acpi/battery/` path removed from Linux kernel
+
+Location: src/measurement/acpi.cpp : 74
+Description: The `acpi_power_meter::measure()` function reads from `/proc/acpi/battery/{name}/state`. This `/proc/acpi/battery/` interface was removed from the Linux kernel in version 2.6.39 (released April 2011). On any kernel shipped in the past decade, `read_file_content()` will always return an empty string, causing `measure()` to return immediately without setting any values. As a result, `power()` always returns 0.0 — the entire `acpi_power_meter` class is silently non-functional on modern systems. The replacement interface is `/sys/class/power_supply/` with the `energy_now`, `power_now`, `voltage_now`, etc. attributes.
+Severity rationale: High — the entire measurement class fails silently on all modern kernels; users relying on ACPI battery data receive no power readings.
+Suggested fix: Rewrite `measure()` to use `/sys/class/power_supply/{name}/power_now` (or `current_now` × `voltage_now`) from the sysfs power supply class. Remove the `/proc/acpi/battery/` parsing entirely.
+
+## Review of sysfs.h, sysfs.cpp, measurement.h, measurement.cpp, extech.h — batch 20
+
+### High item #1 : `using namespace std;` in a header file
+
+Location: src/measurement/measurement.h : 31
+Description: `using namespace std;` appears at global scope in a header file. Every translation unit that includes `measurement.h` (directly or indirectly) inherits this namespace pollution. This is explicitly forbidden by general-c++.md ("using namespace std; is a deprecated construct") and style.md §4.2. It is also the root cause of unqualified `string` and `vector` usage in sysfs.cpp (lines 32, 38) and measurement.cpp (line 58).
+Severity rationale: Broad, silent namespace pollution that violates an explicit project rule and can cause unexpected name collisions in any including file.
+Suggested fix: Remove `using namespace std;` from measurement.h. Replace `vector<class power_meter *>` on line 61 with `std::vector<power_meter *>`. Update all callers that relied on the implicit `using namespace std;` (sysfs.cpp lines 32/38 and measurement.cpp line 58) to use fully qualified `std::string` and `std::vector`.
+
+### High item #2 : `CLOCK_REALTIME` used for elapsed-time measurement
+
+Location: src/measurement/measurement.cpp : 65, 102
+Description: Both `start_power_measurement` (line 65) and `global_sample_power` (line 102) call `clock_gettime(CLOCK_REALTIME, ...)` to measure elapsed wall-clock time. `CLOCK_REALTIME` can jump forward or backward due to NTP corrections, leap-second smearing, or manual adjustments. A backward jump makes `tnow - tlast` negative, accumulating negative joules. A large forward jump inflates the joules figure by hours of phantom energy. `CLOCK_MONOTONIC` is the correct clock for measuring elapsed time intervals.
+Severity rationale: Directly corrupts the joules accumulation used for battery life estimates whenever the system clock is adjusted during a measurement period.
+Suggested fix: Replace `CLOCK_REALTIME` with `CLOCK_MONOTONIC` at both call sites.
+
+### High item #3 : Data race on `sum` and `samples` in extech_power_meter
+
+Location: src/measurement/extech.h : 36-37
+Description: `sum` (double) and `samples` (int) are written by the sampling thread (`sample()` in extech.cpp) and read by the main thread in `end_measurement()` without any mutex, lock, or atomic type. Under the C++20 memory model this is a data race and constitutes undefined behavior. On architectures that do not guarantee atomic double/int reads the final `rate = sum / samples` can observe a torn value.
+Severity rationale: Undefined behavior triggered on every use of an Extech power meter device; can produce garbage power readings or crash.
+Suggested fix: Use `std::atomic<double> sum` and `std::atomic<int> samples`, or protect access with a `std::mutex`. Since `std::atomic<double>` only became lock-free on common hardware in C++20, a mutex is the safer portable choice.
+
+## Review of src/measurement/extech.cpp, src/devices/backlight.cpp — batch 21
+
+### High item #1 : Thread data races on shared variables in extech sampling thread
+
+Location: src/measurement/extech.cpp : 311-312, 330-333, 341-342
+Description: The member variables `sum`, `samples`, and `end_thread` are accessed from two threads concurrently — the sampling thread (via `sample()`) and the main thread (via `start_measurement()` and `end_measurement()`) — with no synchronization whatsoever. `end_thread` is a plain `int` used as a thread-termination flag, which the compiler may cache in a register and never re-read from memory. Reading and writing these variables from multiple threads without atomics or mutexes is undefined behavior under the C++ memory model.
+Severity rationale: Data races are undefined behavior in C++20. The race on `end_thread` can cause the sampling thread to loop forever; races on `sum`/`samples` can produce torn reads and corrupt power-usage values reported to users.
+Suggested fix: Declare `end_thread` as `std::atomic<int>` (or `std::atomic<bool>`). Protect `sum` and `samples` with a `std::mutex`, or use `std::atomic<double>`/`std::atomic<int>` for them.
+
+### High item #2 : Division by zero in backlight::utilization() and end_measurement() when max_level is 0
+
+Location: src/devices/backlight.cpp : 102, 117
+Description: Both `backlight::end_measurement()` (line 102) and `backlight::utilization()` (line 117) compute `100.0 * (...) / max_level`. `max_level` is read from sysfs in `start_measurement()` and is initialized to 0 in the constructor. If the sysfs read fails, or if `start_measurement()` is never called, `max_level` remains 0, causing a division by zero (or, for IEEE 754 double, a ±inf/NaN result) that propagates into power estimates.
+Severity rationale: A missing or unreadable sysfs file causes a divide-by-zero, producing meaningless (inf/NaN) power values that corrupt downstream calculations and user-visible output.
+Suggested fix: Guard both call sites: `if (max_level <= 0) return 0.0;` before the division.
+
+### High item #3 : Error sentinel values from extech_read() silently accumulated into sum
+
+Location: src/measurement/extech.cpp : 311
+Description: `extech_read()` returns `-1.0` on select timeout/error and `-1000.0` on parse failure. In `sample()`, the return value is unconditionally added to `sum` with `sum += extech_read(fd)`. Whenever the device fails to respond or returns a bad packet, a large negative value is folded into the running average, producing a badly wrong `rate` once `end_measurement()` computes `sum / samples`.
+Severity rationale: Error readings directly contaminate the power measurement average, leading to incorrect (heavily negative) watt values shown to the user.
+Suggested fix: Check the return value before accumulating: `double v = extech_read(fd); if (v >= 0.0) { sum += v; samples++; }` (and remove the separate `samples++` on line 312).
+
+## Review of src/devices/usb.h, src/devices/usb.cpp, src/devices/gpu_rapl_device.h, src/devices/gpu_rapl_device.cpp, src/devices/ahci.h — batch 22
+
+### High item #1 : `using namespace std;` in header file gpu_rapl_device.h
+
+Location: src/devices/gpu_rapl_device.h : 31
+Description: The file contains `using namespace std;` at global scope in a header. This is explicitly forbidden by both `style.md` (§4.2) and `general-c++.md`. When placed in a header file, it silently injects the entire `std` namespace into every translation unit that includes this header, causing hard-to-diagnose name collisions and making it impossible for includers to opt out. All other headers in the project use the `std::` prefix convention; this one is an outlier.
+Severity rationale: Header-level `using namespace std` pollutes all includers' namespaces and is explicitly listed as a deprecated construct in the coding rules. The impact is project-wide.
+Suggested fix: Remove `using namespace std;` and prefix all standard-library types in the header with `std::`. Because the header itself only uses `std::string` and `std::vector` (via the includes), the fix is mechanical: drop line 31 and verify no bare `string` or `vector` names remain in the header.
+
+### High item #2 : `power_valid()` can return values other than 0/1 in ahci.h
+
+Location: src/devices/ahci.h : 63
+Description: The method `power_valid()` returns `utilization_power_valid(partial_rindex) + utilization_power_valid(active_rindex)`. Each `utilization_power_valid()` call returns 0 or 1. When both AHCI states are valid, the sum is 2. The base-class `device::power_valid()` contract returns an int treated as a boolean flag; callers that check `power_valid() == 1` or cast to bool (which is fine), but callers checking `!= 0` also work. However the semantics of "how many sub-metrics are valid" vs "is power valid at all" are conflated. If the intent is "power is valid if either partial or active is valid" the expression should be `||` not `+`; if it means "valid only when both are valid" the expression should be `&&`. Neither intention produces the value 2.
+Severity rationale: Incorrect boolean arithmetic in a validation predicate that controls whether power data is displayed to the user. Could cause incorrect display behavior depending on caller comparison style.
+Suggested fix: Change to: `return utilization_power_valid(partial_rindex) || utilization_power_valid(active_rindex);` (or `&&` if both are required).
+
+
+## Review of src/devices/ahci.cpp, src/devices/thinkpad-fan.h, src/devices/thinkpad-fan.cpp, src/devices/device.h, src/devices/device.cpp — batch 23
+
+### High item #1 : `using namespace std;` in a header file
+
+Location: src/devices/device.h : 74
+Description: `using namespace std;` appears at the end of device.h, after the class definition. Because this is a header file, every translation unit that includes device.h silently inherits this directive. This can cause hard-to-diagnose name collisions with std names (e.g. `string`, `vector`, `sort`) silently resolving to `std::` symbols when the programmer may intend otherwise. The `std::` prefix is already used correctly throughout the class definition above it, making this directive entirely unnecessary.
+Severity rationale: Placing `using namespace std;` in a header is explicitly prohibited by style.md §4.2 and general-c++.md ("using namespace std; is a deprecated construct"). Its presence in a header is strictly worse than in a .cpp file because it contaminates all includers transitively.
+Suggested fix: Remove line 74 (`using namespace std;`) from device.h entirely.
+
+### High item #2 : `report_device_stats` never writes the Link-name column; all stats shifted one column
+
+Location: src/devices/ahci.cpp : 307–325
+Description: The table built in `ahci_create_device_stats_table` has five columns: "Link", "Active", "Partial", "Slumber", "Devslp". For row `idx`, the first cell occupies position `idx*5+5` (the "Link" column). `report_device_stats` starts writing at `offset = idx*5+5` and stores `active_util`, then `partial_util`, `slumber_util`, `devslp_util` — four values. Consequently: (1) the "Link" column for every row shows the active-utilization number instead of the device name; (2) "Active" shows partial utilisation; "Partial" shows slumber; "Slumber" shows devslp; and (3) the "Devslp" column is always empty. The human-readable link/disk name is never stored in the table at all.
+Severity rationale: This is a logic error that always produces a visibly wrong HTML report for any system with AHCI links — a user-facing functional defect that always fires.
+Suggested fix: Prepend a store of the link name before the utilisation values:
+```cpp
+void ahci::report_device_stats(std::vector<std::string> &ahci_data, int idx)
+{
+    int offset = (idx * 5 + 5);
+    ahci_data[offset] = humanname;   // Link column
+    offset += 1;
+    ahci_data[offset] = std::format("{:5.1f}", get_result_value(active_rindex, &all_results));
+    offset += 1;
+    ahci_data[offset] = std::format("{:5.1f}", get_result_value(partial_rindex, &all_results));
+    offset += 1;
+    ahci_data[offset] = std::format("{:5.1f}", get_result_value(slumber_rindex, &all_results));
+    offset += 1;
+    ahci_data[offset] = std::format("{:5.1f}", get_result_value(devslp_rindex, &all_results));
+}
+```
+
+### High item #3 : `closedir` not called before early return in `model_name`
+
+Location: src/devices/ahci.cpp : 98
+Description: Inside the `model_name` function, when a directory entry whose name contains both ':' and "target" is found, the code does `return disk_name(pathname, d_name, shortname);` immediately, bypassing the `closedir(dir)` call at line 101. Every call to `model_name` that successfully finds a matching entry leaks one open directory file descriptor. Because `create_all_ahcis` calls `ahci::ahci` which calls `model_name` for every AHCI device at start-up, each AHCI disk leaks one fd per measurement session start.
+Severity rationale: File descriptor leak; bounded by number of AHCI devices but still a resource management defect.
+Suggested fix:
+```cpp
+    std::string result = disk_name(pathname, d_name, shortname);
+    closedir(dir);
+    return result;
+```
+## Review of src/devices/devfreq.cpp, src/devices/devfreq.h, src/devices/alsa.h, src/devices/alsa.cpp, src/devices/runtime_pm.cpp — batch 24
+
+### High item #1 : `using namespace std;` in alsa.cpp
+
+Location: src/devices/alsa.cpp : 33
+Description: `using namespace std;` appears at file scope in alsa.cpp. This is explicitly forbidden by both style.md ("Avoid `using namespace std;`") and general-c++.md ("`using namespace std;` is a deprecated construct"). All other files in this batch that need std names obtain them through the transitive pull of `device.h`'s own `using namespace std;`, which is itself a problem (see batch 23), but alsa.cpp adds a second independent violation. Pollutes the global namespace for all translation-unit consumers of this header chain.
+Severity rationale: Explicitly named as forbidden in both style and language rules.
+Suggested fix: Remove line 33 (`using namespace std;`). Add `std::` prefix to all unqualified standard-library names in the file (they are already there for most; the remaining uses of unqualified `string` on lines 44, 102, etc. are covered by device.h's `using namespace std;` leak, which should also be cleaned up separately).
+
+### High item #2 : Unsigned underflow in `process_time_stamps()` loop bound
+
+Location: src/devices/devfreq.cpp : 76
+Description: `dstates.size()` returns `size_t` (unsigned). The expression `dstates.size()-1` wraps to `SIZE_MAX` when `dstates` is empty. The for-loop `for (i=0; i < dstates.size()-1; i++)` would then iterate from 0 to SIZE_MAX, repeatedly accessing `dstates[i]` out of bounds, causing undefined behaviour. After the loop, `dstates[i]` is accessed again at line 82 on the last element (the idle state). Under normal operation `start_measurement()` always inserts at least the idle state via `update_devfreq_freq_state(0,0)`, so this is not triggered at runtime today — but the code is one misuse or refactor away from silent memory corruption.
+Severity rationale: Unsigned wrap-around producing an enormous loop bound and subsequent out-of-bounds vector access; undefined behaviour if triggered.
+Suggested fix:
+```cpp
+if (dstates.empty())
+    return;
+for (i = 0; i < dstates.size() - 1; i++) { ... }
+dstates[i]->time_after = sample_time - active_time;
+```
+
+### High item #3 : Division by zero in `fill_freq_utilization()` when `sample_time == 0`
+
+Location: src/devices/devfreq.cpp : 196
+Description: `fill_freq_utilization()` computes `percentage(1.0 * state->time_after / sample_time)`. `sample_time` is a `double` member initialised to 0 in `start_measurement()`. If `end_measurement()` has not been called yet, or if the two timestamps are identical (extremely short measurement window), `sample_time` is 0.0 and the division is undefined (IEEE 754 returns ±∞ or NaN). This value propagates into `percentage()` and eventually into the ncurses display as a garbage string.
+Severity rationale: Results in NaN/infinity being formatted and displayed to the user; directly impacts user-visible output.
+Suggested fix:
+```cpp
+if (sample_time <= 0.0)
+    return "";
+return std::format(" {:5.1f}% ", percentage(1.0 * state->time_after / sample_time));
+```
+
+## Review of runtime_pm.h, network.cpp, network.h, i915-gpu.h, i915-gpu.cpp — batch 25
+
+### High item #1 : `using namespace std;` in network.cpp
+
+Location: src/devices/network.cpp : 39
+Description: `using namespace std;` is present at file scope. Per style.md §4.2 and general-c++.md, `using namespace std;` is an explicitly prohibited construct in this codebase. It pollutes the global namespace and can cause subtle name collisions. The rest of the file uses a mix of bare `string`, `map`, etc. (relying on the directive) alongside proper `std::` prefixed names.
+Severity rationale: The style guide calls this a deprecated/prohibited construct; it is a systematic violation affecting the entire file.
+Suggested fix: Remove `using namespace std;` and qualify all standard library names with `std::` (e.g., `std::map`, `std::string`, `string::npos` → `std::string::npos`).
+
+### High item #2 : `using namespace std;` in i915-gpu.cpp
+
+Location: src/devices/i915-gpu.cpp : 35
+Description: Same violation as above — `using namespace std;` at file scope. Although the code in i915-gpu.cpp uses only a small amount of standard library functionality, the directive is present and constitutes a clear style violation as defined in style.md §4.2 and general-c++.md.
+Severity rationale: Prohibited construct per project coding standards.
+Suggested fix: Remove `using namespace std;`; add explicit `std::` prefixes where needed.
+
+### High item #3 : Memory leak when `device_present()` returns false in `create_i915_gpu`
+
+Location: src/devices/i915-gpu.cpp : 86–88
+Description: A `gpu_rapl_device` object is allocated unconditionally (`rapl_dev = new class gpu_rapl_device(gpu)`), but it is only pushed onto `all_devices` if `rapl_dev->device_present()` returns true. When `device_present()` returns false the object is neither stored nor deleted, causing a permanent memory leak. Unlike the rest of PowerTOP where devices live for the duration of the process, this allocation happens early and the leaked object will never be reclaimed.
+Severity rationale: Unconditional resource leak with no recovery path.
+Suggested fix:
+```cpp
+rapl_dev = new(std::nothrow) gpu_rapl_device(gpu);
+if (rapl_dev) {
+    if (rapl_dev->device_present())
+        all_devices.push_back(rapl_dev);
+    else
+        delete rapl_dev;
+}
+```

--- a/logs/low.md
+++ b/logs/low.md
@@ -1,0 +1,1292 @@
+# PowerTOP Low Severity Review Findings
+
+## Review of calibrate.cpp, calibrate.h, lib.cpp, devlist.cpp, main.cpp — batch 01
+
+### Low item #1 : `calibrate.h` uses `#ifndef` guard instead of `#pragma once`
+
+Location: src/calibrate/calibrate.h : 25–27
+
+Description:
+The header uses a traditional include guard:
+```cpp
+#ifndef __INCLUDE_GUARD_CALIBRATE_H
+#define __INCLUDE_GUARD_CALIBRATE_H
+```
+The project style guide (style.md §4.1) mandates `#pragma once` for all headers.
+
+Severity rationale: Style violation; `#pragma once` is the project standard and is universally supported by the compilers in use.
+
+Suggested fix: Replace with `#pragma once` and remove the `#endif` at the bottom.
+
+---
+
+### Low item #2 : `calibrate.h` uses `std::string` without including `<string>`
+
+Location: src/calibrate/calibrate.h : 28
+
+Description:
+The declaration `void one_measurement(int, int, const std::string &)` references `std::string` but the header does not include `<string>`. Any translation unit that includes `calibrate.h` before pulling in `<string>` itself will fail to compile. Headers must be self-contained.
+
+Severity rationale: Latent compilation error; currently masked because all callers happen to include `<string>` earlier.
+
+Suggested fix: Add `#include <string>` to `calibrate.h`.
+
+---
+
+### Low item #3 : Duplicate `#include` directives in lib.cpp
+
+Location: src/lib.cpp : 35, 51, 37, 53, 55, 56, 36, 62
+
+Description:
+The following headers are included more than once:
+- `<stdio.h>` — lines 35 and 51
+- `<stdlib.h>` — lines 37 and 53
+- `<sys/types.h>` — lines 55 and 56 (consecutive duplicates)
+- `<math.h>` — lines 36 and 62
+
+While harmless due to include guards, duplicate includes are noise and may indicate copy-paste accumulation.
+
+Severity rationale: Code quality / maintenance issue; violates the principle of clean, intentional includes.
+
+Suggested fix: Remove the duplicate include directives; keep one of each.
+
+---
+
+### Low item #4 : `setrlimit` return value not checked
+
+Location: src/main.cpp : 369
+
+Description:
+```cpp
+rlmt.rlim_cur = rlmt.rlim_max = get_nr_open();
+setrlimit(RLIMIT_NOFILE, &rlmt);
+```
+The return value of `setrlimit` is silently discarded. If the call fails, PowerTOP will run with a lower file-descriptor limit than required, potentially causing spurious "too many open files" errors later when iterating `/proc/PID/fd/`.
+
+Severity rationale: Unchecked system-call failure can lead to confusing downstream errors.
+
+Suggested fix:
+```cpp
+if (setrlimit(RLIMIT_NOFILE, &rlmt) != 0)
+    fprintf(stderr, _("Failed to raise open file limit: %s\n"), strerror(errno));
+```
+
+---
+
+### Low item #5 : `mkdir` return values not checked in `powertop_init`
+
+Location: src/main.cpp : 402–404
+
+Description:
+```cpp
+if (access("/var/cache/", W_OK) == 0)
+    mkdir("/var/cache/powertop", 0600);
+else
+    mkdir("/data/local/powertop", 0600);
+```
+Neither `mkdir` call checks its return value. If directory creation fails for any reason other than the directory already existing (`EEXIST`), the subsequent `load_results` / `save_parameters` calls will silently fail to find or write their data files.
+
+Severity rationale: Silent failure to create the cache directory; saved calibration data may be quietly lost.
+
+Suggested fix: Check the return value and ignore only `EEXIST`:
+```cpp
+if (mkdir("/var/cache/powertop", 0600) != 0 && errno != EEXIST)
+    fprintf(stderr, _("Failed to create cache directory: %s\n"), strerror(errno));
+```
+
+---
+
+### Low item #6 : `blmax` global is overwritten for each backlight device
+
+Location: src/calibrate/calibrate.cpp : 152–154
+
+Description:
+```cpp
+static int blmax;
+...
+static void find_backlight_callback(const std::string &d_name)
+{
+    ...
+    backlight_devices.push_back(filename);
+    filename = std::format("/sys/class/backlight/{}/max_brightness", d_name);
+    blmax = read_sysfs(filename);
+}
+```
+`blmax` is a single global. When multiple backlight devices exist, each call to the callback overwrites it. `backlight_calibration` then uses this single `blmax` value for all devices, but writes it back only to the device that was current at calibration time, not to each device's own max. The brightness levels written (`blmax/4`, `blmax/2`, etc.) will be wrong for all but the last discovered device.
+
+Severity rationale: Incorrect calibration data for multi-backlight systems.
+
+Suggested fix: Store `(device_path, max_brightness)` pairs together, e.g., using a `std::vector<std::pair<std::string,int>>`.
+
+---
+
+### Low item #7 : Hardcoded `"wlan0"` wireless interface name
+
+Location: src/calibrate/calibrate.cpp : 77, 385, 393, 408
+
+Description:
+The interface name `"wlan0"` is hardcoded in `restore_all_sysfs`, `calibrate`, and the `set_wifi_power_saving` calls. On modern Linux systems the interface may be named `wlp2s0`, `wlan1`, or something else entirely. If `"wlan0"` does not exist, `get_wifi_power_saving` / `set_wifi_power_saving` will silently do nothing (or fail silently), and the saved PS state will be incorrect.
+
+Severity rationale: Calibration will incorrectly handle Wi-Fi power saving on systems without a `wlan0` interface; no error is reported.
+
+Suggested fix: Auto-detect the active wireless interface (e.g., by scanning `/sys/class/net/*/wireless/`) rather than hardcoding `"wlan0"`.
+
+## Review of src/test_framework.h, src/test_framework.cpp, src/display.cpp, src/display.h, src/lib.h — batch 02
+
+### Low item #1 : `NULL` used instead of `nullptr` in lib.h
+
+Location: src/lib.h : 81
+Description: `bool *ok = NULL` uses the C-style null pointer constant `NULL`. In C++11+ (and especially C++20) `nullptr` is the correct null pointer literal, providing type safety. `NULL` is typically `0` or `(void*)0`, which can cause overload ambiguity.
+Severity rationale: C++ best-practice violation; no runtime risk in this specific context but wrong idiom.
+Suggested fix: `bool *ok = nullptr`
+
+---
+
+### Low item #2 : `create_tab()` `bottom_line` parameter passed by value
+
+Location: src/display.h : 96
+Description: `void create_tab(const string &name, const string &translation, class tab_window *w = NULL, string bottom_line = "")` — the `bottom_line` parameter is passed by value (copy), requiring a heap allocation for every non-empty string argument. It should be `const std::string&` consistent with the other string parameters.
+Severity rationale: Unnecessary copy; inconsistent with surrounding API.
+Suggested fix:
+```cpp
+void create_tab(const std::string &name, const std::string &translation,
+                tab_window *w = nullptr, const std::string &bottom_line = "");
+```
+
+---
+
+### Low item #3 : `tab_windows` map holds raw owning pointers with no cleanup
+
+Location: src/display.h : 91, src/display.cpp : 41
+Description: `map<string, class tab_window *> tab_windows` stores raw owning pointers to `tab_window` objects. These are never deleted when the map is destroyed or when tabs are removed. The destructor of `tab_window` deletes the ncurses window (`delwin(win)`), so proper ownership is needed. Using `std::unique_ptr<tab_window>` would enforce automatic cleanup.
+Severity rationale: Memory leak and potential use-after-free if tabs are ever programmatically replaced.
+Suggested fix: Change to `std::map<std::string, std::unique_ptr<tab_window>> tab_windows;` and adjust call sites.
+
+---
+
+### Low item #4 : Magic sentinel string `"__POWERTOP_FILE_NOT_FOUND__"` should be a named constant
+
+Location: src/test_framework.cpp : 52, 62, 125, 159
+Description: The special sentinel value `"__POWERTOP_FILE_NOT_FOUND__"` is used in four places but defined nowhere as a constant. If it is ever changed in one location and not another, the record/replay mechanism silently breaks.
+Severity rationale: Maintainability risk; magic string repeated in multiple locations.
+Suggested fix:
+```cpp
+static constexpr const char* FILE_NOT_FOUND_SENTINEL = "__POWERTOP_FILE_NOT_FOUND__";
+```
+
+---
+
+### Low item #5 : `new(class tab_window)` — misleading placement-new syntax
+
+Location: src/display.cpp : 49
+Description: `w = new(class tab_window);` uses the parenthesised `(type-id)` form of `new`, which is valid C++ but visually identical to placement-new syntax `new(ptr) T`. Any reader encountering `new(...)` expects a placement expression, not a regular heap allocation. The elaborated type specifier `class tab_window` inside the parentheses adds further confusion.
+Severity rationale: Readability/maintenance issue; no runtime risk.
+Suggested fix: `w = new tab_window();`
+
+---
+
+### Low item #6 : `replay_write()` logs mismatch to `cerr` but does not throw — silent test failure
+
+Location: src/test_framework.cpp : 72–85
+Description: When a write mismatch is detected during replay, the function prints to `cerr` and returns normally. The calling code continues executing as if the write was correct. Contrast with `replay_read()` and `replay_msr()`, which throw `test_exception` on unexpected conditions. This inconsistency means write-mismatch test failures are easy to miss, especially in automated pipelines that do not scan `stderr`.
+Severity rationale: Silent test failure undermines the reliability of the test framework.
+Suggested fix: Replace the `cerr` output with `throw test_exception(...)`.
+
+---
+
+### Low item #7 : "PowerTOP %s" version header string not translatable
+
+Location: src/display.cpp : 119
+Description: `mvwprintw(tab_bar, 0,0, "PowerTOP %s", PACKAGE_VERSION)` prints a static English string. While the product name is typically not translated, the format string itself is not wrapped in `_()`, inconsistent with the project i18n policy and preventing translators from reordering tokens if needed.
+Severity rationale: Minor i18n policy violation.
+Suggested fix: `mvwprintw(tab_bar, 0, 0, _("PowerTOP %s"), PACKAGE_VERSION);`
+
+## Review of src/devlist.h, src/tuning/tunable.h, src/tuning/tunable.cpp, src/tuning/runtime.h, src/tuning/runtime.cpp — batch 03
+
+### Low item #1 : Missing copyright/license header in devlist.h
+
+Location: src/devlist.h : 1
+Description: `devlist.h` has no copyright and GPL license header. Every file in the project is required to carry the standard Intel copyright block per style.md §3.1.
+Severity rationale: License compliance issue; all other headers in the project carry the required header.
+Suggested fix: Add the standard copyright/license block at the top of the file (same template as in tunable.h, runtime.h, etc.).
+
+### Low item #2 : `#ifndef`/`#define` header guards instead of `#pragma once` in devlist.h
+
+Location: src/devlist.h : 1–2, 29
+Description: `devlist.h` uses the old-style `#ifndef __INCLUDE_GUARD_DEVLIST_H__` / `#define` / `#endif` guard. The project style (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style violation; inconsistent with the stated project standard.
+Suggested fix: Replace the three guard lines with `#pragma once`.
+
+### Low item #3 : `#ifndef`/`#define` header guards instead of `#pragma once` in tunable.h
+
+Location: src/tuning/tunable.h : 25–26, 92
+Description: Same violation as Low #2. `tunable.h` uses `#ifndef _INCLUDE_GUARD_TUNABLE_H`.
+Severity rationale: Style violation.
+Suggested fix: Replace with `#pragma once`.
+
+### Low item #4 : `#ifndef`/`#define` header guards instead of `#pragma once` in runtime.h
+
+Location: src/tuning/runtime.h : 25–26, 48
+Description: Same violation as Low #2 and Low #3. `runtime.h` uses `#ifndef _INCLUDE_GUARD_RUNTIME_TUNE_H`.
+Severity rationale: Style violation.
+Suggested fix: Replace with `#pragma once`.
+
+### Low item #5 : Constructors do not use member initializer lists in tunable.cpp
+
+Location: src/tuning/tunable.cpp : 35–52
+Description: Both constructors assign to member variables in the constructor body (`desc = str;`, `score = _score;`, etc.) rather than using a member initializer list. In C++, member initializer lists are preferred as they initialize members directly rather than default-constructing them first and then assigning.
+Severity rationale: C++ best-practice violation per general-c++.md. For `std::string` members this causes a default construction followed by a copy-assignment instead of a single copy construction.
+Suggested fix: Use member initializer lists, e.g.:
+```cpp
+tunable::tunable(const std::string &str, double _score,
+                 const std::string &good, const std::string &bad,
+                 const std::string &neutral)
+    : desc(str), score(_score),
+      good_string(good), bad_string(bad), neutral_string(neutral)
+{}
+```
+
+### Low item #6 : `while (1)` instead of `while (true)` in runtime.cpp
+
+Location: src/tuning/runtime.cpp : 133
+Description: `while (1)` is a C idiom. C++ code should use `while (true)` for clarity and to avoid implicit int-to-bool conversion.
+Severity rationale: C++ style violation per general-c++.md.
+Suggested fix: Change `while (1)` to `while (true)`.
+
+### Low item #7 : Redundant `extern` keyword on function declarations in devlist.h
+
+Location: src/devlist.h : 21–27
+Description: All function declarations in `devlist.h` are prefixed with `extern`. In C++, free functions declared at namespace scope are externally linked by default; the `extern` keyword is redundant and adds noise.
+Severity rationale: Low severity style inconsistency; no functional impact.
+Suggested fix: Remove the `extern` keyword from all function declarations in the header.
+
+## Review of ethernet.cpp, ethernet.h, wifi.cpp, wifi.h, tuningusb.h — batch 04
+
+### Low item #1 : C-style casts `(caddr_t)` in ethernet.cpp
+
+Location: src/tuning/ethernet.cpp : 86 and 122
+Description: `ifr.ifr_data = (caddr_t)&wol;` uses a C-style cast. In C++ code, `reinterpret_cast` should be used when casting between unrelated pointer types to make the intent explicit and to be caught by static analysis tools.
+Severity rationale: C++ best-practice violation; C-style casts bypass type-safety checks.
+Suggested fix: `ifr.ifr_data = reinterpret_cast<caddr_t>(&wol);`
+
+### Low item #2 : `interf` member is `public` in `ethernet_tunable`
+
+Location: src/tuning/ethernet.h : 36
+Description: The `interf` data member is declared `public`, exposing the internal interface name of the tunable to all callers. It is only used internally by the class's own methods. Encapsulation calls for it to be `private` (or at most `protected`).
+Severity rationale: Unnecessary exposure of internals; violates encapsulation; matches the pattern used in wifi_tunable where `iface` is correctly `private`.
+Suggested fix: Move `std::string interf;` to the `private:` section.
+
+### Low item #3 : Redundant `class` keyword in local variable declarations
+
+Location: src/tuning/ethernet.cpp : 134 and src/tuning/wifi.cpp : 80, 91
+Description: `class ethernet_tunable *eth` and `class wifi_tunable *wifi` use the elaborated type specifier `class`. In C++ this is unnecessary and unusual; `ethernet_tunable *eth` and `wifi_tunable *wifi` are idiomatic.
+Severity rationale: Low-impact style violation; not idiomatic C++.
+Suggested fix: Remove the redundant `class` keyword from all three variable declarations.
+
+### Low item #4 : Unused includes `<utility>` and `<iostream>` in ethernet.cpp
+
+Location: src/tuning/ethernet.cpp : 33 and 34
+Description: Neither `<utility>` (std::pair, std::move, etc.) nor `<iostream>` (std::cout, std::cin, etc.) symbols are used anywhere in ethernet.cpp. These unused includes add unnecessary compilation overhead and obscure the file's real dependencies.
+Severity rationale: Dead code; same pattern flagged in previous batches.
+Suggested fix: Remove `#include <utility>` and `#include <iostream>` from ethernet.cpp.
+
+### Low item #5 : Unused includes `<utility>` and `<iostream>` in wifi.cpp
+
+Location: src/tuning/wifi.cpp : 31 and 32
+Description: Same as Low item #4 — `<utility>` and `<iostream>` are included but nothing from them is used in wifi.cpp.
+Severity rationale: Same as Low item #4.
+Suggested fix: Remove `#include <utility>` and `#include <iostream>` from wifi.cpp.
+
+## Review of tuningusb.cpp, tuning.cpp, tuning.h, bluetooth.cpp, bluetooth.h — batch 05
+
+### Low item #1 : System header included with quotes instead of angle brackets
+
+Location: src/tuning/tuningusb.cpp : 28
+Description: `#include "unistd.h"` uses double-quote syntax for a system header. Double-quote includes first search the local directory, which can accidentally shadow a system header with a local file of the same name. System headers must use `<unistd.h>`.
+Severity rationale: Incorrect include style; harmless in practice but violates the include-order style rule.
+Suggested fix: Change to `#include <unistd.h>`.
+
+### Low item #2 : Duplicate `#include` directives
+
+Location: src/tuning/bluetooth.cpp : 28 and 35 (`<unistd.h>`), 36 and 38 (`<sys/types.h>`)
+Description: Both `<unistd.h>` and `<sys/types.h>` are included twice in bluetooth.cpp. While include guards make this harmless at the preprocessor level, it is dead code and adds confusion.
+Severity rationale: Unnecessary noise; style issue.
+Suggested fix: Remove the duplicate `#include <unistd.h>` at line 35 and the duplicate `#include <sys/types.h>` at line 38.
+
+### Low item #3 : `strcpy` into a fixed-size struct field
+
+Location: src/tuning/bluetooth.cpp : 123 and 209
+Description: `strcpy(devinfo.name, "hci0")` copies into `hci_dev_info::name[8]`. While "hci0\0" is only 5 bytes so no overflow occurs here, using `strcpy` into a fixed-size field is fragile — a future change to the device name (e.g., "hci10\0") or the field size could silently overflow. The project style guide prefers `std::string` over C-style char arrays.
+Severity rationale: Technically safe with the current string, but unsafe pattern; style violation.
+Suggested fix: Use `strncpy(devinfo.name, "hci0", sizeof(devinfo.name) - 1); devinfo.name[sizeof(devinfo.name)-1] = '\0';` or restructure to avoid the C struct entirely using BlueZ D-Bus APIs.
+
+### Low item #4 : Non-translatable user-visible error string
+
+Location: src/tuning/bluetooth.cpp : 181 and 185
+Description: `printf("System is not available\n")` outputs a user-visible string without the `_()` gettext wrapper. Per the project's i18n rules (rules.md, style.md §5), all user-facing strings must be wrapped in `_()`. Additionally, error output should go to `stderr` not `stdout`, and `printf` should be replaced with `fprintf(stderr, ...)`.
+Severity rationale: Violates mandatory i18n rule; error goes to wrong stream.
+Suggested fix:
+```cpp
+fprintf(stderr, _("Bluetooth toggle failed: system() call unavailable\n"));
+```
+
+### Low item #5 : Mixed tabs and spaces indentation in `report_show_tunables`
+
+Location: src/tuning/tuning.cpp : 207–215
+Description: The `report_show_tunables` function mixes 8-space indentation with tab indentation in adjacent lines (e.g., lines 209–213 use spaces where the rest of the file uses tabs). The project style guide mandates tabs-only indentation.
+Severity rationale: Style violation; makes the file inconsistent and harder to read in editors configured for different tab widths.
+Suggested fix: Convert the space-indented lines to use a single tab at the appropriate nesting level.
+
+### Low item #6 : `#ifndef` header guard instead of `#pragma once`
+
+Location: src/tuning/tuning.h : 26–27; src/tuning/bluetooth.h : 25–26
+Description: Both headers use traditional `#ifndef`/`#define`/`#endif` include guards. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style guide violation; `#pragma once` is simpler and less prone to guard-name collisions.
+Suggested fix: Replace each include-guard triplet with a single `#pragma once` at the top of the file.
+
+### Low item #7 : Unused `#include` directives in bluetooth.cpp
+
+Location: src/tuning/bluetooth.cpp : 32–34
+Description: `#include <utility>`, `#include <iostream>`, and `#include <fstream>` are present but nothing from these headers (`std::move`, `std::cout`, `std::ifstream`, etc.) is used in bluetooth.cpp.
+Severity rationale: Dead includes add compile-time cost and mislead readers about the file's dependencies.
+Suggested fix: Remove the three unused include lines.
+
+### Low item #8 : User-visible notification string not wrapped in `_()`
+
+Location: src/tuning/tuning.cpp : 157
+Description: `ui_notify_user(std::format(">> {}\n", toggle_script))` passes a format string literal that is not wrapped in `_()`. The `">> {}\n"` part is displayed to the user in the Tunables tab when a tunable is toggled. Per the i18n rules, user-visible strings must use the gettext `_()` macro.
+Severity rationale: i18n rule violation; the string is not translatable.
+Suggested fix: `ui_notify_user(pt_format(_(">> {}\n"), toggle_script));`
+
+## Review of src/tuning/tuningsysfs.cpp, src/tuning/tuningsysfs.h, src/tuning/nl80211.h, src/tuning/iw.h, src/tuning/iw.c — batch 06
+
+### Low item #1 : Old-style #ifndef header guard in tuningsysfs.h instead of #pragma once
+
+Location: src/tuning/tuningsysfs.h : 25–26
+Description: The header uses `#ifndef _INCLUDE_GUARD_SYSFS_TUNE_H` / `#define _INCLUDE_GUARD_SYSFS_TUNE_H`. Per `style.md` section 4.1, the project convention is `#pragma once`.
+Severity rationale: Style violation; not a functional bug but inconsistent with project convention.
+Suggested fix: Replace lines 25–26 and 51 with `#pragma once` at the top of the file.
+
+### Low item #2 : Old-style #ifndef header guard in iw.h instead of #pragma once
+
+Location: src/tuning/iw.h : 1–2
+Description: The header uses `#ifndef __IW_H` / `#define __IW_H`. Per `style.md` section 4.1, the project convention is `#pragma once`. Also, the guard name `__IW_H` starts with a double underscore, which is a reserved identifier in C/C++.
+Severity rationale: Style violation and use of reserved identifier name for the macro.
+Suggested fix: Replace with `#pragma once` and remove the closing `#endif /* __IW_H */`.
+
+### Low item #3 : Include ordering in tuningsysfs.cpp mixes project and system headers
+
+Location: src/tuning/tuningsysfs.cpp : 26–37
+Description: Per `style.md` section 4.4, standard library headers should appear before project-specific headers. In `tuningsysfs.cpp` the order is: `"tuning.h"` (project), `"tunable.h"` (project), `<unistd.h>` (system), `"tuningsysfs.h"` (project), `<string.h>` (system), `<dirent.h>` (system), `<utility>` (stdlib), `<iostream>` (stdlib), `<fstream>` (stdlib), `<limits.h>` (system), `<format>` (stdlib), then `"../lib.h"` (project). System and project headers are interleaved rather than grouped.
+Severity rationale: Style violation; ordering makes include dependencies harder to track.
+Suggested fix: Group standard library/system headers first, then project headers.
+
+### Low item #4 : Unused include <limits.h> in tuningsysfs.h
+
+Location: src/tuning/tuningsysfs.h : 29
+Description: `#include <limits.h>` is present but nothing from `<limits.h>` (e.g. `PATH_MAX`, `CHAR_BIT`) is used anywhere in the header.
+Severity rationale: Dead code; increases compilation dependencies unnecessarily.
+Suggested fix: Remove the `#include <limits.h>` line.
+
+### Low item #5 : Unused include <vector> in tuningsysfs.h
+
+Location: src/tuning/tuningsysfs.h : 28
+Description: `#include <vector>` is present but `std::vector` is not used in the header itself. The vector operations on `all_tunables` are in the `.cpp` file which includes the appropriate headers transitively.
+Severity rationale: Unused include; increases compilation overhead.
+Suggested fix: Remove the `#include <vector>` line.
+
+### Low item #6 : Unused include <limits.h> in tuningsysfs.cpp
+
+Location: src/tuning/tuningsysfs.cpp : 35
+Description: `#include <limits.h>` is included in the `.cpp` file but no symbol from it (`PATH_MAX`, etc.) is used in `tuningsysfs.cpp`.
+Severity rationale: Dead code; unnecessary compile-time dependency.
+Suggested fix: Remove line 35.
+
+### Low item #7 : ETH_ALEN defined without a #ifndef guard in iw.h
+
+Location: src/tuning/iw.h : 37
+Description: `#define ETH_ALEN 6` is an unconditional definition. `ETH_ALEN` is also defined in `<linux/if_ether.h>` and in some libnl headers. If iw.h is included after any of those headers, the compiler will emit a macro-redefinition warning (or error with `-Werror`). Additionally, `ETH_ALEN` is never used anywhere in the reviewed files, making the definition dead code.
+Severity rationale: Potential redefinition conflict; unused dead code.
+Suggested fix: Either remove the definition entirely (it is unused), or guard it: `#ifndef ETH_ALEN\n#define ETH_ALEN 6\n#endif`.
+
+### Low item #8 : Redundant `class` keyword in pointer declarations in add_sysfs_tunable
+
+Location: src/tuning/tuningsysfs.cpp : 80–82
+Description: `class sysfs_tunable *st;` and `st = new class sysfs_tunable(...)` use the `class` keyword in variable declarations and `new` expressions. In C++ the `class` tag is not required when the class type is already visible; the idiomatic form is simply `sysfs_tunable *st = new sysfs_tunable(...)`. The `class` keyword in declarations is a C-ism that is unnecessary and non-idiomatic in C++.
+Severity rationale: Non-idiomatic C++; style inconsistency.
+Suggested fix:
+```cpp
+sysfs_tunable *st = new sysfs_tunable(str, _sysfs_path, _target_content);
+all_tunables.push_back(st);
+```
+
+## Review of tuningi2c.h, tuningi2c.cpp, powerconsumer.h, powerconsumer.cpp, processdevice.h — batch 07
+
+### Low item #1 : `#ifndef` header guard instead of `#pragma once` in tuningi2c.h
+
+Location: src/tuning/tuningi2c.h : 20-21
+Description: The header uses the old `#ifndef _INCLUDE_GUARD_I2C_TUNE_H` idiom instead of the project-standard `#pragma once`.
+Severity rationale: Per style.md §4.1, `#pragma once` is the required form.
+Suggested fix: Replace lines 20-21 and 44 with `#pragma once`.
+
+### Low item #2 : `#ifndef` header guard instead of `#pragma once` in powerconsumer.h
+
+Location: src/process/powerconsumer.h : 25-26
+Description: Same as Low item #1 — old `#ifndef` guard instead of `#pragma once`.
+Severity rationale: Per style.md §4.1.
+Suggested fix: Replace guard with `#pragma once`.
+
+### Low item #3 : `#ifndef` header guard instead of `#pragma once` in processdevice.h
+
+Location: src/process/processdevice.h : 25-26
+Description: Same as Low item #1.
+Severity rationale: Per style.md §4.1.
+Suggested fix: Replace guard with `#pragma once`.
+
+### Low item #4 : `"unistd.h"` included with quotes instead of angle brackets
+
+Location: src/tuning/tuningi2c.cpp : 22
+Description: `#include "unistd.h"` uses double-quotes for a system header. The convention (style.md §4.4) is that system/standard headers use angle brackets `<>`.
+Severity rationale: Style violation; can also cause the wrong file to be included if a local `unistd.h` exists.
+Suggested fix: `#include <unistd.h>`
+
+### Low item #5 : C-style headers used instead of C++ equivalents
+
+Location: src/tuning/tuningi2c.cpp : 24, 29, 30
+Description: `<string.h>`, `<ctype.h>`, and `<limits.h>` are C headers. In C++20 code the C++ wrappers `<cstring>`, `<cctype>`, and `<climits>` should be used so that identifiers are placed in `namespace std`.
+Severity rationale: Use of deprecated C-style includes in C++20 code; per general-c++.md, C++20 standard constructs should be preferred.
+Suggested fix: Replace with `<cstring>`, `<cctype>`, `<climits>`.
+
+### Low item #6 : `NULL` used instead of `nullptr`
+
+Location: src/process/powerconsumer.cpp : 75, 76
+Description: The constructor assigns `waker = NULL` and `last_waker = NULL`. In C++11 and later (and mandated by C++20), `nullptr` is the type-safe null pointer constant.
+Severity rationale: `NULL` is a C holdover; `nullptr` is the correct C++20 form per general-c++.md.
+Suggested fix: Replace both occurrences with `nullptr`.
+
+### Low item #7 : Silent clamping of inconsistent `child_runtime`
+
+Location: src/process/powerconsumer.cpp : 40-41
+Description: When `child_runtime > accumulated_runtime`, the code silently resets `child_runtime = 0` with no log or diagnostic. This masks accounting bugs in callers and makes root-cause analysis harder.
+Severity rationale: Defensive silencing of data corruption without any trace; low severity because the clamp prevents a negative cost value, but the lack of any diagnostic makes bugs invisible.
+Suggested fix: Add a debug-mode `fprintf(stderr, ...)` or assertion before clamping so that the anomaly is at least visible during development.
+
+## Review of processdevice.cpp, process.h, process.cpp, work.cpp, work.h — batch 08
+
+### Low item #1 : Index-based for loops where range-for is cleaner
+
+Location: src/process/processdevice.cpp : 61 ; src/process/process.cpp : 156, 213
+Description: Several loops use `unsigned int i` index variables to iterate over `std::vector` containers (`all_proc_devices`, `all_processes`). C++11 range-for is simpler and eliminates the risk of index type mismatch.
+Severity rationale: Style and maintainability; no correctness issue, but inconsistent with modern C++ idioms.
+Suggested fix: Replace, e.g.:
+```cpp
+for (auto *cdev : all_proc_devices) { ... }
+for (auto *proc : all_processes)    { ... }
+```
+
+### Low item #2 : Verbose iterator type declarations; prefer `auto`
+
+Location: src/process/processdevice.cpp : 93 ; src/process/process.cpp : 221
+Description: `std::vector<class device_consumer *>::iterator it = ...` and `std::vector <class process *>::iterator it = ...` are unnecessarily verbose. The `auto` keyword was introduced precisely for this pattern.
+Severity rationale: Readability; no correctness issue.
+Suggested fix: `auto it = all_proc_devices.begin();` / `auto it = all_processes.begin();`.
+
+### Low item #3 : O(n²) clear_work implementation
+
+Location: src/process/work.cpp : 100-108
+Description: `clear_work()` erases one element at a time and resets `it = all_work.begin()` on each iteration, making it O(n²). The standard idiom for clearing a map (freeing each value first) is a simple range-for followed by `all_work.clear()`.
+Severity rationale: Performance; for large work-item maps this degrades noticeably.
+Suggested fix:
+```cpp
+void clear_work(void)
+{
+    for (auto &[key, val] : all_work)
+        delete val;
+    all_work.clear();
+    running_since.clear();
+}
+```
+
+### Low item #4 : Type inconsistency: constructor takes `unsigned long`, caller passes `uint64_t`
+
+Location: src/process/work.h : 38 ; src/process/work.cpp : 122
+Description: `work::work(unsigned long work_func)` accepts `unsigned long`, but `find_create_work(uint64_t func)` passes a `uint64_t`. On LP64 Linux these are the same size, but the inconsistency is confusing and would silently truncate on ILP64 platforms.
+Severity rationale: Portability and clarity.
+Suggested fix: Change the constructor parameter to `uint64_t`: `work(uint64_t work_func);`.
+
+## Review of interrupt.h, interrupt.cpp, timer.cpp, timer.h, do_process.cpp — batch 09
+
+### Low item #1 : Index-based for loops should be range-based for loops
+
+Location: src/process/interrupt.cpp : 104, 117  /  src/process/do_process.cpp : 107, 117, 720, 733, 747, 762, 776
+Description: Numerous loops use the pattern `for (unsigned int i = 0; i < vec.size(); i++)` with index access. C++20 (and the project's general preference for STL constructs) favours range-based for loops which are cleaner and avoid off-by-one errors.
+Severity rationale: Style/best-practice violation; no correctness impact but reduces readability.
+Suggested fix: Convert to `for (auto *item : vec)` or `for (const auto &item : vec)` as appropriate.
+
+### Low item #2 : all_power.erase(begin, end) should be all_power.clear()
+
+Location: src/process/do_process.cpp : 1144, 1201
+Description: `all_power.erase(all_power.begin(), all_power.end())` is equivalent to `all_power.clear()` but is more verbose and less idiomatic C++. `clear()` better expresses intent.
+Severity rationale: Readability; no functional difference.
+Suggested fix: Replace both occurrences with `all_power.clear();`.
+
+### Low item #3 : add_timer takes pair by value instead of const reference
+
+Location: src/process/timer.cpp : 112
+Description: The `add_timer` helper function signature is `static void add_timer(const pair<unsigned long, class timer*>& elem)` — actually the code shows it accepts a `pair` by value. In any case the use with `std::for_each` copies each pair; it should accept `const std::pair<const unsigned long, class timer*>&`.
+Severity rationale: Minor inefficiency.
+Suggested fix: Use a range-based for loop instead, e.g.:
+```cpp
+void all_timers_to_all_power(void)
+{
+    for (auto &[addr, t] : all_timers)
+        all_power.push_back(t);
+}
+```
+
+### Low item #4 : std::string_view wrapping of std::string for starts_with
+
+Location: src/process/do_process.cpp : 284
+Description: `!std::string_view(next_comm).starts_with("migration/")` creates an unnecessary `string_view` wrapper. Since `next_comm` is already a `std::string` and C++20 `std::string` has `starts_with()` directly, the cast is redundant.
+Severity rationale: Minor inefficiency and unnecessary verbosity.
+Suggested fix: Replace with `!next_comm.starts_with("migration/")` etc.
+
+### Low item #5 : Iterator types spelled out instead of using auto
+
+Location: src/process/interrupt.cpp : 124  /  src/process/timer.cpp : 148
+Description: `std::vector<class interrupt *>::iterator it = ...` and `std::map<unsigned long, class timer *>::iterator it = ...` are verbose iterator declarations that obscure intent. The project uses C++20; `auto` should be preferred.
+Severity rationale: Readability; verbose type declarations.
+Suggested fix: Use `auto it = ...`.
+
+### Low item #6 : Local variable timer shadows the class name timer
+
+Location: src/process/timer.cpp : 136
+Description: Inside `find_create_timer`, the local variable is named `timer`, which shadows the class name `timer`. While the compiler handles this correctly, it is confusing to read and maintain.
+Severity rationale: Readability and potential for confusion.
+Suggested fix: Rename to `new_timer` (consistent with `find_create_interrupt` which uses `new_irq`).
+
+## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
+
+### Low item #1 : `malloc`/`free` used in C++ code instead of `new[]`/`delete[]`
+
+Location: src/perf/perf_bundle.cpp : 63, 91, 160
+Description: Raw `malloc` and `free` are used to allocate and release event record buffers. In C++ code, `new[]` / `delete[]` (or `std::vector<unsigned char>`) is strongly preferred. Mixing C and C++ allocation can cause type-safety issues and prevents use of RAII.
+Severity rationale: Low — it works but is against C++ best practices and project style.
+Suggested fix: Use `new unsigned char[header->size]` / `delete[]` or use a `std::vector<unsigned char>` and store by value.
+
+### Low item #2 : `exit(-1)` instead of `exit(EXIT_FAILURE)`
+
+Location: src/perf/perf.cpp : 113
+Description: `exit(-1)` uses a non-portable, non-standard exit code. The portable way to signal failure is `exit(EXIT_FAILURE)`.
+Severity rationale: Minor portability issue.
+Suggested fix: Replace with `exit(EXIT_FAILURE)`.
+
+### Low item #3 : Unused `eventname` parameter in `create_perf_event`
+
+Location: src/perf/perf.cpp : 58
+Description: The `eventname` parameter (of type `const string &`) is marked `__unused` and never referenced inside the function body. The event type is taken from `trace_type` directly. If the parameter is truly unnecessary it should be removed or documented; if it was intended to be used, it is a functional gap.
+Severity rationale: Dead parameter increases maintenance burden and could indicate a missing code path.
+Suggested fix: Remove the parameter from the signature (updating the call site in `start()`) or document why it is intentionally unused.
+
+### Low item #4 : C-style casts used throughout
+
+Location: src/perf/perf_bundle.cpp : 63, 67, 69, 187, 268; src/perf/perf.cpp : 130, 131, 187, 235
+Description: Multiple C-style casts (`(unsigned char *)`, `(struct perf_event_header *)`, `(struct perf_sample *)`, `(perf_event_mmap_page *)`) are used instead of C++ named casts (`reinterpret_cast<>`, `static_cast<>`). C-style casts bypass the type system silently.
+Severity rationale: C++ named casts make intent explicit and are safer.
+Suggested fix: Replace with appropriate named casts, e.g. `reinterpret_cast<unsigned char *>(...)`.
+
+### Low item #5 : `__unused` macro used instead of C++17 `[[maybe_unused]]`
+
+Location: src/perf/perf.cpp : 58, 280
+Description: The project uses `#define __unused __attribute__((unused))` (a GCC extension) rather than the C++17 standard attribute `[[maybe_unused]]`. Since the project targets C++20, the standard attribute should be used.
+Severity rationale: Minor — GCC extension works fine but the standard attribute is preferred in C++17/20 code.
+Suggested fix: Replace `__unused` with `[[maybe_unused]]` in function parameter declarations.
+
+### Low item #6 : `#include <malloc.h>` is a non-standard header
+
+Location: src/perf/perf_bundle.cpp : 26
+Description: `<malloc.h>` is a Linux/glibc-specific header. The standard C/C++ header for `malloc` is `<cstdlib>` (C++) or `<stdlib.h>` (C). `stdlib.h` is already included on line 31 of `perf.cpp`; `perf_bundle.cpp` should use `<cstdlib>` or `<stdlib.h>`.
+Severity rationale: Minor portability issue.
+Suggested fix: Replace `#include <malloc.h>` with `#include <cstdlib>`.
+
+### Low item #7 : Return value of `fcntl` not checked
+
+Location: src/perf/perf.cpp : 115
+Description: `fcntl(perf_fd, F_SETFL, O_NONBLOCK)` is called without checking the return value. If this fails, the fd will remain in blocking mode and subsequent `read`/`process` calls may block indefinitely.
+Severity rationale: Silent failure in a system call that affects event processing behavior.
+Suggested fix:
+```cpp
+if (fcntl(perf_fd, F_SETFL, O_NONBLOCK) < 0)
+    fprintf(stderr, _("fcntl O_NONBLOCK failed: %s\n"), strerror(errno));
+```
+
+## Review of persistent.cpp, parameters.cpp, parameters.h, learn.cpp, report-formatter.h — batch 11
+
+### Low item #1 : `using namespace std` in persistent.cpp
+
+Location: src/parameters/persistent.cpp : 34
+Description: `using namespace std;` in a .cpp translation unit is explicitly discouraged by style.md and general-c++.md. While the impact is limited to this translation unit (unlike a header), it is still a rule violation that hides which symbols come from the standard library, reducing readability and increasing collision risk.
+Severity rationale: Rule violation contained to one TU.
+Suggested fix: Remove the `using namespace std;` line and add the `std::` prefix to `ofstream`, `istringstream`, `string`, `getline`, `setprecision`, `setiosflags`, etc.
+
+### Low item #2 : Old-style iterator and index loops instead of range-based for
+
+Location: src/parameters/persistent.cpp : 50, 55 ; src/parameters/parameters.cpp : 55, 166, 256, 278
+Description: Multiple loops use `for (it = …begin(); it != …end(); it++)` or `for (i = 0; i < vec.size(); i++)` patterns. C++20 range-based for (`for (auto &x : container)`) is clearer, less error-prone and preferred by the project style.
+Severity rationale: C++20 style violation; no functional impact.
+Suggested fix: Convert to range-based for where possible, e.g. `for (auto &[name, idx] : param_index) { … }`.
+
+### Low item #3 : `#ifndef` include guard instead of `#pragma once` in parameters.h
+
+Location: src/parameters/parameters.h : 25
+Description: The header uses `#ifndef __INCLUDE_GUARD_PARAMETERS_H_` / `#define` / `#endif` style guards. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style violation; `#pragma once` is universally supported and less error-prone.
+Suggested fix: Replace the `#ifndef`/`#define`/`#endif` triple with `#pragma once`.
+
+### Low item #4 : `#ifndef` include guard instead of `#pragma once` in report-formatter.h
+
+Location: src/report/report-formatter.h : 26
+Description: Same violation as Low item #3 — `#ifndef _REPORT_FORMATTER_H_` guard instead of `#pragma once`.
+Severity rationale: Style violation.
+Suggested fix: Replace with `#pragma once`.
+
+### Low item #5 : GCC-specific `__unused` attribute instead of standard `[[maybe_unused]]`
+
+Location: src/report/report-formatter.h : 43, 49, 50, 51, 53, 54
+Description: Six virtual method parameters use the GCC extension `__unused` (e.g. `const std::string &str __unused`). C++17 introduced `[[maybe_unused]]` as the portable, standard-compliant spelling. Since the project targets C++20, the standard attribute should be used instead.
+Severity rationale: Non-portable, GCC-specific attribute in a C++20 codebase.
+Suggested fix: Replace `__unused` with `[[maybe_unused]]` on each affected parameter.
+
+## Review of report-formatter-html.h, report.cpp, report.h, report-formatter-csv.h, report-maker.cpp — batch 12
+
+### Low item #1 : Duplicate `#include <string.h>`
+
+Location: report.cpp : 31, 36
+Description: `<string.h>` is included twice. The second inclusion is redundant and suggests copy-paste; the same translation unit also includes `<string>` (the C++ header), so the C header should likely be replaced with `<cstring>` and included only once.
+Severity rationale: Harmless (include guards prevent double-definition), but indicates dead code and the wrong header name.
+Suggested fix: Remove one of the two occurrences and ensure the remaining one uses `<cstring>`.
+
+### Low item #2 : Non-standard `#include <malloc.h>`
+
+Location: report.cpp : 37
+Description: `<malloc.h>` is a GNU extension, not a standard C or C++ header. Nothing in `report.cpp` appears to use any `malloc.h`-specific declarations; `malloc`/`free` are available via `<cstdlib>`. Including it reduces portability.
+Severity rationale: Portability issue; the header is unnecessary in this file.
+Suggested fix: Remove `#include <malloc.h>`.
+
+### Low item #3 : `NULL` used instead of `nullptr`
+
+Location: report-maker.cpp : 41, report.cpp : 114
+Description: `formatter = NULL` (report-maker.cpp:41) and `time(NULL)` (report.cpp:114) use the C-style `NULL` macro. In C++11 and later, `nullptr` is the correct null-pointer constant; `NULL` is implementation-defined and may expand to an integer.
+Severity rationale: C++ style / correctness hygiene; not a runtime bug in practice.
+Suggested fix: Replace `NULL` with `nullptr` where used as a pointer; `time(nullptr)` for the `time()` call.
+
+### Low item #4 : `formatter` member is a raw owning pointer
+
+Location: report-maker.cpp : 40-51, 99-110
+Description: `report_maker` manages the lifetime of its `formatter` through manual `new` / `delete`. This is fragile: if `setup_report_formatter()` is called while an exception propagates (e.g., from `new`), the previously held `formatter` may already have been deleted, leaving the member dangling. Using `std::unique_ptr<report_formatter>` would express ownership clearly and make the destructor body trivial.
+Severity rationale: Low — exception propagation from `new` in this code path is very unlikely in practice.
+Suggested fix: Declare `formatter` as `std::unique_ptr<report_formatter>` and replace `new`/`delete` with `std::make_unique`.
+
+## Review of report-maker.h, report-data-html.cpp, report-data-html.h, report-formatter-base.cpp, report-formatter-base.h — batch 13
+
+### Low item #1 : C-style headers used instead of C++ equivalents
+
+Location: src/report/report-maker.h : 61  and  src/report/report-formatter-base.cpp : 29, 31
+Description: `report-maker.h` includes `<stdarg.h>` and `report-formatter-base.cpp` includes `<stdio.h>` and `<stdarg.h>`. In C++ code these should be `<cstdarg>` and `<cstdio>` respectively, which place their declarations in the `std` namespace and avoid polluting the global namespace with C names.
+Severity rationale: C++ best practice; the C headers are deprecated in C++.
+Suggested fix: Replace `<stdarg.h>` with `<cstdarg>` and `<stdio.h>` with `<cstdio>`. If neither is actually used in these files, remove the includes entirely.
+
+### Low item #2 : Unqualified `string` in `report-formatter-base.cpp`
+
+Location: src/report/report-formatter-base.cpp : 54, 62
+Description: The parameter type in `add(const string &str)` and `add_exact(const string &str)` uses the unqualified name `string` rather than `std::string`. This only compiles because `using namespace std;` is injected transitively via the included headers — a dependency on namespace pollution.
+Severity rationale: Style guide violation (style.md §4.2); correct names must be fully qualified.
+Suggested fix: Replace `const string &` with `const std::string &` in both definitions.
+
+### Low item #3 : `__()` macro silently depends on a global variable named `report`
+
+Location: src/report/report-maker.h : 68–70
+Description: The `__()` translation macro is defined as `((report.get_type() == REPORT_CSV) ? (STRING) : gettext(STRING))`. It silently requires a globally visible `report_maker` object named `report`. Any translation unit that includes `report-maker.h` and uses `__()` without such a global will get a compilation error or, worse, accidentally reference a different `report` object in scope. The macro provides no warning about this hidden dependency.
+Severity rationale: Hidden global-state dependency in a header-level macro; fragile and non-obvious to users of the header.
+Suggested fix: Rename the macro to something that makes the dependency explicit, or refactor it as a function taking a `const report_maker &` parameter.
+
+## Review of report-formatter-csv.cpp, report-formatter-html.cpp, dram_rapl_device.cpp, dram_rapl_device.h, cpu_linux.cpp — batch 14
+
+### Low item #1 : `dram_rapl_device.h` uses `#ifndef`/`#define` guard instead of `#pragma once`
+
+Location: src/cpu/dram_rapl_device.h : 25-26
+Description: The style guide specifies `#pragma once` for header guards. `dram_rapl_device.h` uses the older `#ifndef _INCLUDE_GUARD_DRAM_RAPL_DEVICE_H` / `#define` pattern.
+Severity rationale: Deviation from stated style guide. Low impact in practice.
+Suggested fix: Replace with `#pragma once` and remove the `#ifndef`/`#define`/`#endif` guards.
+
+### Low item #2 : `NULL` used instead of `nullptr` in C++20 code
+
+Location: src/cpu/dram_rapl_device.h : 46 ; src/cpu/dram_rapl_device.cpp : 40, 50, 57
+Description: In C++20 code, `nullptr` is the correct null pointer constant. `NULL` is a C macro and, while still valid, is discouraged in modern C++. In `dram_rapl_device.h` line 46 the default argument uses `NULL`; in `dram_rapl_device.cpp` `time(NULL)` appears three times (though `time()` takes a `time_t*`, so `nullptr` is the right form).
+Severity rationale: Style rule violation; `NULL` vs `nullptr` does not affect correctness here but is inconsistent with C++20 practice.
+Suggested fix: Replace `NULL` with `nullptr` in all occurrences.
+
+### Low item #3 : `device_name()` and `human_name()` not marked `const` in `dram_rapl_device.h`
+
+Location: src/cpu/dram_rapl_device.h : 48-49
+Description: Both `device_name()` and `human_name()` return a compile-time constant string and do not modify any member state, yet neither is declared `const`. The C++ rule states: "Use 'const' when possible for method and function parameters [and methods]."
+Severity rationale: Missing `const` prevents calling these methods on const references/pointers and violates the stated coding rule.
+Suggested fix:
+```cpp
+virtual std::string device_name() const { return "DRAM"; }
+virtual std::string human_name() const  { return "DRAM"; }
+```
+
+### Low item #4 : `cpu_linux.cpp` has duplicate `#include` directives
+
+Location: src/cpu/cpu_linux.cpp : 37-38 and 41, 192
+Description: `#include <sys/types.h>` appears on two consecutive lines (37 and 38). Additionally, `#include <format>` appears at both line 41 and again at line 192 (after `measurement_end()`). Duplicate includes are harmless due to include guards but indicate sloppy maintenance.
+Severity rationale: Minor style/maintenance issue; no functional impact.
+Suggested fix: Remove the duplicate `#include <sys/types.h>` on line 38 and the duplicate `#include <format>` on line 192.
+
+### Low item #5 : Bare `string` type used without `std::` qualifier
+
+Location: src/report/report-formatter-html.cpp : 102, 105, 280, 331 ; src/report/report-formatter-csv.cpp : 52, 55, 112, 143
+Description: These files use `string` (and the return type `string` for functions) without the `std::` prefix. The style guide requires always using `std::string`. The bare `string` resolves only because the included headers (`report-formatter-html.h`, `report-formatter-csv.h`) themselves contain `using namespace std;`, which itself is a style violation. The `.cpp` files should use `std::string` explicitly.
+Severity rationale: Style rule violation; indirect resolution through a namespace-polluting header.
+Suggested fix: Replace all bare `string` with `std::string` in both `.cpp` files, and remove `using namespace std;` from the included headers.
+
+### Low item #6 : C-style headers used instead of C++ equivalents
+
+Location: src/report/report-formatter-html.cpp : 29-31 ; src/report/report-formatter-csv.cpp : 29-31 ; src/cpu/dram_rapl_device.cpp : 25-27 ; src/cpu/cpu_linux.cpp : 32, 35-36
+Description: Multiple files include C-style headers (`<stdio.h>`, `<assert.h>`, `<stdarg.h>`, `<stdlib.h>`, `<string.h>`) in C++20 code. The C++ equivalents (`<cstdio>`, `<cassert>`, `<cstdarg>`, `<cstdlib>`, `<cstring>`) are preferred as they place declarations in the `std` namespace and avoid potential macro/symbol pollution.
+Severity rationale: Style violation; no functional impact but inconsistent with modern C++20 practice.
+Suggested fix: Replace each C-style header with its `<c...>` equivalent.
+
+### Low item #7 : Include order: C standard headers after project headers in `cpu_linux.cpp`
+
+Location: src/cpu/cpu_linux.cpp : 29-40
+Description: The style guide specifies "Standard library headers first, followed by project-specific headers." In `cpu_linux.cpp`, `"cpu.h"` (line 29) and `"../lib.h"` (line 30) appear before `<stdlib.h>`, `<unistd.h>`, `<stdio.h>`, `<string.h>`, etc. (lines 32–40).
+Severity rationale: Style rule violation.
+Suggested fix: Move all standard/system `<...>` headers before the project `"..."` headers.
+
+## Review of src/cpu/cpu_core.cpp, src/cpu/cpudevice.h, src/cpu/cpudevice.cpp, src/cpu/abstract_cpu.cpp, src/cpu/cpu_rapl_device.cpp — batch 15
+
+### Low item #1 : `#ifndef`/`#define` include guard instead of `#pragma once` in cpudevice.h
+
+Location: src/cpu/cpudevice.h : 25-27
+Description: The file uses the traditional `#ifndef _INCLUDE_GUARD_CPUDEVICE_H` / `#define`
+/ `#endif` pattern. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style guide violation; `#pragma once` is simpler and avoids possible
+macro name collisions.
+Suggested fix: Replace the three guard lines with `#pragma once`.
+
+### Low item #2 : `#ifndef`/`#define` include guard instead of `#pragma once` in cpu_rapl_device.h
+
+Location: src/cpu/cpu_rapl_device.h : 25-27
+Description: Same violation as item #1 in this header.
+Severity rationale: Style guide violation; same rationale.
+Suggested fix: Replace with `#pragma once`.
+
+### Low item #3 : `NULL` used instead of `nullptr` in cpudevice.h
+
+Location: src/cpu/cpudevice.h : 51
+Description: The default parameter `class abstract_cpu *_cpu = NULL` uses the C-style `NULL`
+macro. C++11 and later (the project targets C++20) provide the type-safe `nullptr` keyword
+which should always be preferred.
+Severity rationale: C++20 code should not use the untyped `NULL` macro.
+Suggested fix: Change `= NULL` to `= nullptr`.
+
+### Low item #4 : `NULL` used instead of `nullptr` in cpu_rapl_device.h
+
+Location: src/cpu/cpu_rapl_device.h : 46
+Description: Same violation — `class abstract_cpu *_cpu = NULL` in the constructor default.
+Severity rationale: Same as item #3.
+Suggested fix: Change `= NULL` to `= nullptr`.
+
+### Low item #5 : Error diagnostic strings not wrapped in `_()` for translation
+
+Location: src/cpu/abstract_cpu.cpp : 275, 375
+Description: The error messages `"Invalid C state finalize "` and `"Invalid P state finalize "`
+are not wrapped in the `_()` gettext macro. Even though these are internal diagnostics, the
+project rule states all user-visible strings must be translatable. These messages do appear in
+the terminal when unexpected state transitions occur, making them user-visible in practice.
+Severity rationale: Violates the universal translation requirement (rules.md).
+Suggested fix: Wrap the string literals in `_()`, e.g.
+`fprintf(stderr, _("Invalid C state finalize %s\n"), linux_name.c_str());`
+
+## Review of src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp — batch 16
+
+### Low item #1 : cpu_rapl_dev and dram_rapl_dev created with identical packagename
+
+Location: src/cpu/cpu.cpp : 90, 97
+Description: Both the `cpu_rapl_device` and `dram_rapl_device` are created using
+the same `packagename = pt_format(_("package-{}"), cpu)` string (the assignment
+is repeated identically on lines 90 and 97). While this may be intentional, it
+means both devices share the same identifier, which could cause confusion in the
+device list and in parameter lookups. This looks like a copy-paste artefact.
+Severity rationale: Potential functional confusion in device naming/lookup; low risk on current code paths but a maintenance hazard.
+Suggested fix: Give the DRAM device a distinct name, e.g. `pt_format(_("dram-package-{}"), cpu)`.
+
+### Low item #2 : `exit(-2)` uses a non-standard exit code
+
+Location: src/cpu/intel_cpus.cpp : 147
+Description: `exit(-2)` is called on MSR read failure. Negative exit codes are
+non-portable; POSIX only guarantees correct behaviour for 0 and values
+representable in the low 8 bits of an unsigned char. On Linux, exit(-2) is
+received by the parent as exit code 254 (a confusing, meaningless value).
+The project style guide states `exit(EXIT_FAILURE)` for fatal errors.
+Severity rationale: Low impact on Linux, but a portability and style issue.
+Suggested fix: Replace with `exit(EXIT_FAILURE)`.
+
+### Low item #3 : Inconsistent hex literal case — uppercase `0X`
+
+Location: src/cpu/intel_cpus.cpp : 83, 401
+Description: Two hex literals use uppercase `0X8F` and `0X9A` (capital X). Every
+other hex literal in these files uses lowercase `0x`. While both forms are valid
+C++, the inconsistency is a readability issue and deviates from the established
+style.
+Severity rationale: Pure style/consistency issue.
+Suggested fix: Change to `0x8F` and `0x9A`.
+
+### Low item #4 : Unnecessary `.c_str()` conversion passed to `std::string` parameter
+
+Location: src/cpu/intel_cpus.cpp : 627
+Description: `update_pstate(state->freq, state->human_name.c_str(), ...)` converts
+`state->human_name` (a `std::string`) to `const char *` for a function that accepts
+`const std::string&`. This is an unnecessary round-trip that creates a temporary
+`std::string`.
+Severity rationale: Minor inefficiency; violates the "prefer std::string over C-style strings" guideline.
+Suggested fix: Pass `state->human_name` directly without `.c_str()`.
+
+### Low item #5 : Bare `vector<>` without `std::` in public class members in cpu.h
+
+Location: src/cpu/cpu.h : 103-105
+Description: The public data members `children`, `cstates`, and `pstates` in
+`abstract_cpu` are declared as bare `vector<...>` without the `std::` prefix:
+```cpp
+vector<class abstract_cpu *> children;
+vector<struct idle_state *> cstates;
+vector<struct frequency *> pstates;
+```
+The project C++ guidelines and style guide both require `std::vector<>`. These
+are tolerated at present only because `using namespace std;` is (incorrectly) in
+the header, but once that is removed they will not compile.
+Severity rationale: Directly tied to the `using namespace std` violation; fixing
+that without fixing these would break the build.
+Suggested fix: Change to `std::vector<...>` for all three members.
+
+## Review of src/cpu/intel_cpus.h, src/cpu/rapl/rapl_interface.h, src/cpu/rapl/rapl_interface.cpp, src/wakeup/wakeup.h — batch 17
+
+### Low item #1 : `#ifndef` header guard instead of `#pragma once` (intel_cpus.h)
+
+Location: src/cpu/intel_cpus.h : 1
+Description: The file uses a traditional `#ifndef`/`#define`/`#endif` header guard instead of the project-mandated `#pragma once` (style.md §4.1).
+Severity rationale: Style violation; `#pragma once` is required by the project style guide.
+Suggested fix: Replace the `#ifndef` guard with `#pragma once`.
+
+### Low item #2 : `#ifndef` header guard instead of `#pragma once` (rapl_interface.h)
+
+Location: src/cpu/rapl/rapl_interface.h : 24
+Description: Same issue as Low item #1 — uses `#ifndef RAPL_INTERFACE_H` instead of `#pragma once`.
+Severity rationale: Style violation per style.md §4.1.
+Suggested fix: Replace the `#ifndef` guard with `#pragma once`.
+
+### Low item #3 : `#ifndef` header guard instead of `#pragma once` (wakeup.h)
+
+Location: src/wakeup/wakeup.h : 25
+Description: Same issue — uses `#ifndef _INCLUDE_GUARD_WAKEUP_H` instead of `#pragma once`.
+Severity rationale: Style violation per style.md §4.1.
+Suggested fix: Replace the `#ifndef` guard with `#pragma once`.
+
+### Low item #4 : Pervasive typo `measurment_interval` (missing 'e')
+
+Location: src/cpu/rapl/rapl_interface.h : 47, src/cpu/rapl/rapl_interface.cpp : 79, 661, 671, 681, 691, 696
+Description: The member variable and all references are spelled `measurment_interval` instead of `measurement_interval`. The typo propagates across the header and all uses in the implementation.
+Severity rationale: Misspelling in a protected member variable name; low functional impact but reduces readability and searchability.
+Suggested fix: Rename to `measurement_interval` throughout.
+
+### Low item #5 : Missing space between `if` and `(` in multiple locations (rapl_interface.cpp)
+
+Location: src/cpu/rapl/rapl_interface.cpp : 248, 262, 276, 294, 315, 335, 355, 384, 405, 428, 447, 474, 495, 512, 532, 562, 583, 600, 620
+Description: Many `if` statements are written as `if(ret < 0)` without a space between the keyword and the opening parenthesis, violating the K&R style requirement (style.md §1.2) and the project's Linux-kernel-variant brace/spacing convention.
+Severity rationale: Consistent style violation throughout the file.
+Suggested fix: Add a space: `if (ret < 0)`.
+
+### Low item #6 : Space-indented line in intel_cpus.h (mixed indentation)
+
+Location: src/cpu/intel_cpus.h : 56
+Description: The line `        DIR *dir;` uses 8 spaces for indentation instead of a tab character. All other members in the class use tab indentation. This breaks the "tabs only" rule from style.md §1.1.
+Severity rationale: Mixed indentation in a single class declaration; style violation per style.md §1.1.
+Suggested fix: Replace the leading spaces with a tab character.
+
+## Review of wakeup_usb.h, wakeup_ethernet.h, waketab.cpp, wakeup_ethernet.cpp, wakeup.cpp — batch 18
+
+### Low item #1 : duplicate sysfs path construction in wakeup_eth_callback
+
+Location: src/wakeup/wakeup_ethernet.cpp : 99-103
+Description: `filename` is set by `std::format(...)` on line 99, checked with `access()`, then set identically again on line 103 before being passed to the constructor. The second assignment is dead code and suggests a copy/paste error. The same pattern occurs in `wakeup_usb_callback`.
+Severity rationale: Low — no functional impact, but dead code is misleading and could mask a future bug if lines diverge.
+Suggested fix: Remove the second (redundant) `filename = std::format(...)` assignment on line 103.
+
+### Low item #2 : virtual overrides missing `override` specifier
+
+Location: src/wakeup/wakeup_usb.h : 40-44  and  src/wakeup/wakeup_ethernet.h : 40-44
+Description: The three virtual methods (`wakeup_value`, `wakeup_toggle`, `wakeup_toggle_script`) declared in both headers are overrides of the base class `wakeup`, but they lack the `override` keyword. Without `override`, a typo in a method signature silently creates a new virtual function instead of overriding the base.
+Severity rationale: Low — no current bug, but `override` is a C++11 safety net that costs nothing and prevents subtle errors.
+Suggested fix: Add `override` and remove the redundant `virtual`:
+```cpp
+int wakeup_value(void) override;
+void wakeup_toggle(void) override;
+std::string wakeup_toggle_script(void) override;
+```
+
+### Low item #3 : `#ifndef`/`#define` include guards instead of `#pragma once`
+
+Location: src/wakeup/wakeup_usb.h : 25-26  and  src/wakeup/wakeup_ethernet.h : 25-26
+Description: Both headers use old-style `#ifndef _INCLUDE_GUARD_*` guards. The project style guide mandates `#pragma once`.
+Severity rationale: Low — style guide violation; `#pragma once` is simpler and universally supported by all toolchains targeted by PowerTOP.
+Suggested fix: Replace the `#ifndef`/`#define`/`#endif` guards with `#pragma once`.
+
+### Low item #4 : user-visible string not wrapped in `_()` for translation
+
+Location: src/wakeup/waketab.cpp : 110
+Description: `ui_notify_user(std::format(">> {}\n", wakeup_toggle_script))` presents text to the user but the format string `">> {}\n"` is not marked for translation with `_()`. All user-facing strings must use the gettext `_()` macro per the style guide. Additionally, the style guide states user-facing `pt_format` should be used for translated strings with arguments.
+Severity rationale: Low — i18n requirement clearly stated in the style guide; the string will never be translated.
+Suggested fix:
+```cpp
+ui_notify_user(pt_format(_(">> {}\n"), wakeup_toggle_script));
+```
+
+### Low item #5 : excessive unused includes in wakeup_ethernet.cpp
+
+Location: src/wakeup/wakeup_ethernet.cpp : 27-43
+Description: The following headers are included but nothing from them is used in the file: `<sys/socket.h>`, `<errno.h>`, `<linux/types.h>`, `<net/if.h>`, `<linux/sockios.h>`, `<sys/ioctl.h>`, `<linux/ethtool.h>`, `<iostream>`, `<fstream>`, `<stdlib.h>`, `<string.h>`, `<sys/types.h>`, `<unistd.h>`, `<utility>`. These appear to be leftovers from an earlier implementation that used raw ethtool ioctls.
+Severity rationale: Low — no functional impact, but unnecessary includes increase compile time, pollute the macro/symbol namespace, and hide the real dependencies of the file.
+Suggested fix: Remove all unused includes. Keep only: `<stdio.h>`, `<format>`, `"wakeup.h"`, `"../lib.h"`, `"wakeup_ethernet.h"`.
+
+## Review of src/wakeup/wakeup_usb.cpp, src/measurement/acpi.cpp, src/measurement/acpi.h, src/measurement/opal-sensors.h — batch 19
+
+### Low item #1 : Duplicate `filename` computation in `wakeup_usb_callback`
+
+Location: src/wakeup/wakeup_usb.cpp : 99 and 103
+Description: `filename` is computed with `std::format("/sys/bus/usb/devices/{}/power/wakeup", d_name)` on line 99, used only for the `access()` call, and then immediately recomputed with the exact same expression on line 103. The second assignment is dead code — it produces the same value as the first. This is misleading (suggests the value might differ) and wasteful.
+Severity rationale: Low — no functional impact, but creates confusion and violates DRY; the double computation also hints at a refactoring left half-done.
+Suggested fix: Remove line 103. The existing value of `filename` from line 99 is valid for passing to the `usb_wakeup` constructor.
+
+### Low item #2 : Unused includes in wakeup_usb.cpp
+
+Location: src/wakeup/wakeup_usb.cpp : 33-40
+Description: The following headers are included but no symbols from them are referenced anywhere in the file: `<sys/socket.h>`, `<net/if.h>`, `<linux/sockios.h>`, `<sys/ioctl.h>`, `<linux/ethtool.h>`, and `<iostream>`. These appear to be leftover from copy-paste from an ethernet wakeup file. Unnecessary includes increase compilation time and mislead readers about the file's dependencies.
+Severity rationale: Low — no functional impact, but violates clean-code principles and harms readability.
+Suggested fix: Remove the six unused include directives.
+
+### Low item #3 : Override methods in `acpi_power_meter` lack `override` keyword
+
+Location: src/measurement/acpi.h : 37-42
+Description: `start_measurement`, `end_measurement`, `power`, and `dev_capacity` are declared with `virtual` in the derived class `acpi_power_meter` but without the `override` specifier. C++11 and later best practice (and the C++20 standard used by this project) require `override` on overriding functions so the compiler can catch signature mismatches.
+Severity rationale: Low — no crash risk but silently hides interface-mismatch bugs; violates C++20 best practices.
+Suggested fix: Add `override` and remove the redundant `virtual` on all four overriding method declarations.
+
+### Low item #4 : Override methods in `opal_sensors_power_meter` lack `override` keyword
+
+Location: src/measurement/opal-sensors.h : 34-38
+Description: Same issue as batch 19 Low item #3: `start_measurement`, `end_measurement`, `power`, and `dev_capacity` use `virtual` without `override`.
+Severity rationale: Low — same rationale as item #3 above.
+Suggested fix: Add `override`, remove `virtual`, on all four declarations.
+
+## Review of sysfs.h, sysfs.cpp, measurement.h, measurement.cpp, extech.h — batch 20
+
+### Low item #1 : C headers used instead of C++ headers in sysfs.cpp
+
+Location: src/measurement/sysfs.cpp : 28-30
+Description: `#include <string.h>`, `#include <stdio.h>`, and `#include <limits.h>` are C headers. The C++ equivalents (`<cstring>`, `<cstdio>`, `<climits>`) place all symbols in the `std::` namespace, avoiding accidental name collisions. The project uses C++20 throughout.
+Severity rationale: Low — compiles correctly, but uses non-idiomatic headers for a C++20 codebase.
+Suggested fix: Replace with `<cstring>`, `<cstdio>`, `<climits>`.
+
+### Low item #2 : `power_meters.size() == 0` instead of `power_meters.empty()`
+
+Location: src/measurement/measurement.cpp : 174
+Description: Comparing `size()` to 0 is less idiomatic and slightly less efficient than `empty()`. The STL guideline (and general C++ best practice) is to use `empty()` when testing for an empty container.
+Severity rationale: Correctness is unaffected, but violates the "prefer STL constructs" rule in general-c++.md.
+Suggested fix: `if (power_meters.empty()) {`
+
+### Low item #3 : Index-based loops where range-based for loops should be used
+
+Location: src/measurement/measurement.cpp : 66-67, 73-74, 83-86, 121-125
+Description: Four loops iterate over `power_meters` using `unsigned int i` as an index. The project uses C++20 and range-based for loops are cleaner, avoid off-by-one risk, and do not require a manual index variable. general-c++.md states to strongly prefer STL constructs.
+Severity rationale: Style / best-practice violation; no functional impact.
+Suggested fix: Replace e.g. `for (i = 0; i < power_meters.size(); i++) power_meters[i]->start_measurement();` with `for (auto *m : power_meters) m->start_measurement();`.
+
+### Low item #4 : Unqualified `vector` and unqualified `string` due to namespace pollution
+
+Location: src/measurement/measurement.cpp : 58; src/measurement/sysfs.cpp : 32, 38
+Description: `vector<class power_meter *> power_meters;` (measurement.cpp:58) and `const string &` parameters (sysfs.cpp:32,38) are unqualified. They compile only because `using namespace std;` in measurement.h leaks `std::vector` and `std::string`. Once the `using namespace std;` is removed (High item #1), these lines will fail to compile.
+Severity rationale: Latent compilation error that will surface when fixing the high-severity issue.
+Suggested fix: Use `std::vector<power_meter *>` and `const std::string &` at the affected locations.
+
+## Review of src/measurement/extech.cpp, src/devices/backlight.h, src/devices/rfkill.h, src/devices/rfkill.cpp — batch 21
+
+### Low item #1 : Duplicate includes in extech.cpp
+
+Location: src/measurement/extech.cpp : 37-48 and 58-62
+Description: `<string.h>`, `<stdio.h>`, and `<stdlib.h>` are each included twice — once near the top of the file and again after the project headers. While harmless at compile time due to include guards, it indicates copy-paste accumulation and clutters the file.
+Severity rationale: Code hygiene; redundant code obscures intent.
+Suggested fix: Remove the second block of duplicate includes (lines 60-62).
+
+### Low item #2 : Header guards use `#ifndef` style instead of `#pragma once` (backlight.h, rfkill.h)
+
+Location: src/devices/backlight.h : 25-26 | src/devices/rfkill.h : 25-26
+Description: Both headers use the traditional `#ifndef _INCLUDE_GUARD_*` / `#define` / `#endif` pattern. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style rule violation in two files.
+Suggested fix: Replace each `#ifndef … #define … #endif` triple with `#pragma once`.
+
+### Low item #3 : Fixed-size `char buf[4096]` in rfkill constructor
+
+Location: src/devices/rfkill.cpp : 47
+Description: A fixed-size 4096-byte buffer is used for `readlink()` output. Although the call is correctly bounded with `sizeof(buf) - 1`, the use of a fixed C-style buffer is discouraged by the style guide and general-c++.md in favor of `std::string`-based alternatives. The kernel maximum path length is `PATH_MAX` (typically 4096), so the size is correct, but the idiom is out of place in C++20 code.
+Severity rationale: Style/practice concern; provably safe but violates the preference for STL types.
+Suggested fix: Use `std::array<char, PATH_MAX>` and reference `sizeof` from that, or use an OS-level path query helper if available.
+
+### Low item #4 : `<unistd.h>` included twice in rfkill.cpp
+
+Location: src/devices/rfkill.cpp : 31 and 42
+Description: `<unistd.h>` is included twice in the same translation unit. Harmless but redundant.
+Severity rationale: Code cleanliness; signals lack of attention during editing.
+Suggested fix: Remove the second `#include <unistd.h>` at line 42.
+
+### Low item #5 : `rate` member initialized in constructor body, not initializer list
+
+Location: src/measurement/extech.cpp : 271
+Description: `rate = 0.0;` is assigned in the constructor body instead of the member initializer list. For a plain `double`, there is no performance difference, but it is inconsistent with C++ best practice and with how other data members are initialized.
+Severity rationale: Minor C++ best-practice violation.
+Suggested fix: Move `rate(0.0)` into the initializer list: `extech_power_meter::extech_power_meter(const string &extech_name) : power_meter(extech_name), rate(0.0)`.
+
+## Review of src/devices/usb.h, src/devices/usb.cpp, src/devices/gpu_rapl_device.h, src/devices/gpu_rapl_device.cpp, src/devices/ahci.h — batch 22
+
+### Low item #1 : Header guards using `#ifndef` instead of `#pragma once`
+
+Location: src/devices/usb.h : 25-26, src/devices/gpu_rapl_device.h : 25-26, src/devices/ahci.h : 25-26
+Description: All three headers use the traditional `#ifndef _INCLUDE_GUARD_XXX` / `#define` / `#endif` pattern. The project style guide (`style.md §4.1`) specifies `#pragma once` as the required form. All other recently touched headers in the codebase already use `#pragma once`.
+Severity rationale: Style rule violation; non-conforming to stated project standard.
+Suggested fix: Replace the `#ifndef`/`#define`/`#endif` triple with a single `#pragma once` at the top of each header (after the copyright block).
+
+### Low item #2 : Include order violation in usb.cpp
+
+Location: src/devices/usb.cpp : 25-39
+Description: `#include <iostream>` and `#include <fstream>` (lines 38-39) appear after the project-specific headers `#include "../lib.h"` etc. The project style (`style.md §4.4`) requires standard library headers to appear before project-specific headers. Additionally `#include <iostream>` is never used in this translation unit (no `std::cin`, `std::cout`, etc.), so it is dead code.
+Severity rationale: Style violation; dead include adds unnecessary compile-time overhead.
+Suggested fix: Move `<iostream>` and `<fstream>` before the project includes, and remove `<iostream>` entirely if it is not needed.
+
+### Low item #3 : C-style `class` keyword in variable declaration and `new` expression
+
+Location: src/devices/usb.cpp : 144, 158
+Description: Line 144 declares `class usbdevice *usb;` and line 158 uses `new class usbdevice(...)`. Prefixing the class name with the `class` keyword in expressions is a C idiom not idiomatic C++; in C++ the type name `usbdevice` is sufficient. This is the only file in the recently reviewed batch that does this.
+Severity rationale: Style violation; C idiom in C++ code.
+Suggested fix: Change to `usbdevice *usb;` and `usb = new usbdevice(...)`.
+
+### Low item #4 : Missing `const` on pure-getter methods
+
+Location: src/devices/usb.h : 55-62, src/devices/gpu_rapl_device.h : 47-50, src/devices/ahci.h : 58-65
+Description: Methods such as `class_name()`, `device_name()`, `human_name()`, `power_valid()`, `grouping_prio()`, and `device_present()` access no mutable state and should be declared `const`. The project rules (`general-c++.md`) require `const` where possible. Omitting `const` prevents calling these methods on `const` references or through `const` pointers to the objects.
+Severity rationale: C++ best-practice and coding-rule violation; limits const-correctness of callers.
+Suggested fix: Append `const` to each getter: e.g., `virtual std::string class_name(void) const { return "usb"; }`.
+
+### Low item #5 : Unused `#include <iostream>` in usb.cpp
+
+Location: src/devices/usb.cpp : 38
+Description: `<iostream>` is included but no symbols from it (`std::cin`, `std::cout`, `std::cerr`, etc.) are used anywhere in `usb.cpp`. Dead includes slow compilation and confuse readers.
+Severity rationale: Dead code / style violation.
+Suggested fix: Remove `#include <iostream>`.
+
+### Low item #6 : Return value of `rapl.get_pp1_energy_status()` is silently ignored
+
+Location: src/devices/gpu_rapl_device.cpp : 39, 47, 57
+Description: `c_rapl_interface::get_pp1_energy_status()` presumably returns a status code indicating success or failure. All three call sites discard the return value. If the call fails, `last_energy` / `energy` will hold an outdated or garbage value and `consumed_power` will be computed incorrectly. At minimum, a failure check should log a warning or set `consumed_power = 0.0`.
+Severity rationale: Missing error handling; silent failure mode could produce incorrect power readings.
+Suggested fix: Check the return value and, on failure, skip the energy update: `if (rapl.get_pp1_energy_status(&energy) == 0) { consumed_power = ...; last_energy = energy; }`.
+
+### Low item #7 : Unused `#include <limits.h>` in usb.h
+
+Location: src/devices/usb.h : 28
+Description: `<limits.h>` is included in usb.h but no symbol from it (e.g., `INT_MAX`, `PATH_MAX`) is used in the header. If it was needed in usb.cpp, the include belongs there. Dead includes in headers are transitive and affect all translation units that include usb.h.
+Severity rationale: Dead include in a header; increases compile time and can mask missing includes in .cpp files.
+Suggested fix: Remove `#include <limits.h>` from usb.h; add it to usb.cpp only if actually needed there (it is not used in usb.cpp either, so remove entirely).
+
+
+## Review of src/devices/ahci.cpp, src/devices/thinkpad-fan.h, src/devices/thinkpad-fan.cpp, src/devices/device.h, src/devices/device.cpp — batch 23
+
+### Low item #1 : Typo "macine" in user-visible translatable string
+
+Location: src/devices/ahci.cpp : 277
+Description: The string `__("AHCI ALPM Residency Statistics - Not supported on this macine")` contains the typo "macine" (should be "machine"). This string appears in the HTML report and is visible to users.
+Severity rationale: Typo in a user-visible string; cosmetic but incorrect.
+Suggested fix: `__("AHCI ALPM Residency Statistics - Not supported on this machine")`
+
+### Low item #2 : `links.size() == 0` should use `.empty()`
+
+Location: src/devices/ahci.cpp : 276
+Description: `if (links.size() == 0)` tests emptiness by comparing the size to zero. The idiomatic and slightly more efficient C++ expression is `links.empty()`.
+Severity rationale: Style / best practice; STL guideline prefers `.empty()` for emptiness checks.
+Suggested fix: `if (links.empty()) {`
+
+### Low item #3 : `end_devslp` not clamped to `start_devslp` unlike the other three counters
+
+Location: src/devices/ahci.cpp : 156–163
+Description: In `ahci::end_measurement`, counter underflow is guarded for `end_active`, `end_partial`, and `end_slumber` (lines 156–162), but `end_devslp` has no corresponding clamp. If the sysfs counter wraps or is reset between `start_measurement` and `end_measurement`, `end_devslp - start_devslp` will be a large negative number. While the subsequent `if (p < 0) p = 0` guard prevents a negative percentage, the unclamped value also distorts `total`, which is used as the divisor for all four percentages.
+Severity rationale: Inconsistent defensive logic; can skew all four reported percentages on counter reset/wrap.
+Suggested fix: Add `if (end_devslp < start_devslp) end_devslp = start_devslp;` after line 161.
+
+### Low item #4 : Untranslated user-visible strings in thinkpad-fan.h
+
+Location: src/devices/thinkpad-fan.h : 47 and 50
+Description: `device_name()` returns `"Fan-1"` and `util_units()` returns `" rpm"`. Both strings may be displayed to the user (device name column, utilisation unit column). Neither is wrapped in `_()`. Per rules.md all user-visible strings must be translatable.
+Severity rationale: i18n violation for strings that appear in the device table.
+Suggested fix: `return _("Fan-1");` and `return _(" rpm");`
+
+### Low item #5 : Untranslated default `device_name` and `class_name` in device.h
+
+Location: src/devices/device.h : 58–59
+Description: The base class `device` returns `"abstract device"` for both `class_name()` and `device_name()`. Should a concrete subclass fail to override these methods, the bare English strings would be displayed to the user without translation.
+Severity rationale: Latent i18n risk; currently only triggered if a subclass forgets to override.
+Suggested fix: `{ return _("abstract device"); }`
+
+### Low item #6 : Index-based loops should use range-for
+
+Location: src/devices/device.cpp : 107–108, 113–115, 119–122, 187–214, 274–310, 331–334
+Description: Multiple loops over `all_devices` use `unsigned int i` index variables and manual `size()` comparisons. Modern C++20 idiom prefers range-for (`for (auto *dev : all_devices) { … }`) which is clearer and avoids potential signed/unsigned comparison warnings.
+Severity rationale: Style / best practice; not a functional issue.
+Suggested fix: Convert to range-for where the index is not used for anything other than element access.
+## Review of src/devices/devfreq.cpp, src/devices/devfreq.h, src/devices/alsa.h, src/devices/alsa.cpp, src/devices/runtime_pm.cpp — batch 24
+
+### Low item #1 : Global `DIR *dir` held open unnecessarily between create and clear
+
+Location: src/devices/devfreq.cpp : 44, 237-253, 325-328
+Description: `dir` is opened in `create_all_devfreq_devices()` only to count directory entries and is then left open until `clear_all_devfreq()` is called — potentially hours later. There is no functional reason to keep this handle open; the directory enumeration is done by `process_directory()` which opens the directory independently. Holding the file descriptor wastes a system resource and means the kernel cannot release the dentry.
+Severity rationale: Unnecessary resource hold; no correctness benefit.
+Suggested fix: Close `dir` with `closedir(dir); dir = NULL;` immediately after the `num == 2` early-exit or right after the counting loop completes; remove the close in `clear_all_devfreq()`.
+
+### Low item #2 : Magic number `7` in `alsa::register_power_with_devlist()`
+
+Location: src/devices/alsa.cpp : 163
+Description: `if (name.length() > 7) register_devpower(name.substr(7), ...)` uses the literal `7` to strip a prefix from `name`. The name is formatted as `"alsa:{}"` (prefix length 5). The value 7 corresponds to `"alsa:hw"` (stripping the `alsa:hw` prefix from an ALSA hwCxDy identifier). This is undocumented and error-prone; if the name format ever changes, this silently breaks.
+Severity rationale: Unmaintainable magic number; silent breakage risk on format change.
+Suggested fix: Define a named constant or use `name.starts_with("alsa:hw") ? name.substr(7) : name` with a clear comment.
+
+### Low item #3 : Duplicate `#include <unistd.h>`
+
+Location: src/devices/alsa.cpp : 30, 41
+Description: `<unistd.h>` is included twice. While harmless due to include guards, it is dead code noise.
+Severity rationale: Minor code quality issue.
+Suggested fix: Remove the second occurrence at line 41.
+
+### Low item #4 : `!all_devfreq.size()` should use `.empty()`
+
+Location: src/devices/devfreq.cpp : 282
+Description: `if (!all_devfreq.size())` tests emptiness via the size. The idiomatic and potentially more efficient form is `if (all_devfreq.empty())`.
+Severity rationale: Style/best-practice issue; `.empty()` is semantically clearer.
+Suggested fix: `if (all_devfreq.empty())`
+
+### Low item #5 : Mixed tabs/spaces indentation in `display_devfreq_devices()`
+
+Location: src/devices/devfreq.cpp : 271-275
+Description: Lines 271–275 (`if (!win) return;`, `wclear(win);`, `wmove(win, 2,0);`) use 8 spaces for indentation while the surrounding code uses tabs. style.md §1.1 mandates tabs-only indentation.
+Severity rationale: Style violation; inconsistent indentation in a single function.
+Suggested fix: Replace the leading 8-space sequences with a single tab character.
+
+### Low item #6 : Mixed tabs/spaces indentation in `runtime_pmdevice::start_measurement()`
+
+Location: src/devices/runtime_pm.cpp : 64
+Description: Line 64 (`after_suspended_time = 0;`) uses 8 spaces while the adjacent lines use tabs. style.md §1.1 mandates tabs-only indentation. A similar issue appears at line 97 inside `power_usage()`.
+Severity rationale: Style violation.
+Suggested fix: Replace the leading spaces with a single tab.
+
+## Review of runtime_pm.h, network.cpp, network.h, i915-gpu.h, i915-gpu.cpp — batch 25
+
+### Low item #1 : Virtual override methods lack `override` keyword — runtime_pm.h
+
+Location: src/devices/runtime_pm.h : 46–59
+Description: All virtual methods in `runtime_pmdevice` that override base-class `device` methods (`start_measurement`, `end_measurement`, `utilization`, `class_name`, `device_name`, `human_name`, `power_usage`, `power_valid`, `grouping_prio`) use the `virtual` keyword but omit `override`. In C++11 and later (the project targets C++20), `override` makes the compiler verify the override is correct and improves readability.
+Severity rationale: Missing `override` allows silent signature mismatches to go undetected; C++ best practice violation.
+Suggested fix: Replace `virtual` with `override` (or add `override` after the signature) on each overriding method, e.g. `void start_measurement(void) override;`.
+
+### Low item #2 : Virtual override methods lack `override` keyword — network.h
+
+Location: src/devices/network.h : 69–81
+Description: All virtual methods in the `network` class that override `device` base methods lack the `override` keyword. Same issue as Low item #1.
+Severity rationale: Same as Low item #1.
+Suggested fix: Add `override` to each overriding method declaration.
+
+### Low item #3 : Virtual override methods lack `override` keyword — i915-gpu.h
+
+Location: src/devices/i915-gpu.h : 40–57
+Description: All overriding virtual methods in `i915gpu` lack `override`. Same issue as Low item #1.
+Severity rationale: Same as Low item #1.
+Suggested fix: Add `override` to each overriding method declaration.
+
+### Low item #4 : Unnecessary `.c_str()` on calls to `std::string`-accepting functions
+
+Location: src/devices/network.cpp : 278, 280, 295, 296
+Description: `iface_speed()` and `net_iface_up()` both accept `const std::string &`. The calls `iface_speed(name.c_str())` and `net_iface_up(name.c_str())` needlessly convert the `std::string` member to a `const char*` only to have the callee construct a new temporary `std::string` from it. This is wasteful and error-prone.
+Severity rationale: Unnecessary conversion; violates the STL preference rule from general-c++.md.
+Suggested fix: Pass `name` directly: `iface_speed(name)` and `net_iface_up(name)`.
+
+### Low item #5 : `ioctl` return value ignored in `iface_link`
+
+Location: src/devices/network.cpp : 227
+Description: The `ioctl(sock, SIOCETHTOOL, &ifr)` call in `iface_link()` is performed but its return value is silently discarded. Because `cmd` is zero-initialised before the call, a failed ioctl will cause the function to return 0 (no link), which may be the wrong answer without any diagnostic.
+Severity rationale: Silent ioctl failure leads to incorrect link-state reporting with no diagnostic.
+Suggested fix: Check the return value and return a sensible error indicator, or at minimum log the failure.
+
+### Low item #6 : `ioctl` return value ignored in `iface_speed`
+
+Location: src/devices/network.cpp : 255
+Description: Same as Low item #5 — `ioctl(sock, SIOCETHTOOL, &ifr)` return value is discarded in `iface_speed()`. A failed call will cause `ethtool_cmd_speed()` to run on zeroed memory, returning 0, which the code then maps to "no link" — a possibly incorrect result obtained without any diagnostic.
+Severity rationale: Silent ioctl failure with incorrect speed/link result.
+Suggested fix: Check ioctl return value; close socket and return 0 on failure.
+
+### Low item #7 : `ethtool_cmd_speed_set` defined but never used
+
+Location: src/devices/network.cpp : 116–122
+Description: Inside the `#ifdef DISABLE_TRYCATCH` block, `ethtool_cmd_speed_set` is defined as a static inline function but is never called anywhere in the file. It is dead code. The macro name `DISABLE_TRYCATCH` is also misleading for what is evidently an ethtool API compatibility guard.
+Severity rationale: Dead code; misleading macro name adds confusion.
+Suggested fix: Remove the unused `ethtool_cmd_speed_set` definition. If retained for future use, rename the guard macro (e.g., `ETHTOOL_CMD_SPEED_MISSING`) to reflect its purpose.
+
+### Low item #8 : Redundant initial assignments immediately overwritten in `start_measurement`
+
+Location: src/devices/network.cpp : 273–280
+Description: `start_measurement` sets `start_up = 1` and `end_up = 1` on lines 273 and 275, only to unconditionally overwrite them with the actual values from `net_iface_up()` and `iface_speed()` on lines 278 and 280. The intermediate values are never observed, making the initialisation misleading (it implies the interface is "up" before we've checked).
+Severity rationale: Misleading dead assignments; reduces readability.
+Suggested fix: Remove the early `start_up = 1; end_up = 1;` assignments; initialise only to `0` or directly assign from the query results.
+
+### Low item #9 : Public data members `pkts` and `duration` in `network` class
+
+Location: src/devices/network.h : 64–65
+Description: `pkts` and `duration` are declared `public` in the `network` class. `pkts` is written by the file-global `do_proc_net_dev()` function and `duration` is exposed publicly with no protection. This breaks encapsulation; any code could modify these values, corrupting measurements.
+Severity rationale: Breaks encapsulation; external write access to measurement state.
+Suggested fix: Make both members private and add a friend declaration or accessor for `do_proc_net_dev`, or refactor `do_proc_net_dev` to return values rather than write directly.
+
+## Review of src/devices/thinkpad-light.cpp, src/devices/thinkpad-light.h — batch 26
+
+### Low item #1 : `#ifndef` header guard instead of `#pragma once`
+
+Location: src/devices/thinkpad-light.h : 25–26
+Description: The header uses a traditional `#ifndef _INCLUDE_GUARD_THINKPAD_LIGHT_H` / `#define` guard. The project style guide (style.md §4.1) mandates `#pragma once` for all headers.
+Severity rationale: Style violation; inconsistency with the rest of the codebase as mandated by style.md.
+Suggested fix: Replace the `#ifndef`/`#define`/`#endif` guard with `#pragma once`.
+
+### Low item #2 : Hard-coded sysfs path literal duplicated three times
+
+Location: src/devices/thinkpad-light.cpp : 52, 58, 63, 79
+Description: The path `/sys/devices/platform/thinkpad_acpi/leds/tpacpi::thinklight/brightness` is written out in full four times: once in the constructor's `register_sysfs_path()` call, twice in `start_measurement()` / `end_measurement()`, and once in `create_thinkpad_light()`. A single typo or kernel-path change would require editing all four sites and risks inconsistencies.
+Severity rationale: DRY violation; maintenance burden and risk of divergence.
+Suggested fix: Define a file-scope `static constexpr char THINKLIGHT_BRIGHTNESS_PATH[]` constant and use it throughout.
+
+### Low item #3 : Magic numbers 2.55 and 2.0 in `utilization()`
+
+Location: src/devices/thinkpad-light.cpp : 71
+Description: `(start_rate + end_rate) / 2.55 / 2.0` uses two unexplained magic numbers. `2.55` is the scale factor to convert a raw [0–255] sysfs brightness value to a percentage (255 / 100 = 2.55), and `2.0` averages the two readings. Neither is obvious from context.
+Severity rationale: Reduces readability and maintainability; magic numbers should be named constants per general best practice.
+Suggested fix: Use named constants, e.g. `static constexpr double BRIGHTNESS_MAX = 255.0;` and express the formula as `((start_rate + end_rate) / 2.0) / BRIGHTNESS_MAX * 100.0`.
+
+### Low item #4 : Magic number `10.0` in `power_usage()`
+
+Location: src/devices/thinkpad-light.cpp : 106
+Description: `get_parameter_value(light_index, bundle) - 10.0` subtracts a hard-coded `10.0` from the stored parameter value without any comment explaining its significance (it represents the idle baseline power at 0 % brightness).
+Severity rationale: Unexplained magic constant; reduces readability and maintainability.
+Suggested fix: Define `static constexpr double THINKLIGHT_BASELINE_POWER = 10.0;` and use it in the expression.

--- a/logs/medium.md
+++ b/logs/medium.md
@@ -1,0 +1,1453 @@
+# PowerTOP Medium Severity Review Findings
+
+## Review of calibrate.cpp, calibrate.h, lib.cpp, devlist.cpp, main.cpp — batch 01
+
+### Medium item #1 : `using namespace std;` in calibrate.cpp
+
+Location: src/calibrate/calibrate.cpp : 48
+
+Description:
+`using namespace std;` is present at file scope. The project style guide (style.md §4.2) explicitly prohibits this; all standard-library elements must be referenced via the `std::` prefix. Code earlier in the same file already uses `std::string` and `std::format` correctly, making the `using` directive redundant and inconsistent.
+
+Severity rationale: Namespace pollution can cause silent name collisions with POSIX and project symbols; it is a banned construct per the project coding rules.
+
+Suggested fix: Remove `using namespace std;` and qualify any bare `string`, `map`, `vector`, `ifstream`, etc. with `std::`.
+
+---
+
+### Medium item #2 : `using namespace std;` in lib.cpp
+
+Location: src/lib.cpp : 109
+
+Description:
+`using namespace std;` appears after a block of code that already uses explicit `std::` prefixes, and before code that mixes both styles. This is prohibited by style.md §4.2 and general-c++.md.
+
+Severity rationale: Same as Medium item #1 — namespace pollution and banned construct.
+
+Suggested fix: Remove the directive; qualify all standard-library identifiers with `std::`.
+
+---
+
+### Medium item #3 : `using namespace std;` in devlist.cpp
+
+Location: src/devlist.cpp : 43
+
+Description:
+`using namespace std;` at file scope, prohibited by the project style guide.
+
+Severity rationale: Same as Medium items #1 and #2.
+
+Suggested fix: Remove and add `std::` qualifiers throughout.
+
+---
+
+### Medium item #4 : Error message in `burn_disk` not translatable
+
+Location: src/calibrate/calibrate.cpp : 232
+
+Description:
+```cpp
+printf("Error: %s\n", strerror(errno));
+```
+The string literal `"Error: %s\n"` is not wrapped in `_()`. All user-visible strings must be internationalised (rules.md, style.md §5). The message is also emitted to `stdout` instead of `stderr`.
+
+Severity rationale: Violates the project i18n requirement; non-English users will always see the untranslated string.
+
+Suggested fix:
+```cpp
+fprintf(stderr, _("Error writing calibration file: %s\n"), strerror(errno));
+```
+
+---
+
+### Medium item #5 : `pthread_create` return value not checked in calibration functions
+
+Location: src/calibrate/calibrate.cpp : 248, 264, 369
+
+Description:
+`cpu_calibration`, `wakeup_calibration`, and `disk_calibration` all call `pthread_create` without checking the return value. If thread creation fails, `stop_measurement` is still set to 0 and `one_measurement` is called, but there is no thread to drive CPU/wakeup/disk load. Calibration data collected in that phase will be silently invalid.
+
+Severity rationale: Silent calibration failure leads to incorrect power model parameters being saved to `saved_parameters.powertop`.
+
+Suggested fix: Check the return value of `pthread_create`; log an error and return early if it fails.
+
+---
+
+### Medium item #6 : `burn_cpu_wakeups` — undefined behaviour casting pointer to `long`
+
+Location: src/calibrate/calibrate.cpp : 210, 264
+
+Description:
+```cpp
+tm.tv_nsec = (unsigned long)dummy;   // dummy is void *
+...
+pthread_create(&thr, NULL, burn_cpu_wakeups, (void *)interval);
+```
+Converting a pointer to `unsigned long` and then storing it in `tv_nsec` (which is of type `long`) is a round-trip pointer → integer → integer that is undefined behaviour in C++. Although it works on most 64-bit Linux targets, it is technically UB and violates general-c++.md ("Undefined behavior language constructs are a violation of coding style").
+
+Severity rationale: Technically undefined behaviour; a cleaner approach avoids the risk of miscompilation under aggressive optimisers.
+
+Suggested fix: Pass the interval via a heap-allocated struct or a file-scope variable rather than through the thread argument pointer.
+
+---
+
+### Medium item #7 : `one_measurement` — workload thread creation error not translatable
+
+Location: src/main.cpp : 239
+
+Description:
+```cpp
+fprintf(stderr, "ERROR: workload measurement thread creation failed\n");
+```
+The string literal is not wrapped in `_()`, violating the i18n requirement.
+
+Severity rationale: Violates mandatory i18n rule for all user-visible strings.
+
+Suggested fix:
+```cpp
+fprintf(stderr, _("ERROR: workload measurement thread creation failed\n"));
+```
+
+---
+
+### Medium item #8 : Debug message not translatable
+
+Location: src/main.cpp : 545
+
+Description:
+```cpp
+printf("Learning debugging enabled\n");
+```
+User-visible string not wrapped in `_()`.
+
+Severity rationale: Violates i18n requirement.
+
+Suggested fix:
+```cpp
+printf(_("Learning debugging enabled\n"));
+```
+
+---
+
+### Medium item #9 : Case `'c'` (calibrate) does not exit after calibration
+
+Location: src/main.cpp : 471–474
+
+Description:
+```cpp
+case 'c':
+    powertop_init(0);
+    calibrate();
+    break;
+```
+After the `break`, the `getopt` loop ends and `powertop_init(auto_tune)` is called again (line 539), followed by a potential interactive display mode or report generation. There is no `exit()` after `calibrate()`. If a user runs `powertop --calibrate`, the tool silently starts the interactive or report mode immediately after calibration completes, which is likely unintended.
+
+Severity rationale: Incorrect program flow; calibration is a standalone operation and should terminate the process.
+
+Suggested fix: Add `exit(0);` after `calibrate();`.
+
+---
+
+### Medium item #10 : `load_parameters` called twice in `powertop_init`
+
+Location: src/main.cpp : 407, 422
+
+Description:
+`load_parameters("saved_parameters.powertop")` is called at line 407 (before parameter registration) and again at line 422 (after). The second call overrides the default registered parameters with saved values, which may be the intent; but calling it before registration at line 407 loads values that are then immediately overwritten by `register_parameter` calls, making the first call a no-op. At minimum this is wasteful; it also suggests a latent ordering bug.
+
+Severity rationale: Redundant call with unclear intent; first call is ineffective and may mask a future ordering bug.
+
+Suggested fix: Remove the first `load_parameters` call (line 407), keeping only the one after all `register_parameter` calls.
+
+## Review of src/test_framework.h, src/test_framework.cpp, src/display.cpp, src/display.h, src/lib.h — batch 02
+
+### Medium item #1 : `using namespace std;` in test_framework.cpp
+
+Location: src/test_framework.cpp : 18
+Description: `using namespace std;` is present at file scope in the .cpp implementation file. While less dangerous than in a header, it still violates style rule 4.2 and general-c++.md ("deprecated construct"). All subsequent unqualified STL identifiers (`string`, `vector`, `ofstream`, `getline`, etc.) rely on this directive.
+Severity rationale: Style/rules violation; medium because it only affects this translation unit.
+Suggested fix: Remove `using namespace std;` and prefix all STL types with `std::`.
+
+---
+
+### Medium item #2 : `using namespace std;` in display.cpp
+
+Location: src/display.cpp : 36
+Description: Same issue as medium item #1 — `using namespace std;` at file scope in a .cpp file. All bare `string`, `vector`, and `map` references in this file rely on it.
+Severity rationale: Style/rules violation; medium because it only affects this translation unit.
+Suggested fix: Remove `using namespace std;` and use `std::` prefix throughout.
+
+---
+
+### Medium item #3 : `#ifndef`/`#define` guard instead of `#pragma once` in test_framework.h
+
+Location: src/test_framework.h : 11
+Description: The file uses an old-style `#ifndef _INCLUDE_GUARD_TEST_FRAMEWORK_H_` / `#define` / `#endif` guard. Style rule 4.1 mandates `#pragma once`.
+Severity rationale: Style violation; also the guard name uses a reserved double-underscore prefix (`_INCLUDE_GUARD_…_H_`), which is UB in C++ (names starting with `_` followed by upper-case are reserved).
+Suggested fix: Replace lines 11–12 and 104 with a single `#pragma once`.
+
+---
+
+### Medium item #4 : `#ifndef` guard instead of `#pragma once` in display.h
+
+Location: src/display.h : 25
+Description: Same issue — old `#ifndef __INCLUDE_GUARD_DISPLAY_H_` guard. The guard name also uses the reserved `__` prefix.
+Severity rationale: Style violation + reserved identifier usage.
+Suggested fix: Replace with `#pragma once`.
+
+---
+
+### Medium item #5 : `#ifndef` guard instead of `#pragma once` in lib.h
+
+Location: src/lib.h : 25
+Description: `#ifndef INCLUDE_GUARD_LIB_H` guard. While the guard name itself is not reserved here, `#pragma once` is the project standard.
+Severity rationale: Style violation.
+Suggested fix: Replace with `#pragma once`.
+
+---
+
+### Medium item #6 : Use of deprecated `resetterm()` in `reset_display()`
+
+Location: src/display.cpp : 87
+Description: `resetterm()` is an obsolete ncurses function (removed in newer ncurses versions). The correct modern API is `endwin()`, which restores the terminal state after curses use. Using `resetterm()` may fail to link against current ncurses or produce wrong terminal behaviour.
+Severity rationale: Deprecated/removed API that can break on modern systems.
+Suggested fix:
+```cpp
+endwin();
+```
+
+---
+
+### Medium item #7 : Hardcoded 120-column width in `show_tab()`
+
+Location: src/display.cpp : 118, 123
+Description: `mvwprintw(tab_bar, 0,0, "%120s", "")` and the same pattern for `bottom_line` pad the line to exactly 120 characters regardless of the actual terminal width (`COLS`). On narrower terminals this overflows the window; on wider terminals the bar is not filled. This is also a printf format-string that doesn't respect COLS.
+Severity rationale: Functional display bug on any terminal not exactly 120 columns wide.
+Suggested fix: Use `COLS` dynamically:
+```cpp
+mvwprintw(tab_bar, 0, 0, "%*s", COLS, "");
+```
+
+---
+
+### Medium item #8 : Hardcoded tab-name string comparisons in `cursor_down()`
+
+Location: src/display.cpp : 247
+Description: `tab_names[current_tab] == "Tunables" || tab_names[current_tab] == "WakeUp"` hardcodes internal tab key names in the cursor navigation logic. This breaks if the tab name is ever changed and creates a fragile coupling between display.cpp and any code that creates those tabs. `init_display()` itself does not create "Tunables" or "WakeUp" tabs, so this comparison is already stale relative to the tabs initialised in this file.
+Severity rationale: Fragile design; logic depends on magic string literals scattered in separate code.
+Suggested fix: Introduce a flag or virtual method on `tab_window` to indicate that the tab uses cursor-tracking, rather than comparing by name.
+
+---
+
+### Medium item #9 : User-visible error strings in test_framework.cpp not wrapped in `_()`
+
+Location: src/test_framework.cpp : 75, 81–84, 120, 144
+Description: Strings such as `"TEST FAIL: Unexpected write to: "`, `"Failed to open record file: "`, and `"Failed to open replay file: "` are printed to `stderr` where they are visible to users running the tool. Per rules.md and style.md §5, all user-visible strings must be wrapped in `_()` for gettext internationalisation.
+Severity rationale: i18n rule violation; strings will not be translatable.
+Suggested fix: Wrap each string literal: e.g. `cerr << _("Failed to open record file: ") << ...`.
+
+---
+
+### Medium item #10 : C-style `typedef` for callback type in lib.h
+
+Location: src/lib.h : 102
+Description: `typedef void (*callback)(const std::string&);` uses the C-style `typedef` syntax. In C++11 and later (the project uses C++20) the preferred form is a `using` alias.
+Severity rationale: Style / C++ best-practice violation.
+Suggested fix:
+```cpp
+using callback = void (*)(const std::string&);
+```
+
+---
+
+### Medium item #11 : `newpad(1000, 1000)` with hardcoded magic numbers in `create_tab()`
+
+Location: src/display.cpp : 51
+Description: Each tab's pad is created with a fixed 1000×1000 cell size. This magic number is repeated in the scroll-limit guards in `cursor_down()` and `cursor_right()` (lines 246, 301) without any shared constant. Using the actual content size or a named constant would make the intent clear and prevent the limit checks from getting out of sync if the pad size is ever changed.
+Severity rationale: Magic number; creates a latent inconsistency between pad allocation and scroll boundary guards.
+Suggested fix: Define `constexpr int PAD_MAX = 1000;` and use it in `newpad` and all guard comparisons.
+
+## Review of src/tuning/tunable.h, src/tuning/tunable.cpp, src/tuning/runtime.h, src/tuning/runtime.cpp — batch 03
+
+### Medium item #1 : Duplicate and malformed `<unistd.h>` include in runtime.cpp
+
+Location: src/tuning/runtime.cpp : 28, 34
+Description: `unistd.h` is included twice. The first occurrence at line 28 uses quotes (`#include "unistd.h"`), which is incorrect for a system header — it causes the compiler to search project directories first. The second occurrence at line 34 uses the correct angle-bracket form (`#include <unistd.h>`). The first include should be removed.
+Severity rationale: Using quotes for system headers can cause subtle include-path issues and is a misuse of the include syntax. Having duplicate includes is also wasteful.
+Suggested fix: Remove line 28 (`#include "unistd.h"`), keep line 34 (`#include <unistd.h>`).
+
+### Medium item #2 : Missing `override` specifier on virtual methods in `runtime_tunable`
+
+Location: src/tuning/runtime.h : 39–41
+Description: `good_bad()` and `toggle()` override virtual methods from `tunable` but do not use the `override` keyword. Without `override`, a typo in the method signature would silently create a new virtual function instead of overriding the base class method.
+Severity rationale: Missing `override` is a C++11+ best-practice violation. It prevents the compiler from catching signature mismatches.
+Suggested fix:
+```cpp
+virtual int good_bad(void) override;
+virtual void toggle(void) override;
+```
+
+### Medium item #3 : C header `<limits.h>` used instead of C++ header `<climits>`
+
+Location: src/tuning/runtime.h : 29
+Description: The C header `<limits.h>` is included. In C++ code, the corresponding C++ header `<climits>` should be used, which places all declarations in the `std` namespace.
+Severity rationale: Using C headers in C++ code is a style violation per general-c++.md (C++20 standard compliance).
+Suggested fix: Replace `#include <limits.h>` with `#include <climits>`. Also applies to runtime.cpp line 37.
+
+### Medium item #4 : C header `<string.h>` used instead of C++ header `<cstring>`
+
+Location: src/tuning/tunable.cpp : 28 ; src/tuning/runtime.cpp : 30
+Description: Both files include `<string.h>` (C header) instead of `<cstring>` (C++ header). Additionally, given that these files use `std::string` throughout and do not appear to call any `string.h` functions, this include may be unnecessary entirely.
+Severity rationale: Same as Medium #3 — C-style headers in C++ code.
+Suggested fix: Replace `#include <string.h>` with `#include <cstring>` in both files, or remove if unused.
+
+### Medium item #5 : Raw owning pointers in `all_tunables` / `all_untunables` vectors
+
+Location: src/tuning/tunable.h : 89–90 ; src/tuning/runtime.cpp : 151–156, 169–171, 187–190
+Description: `all_tunables` and `all_untunables` hold `class tunable *` raw owning pointers. Objects allocated with `new` in `add_runtime_tunables()` are pushed into these vectors and are never deleted. This is a memory leak. The same pattern was noted for other vectors in batch 02.
+Severity rationale: Repeated memory allocation without deallocation; affects every device enumeration run. Using raw owning pointers is a C++ best-practice violation.
+Suggested fix: Change the vector types to `std::vector<std::unique_ptr<tunable>>` and update all push_back calls and consumers to use `std::move` / `.get()` as appropriate.
+
+### Medium item #6 : Block-device scan logic runs only once; devices associated with arbitrary PCI entry
+
+Location: src/tuning/runtime.cpp : 127, 173–192
+Description: The `count` variable (initialized to 0, set to 1 after the first outer-while iteration) causes the block-device `for (char blk...)` loop to execute only on the first PCI device encountered in the directory. Subsequent PCI device iterations skip it entirely. Furthermore, the `runtime_tunable` for each disk is constructed with `entry->d_name` (the current PCI device's name) as the `dev` argument, which is the PCI device at an arbitrary iteration order — not necessarily the one the disk is attached to. The `count` variable name gives no indication of its intended purpose.
+Severity rationale: Functional correctness issue and confusing code. Disk tunables may be silently skipped or associated with the wrong PCI device.
+Suggested fix: If the intent is to scan block devices only once (since their paths are global, not per-PCI-device), move the block-device loop outside the `while` directory-iteration loop entirely. Replace `count` with a clearly named boolean such as `bool block_devices_scanned = false`.
+
+### Medium item #7 : Unused includes in runtime.cpp
+
+Location: src/tuning/runtime.cpp : 32–33
+Description: `#include <utility>` and `#include <iostream>` are present but nothing from `<utility>` (e.g., `std::move`, `std::pair`) or `<iostream>` (`std::cout`, `std::cin`) appears to be used in the file.
+Severity rationale: Unused includes increase compile time and obscure actual dependencies.
+Suggested fix: Remove `#include <utility>` and `#include <iostream>` from runtime.cpp.
+
+## Review of ethernet.cpp, ethernet.h, wifi.cpp, wifi.h, tuningusb.h — batch 04
+
+### Medium item #1 : `#ifndef` include guard instead of `#pragma once` in ethernet.h
+
+Location: src/tuning/ethernet.h : 25–26
+Description: The header uses a traditional `#ifndef _INCLUDE_GUARD_ETHERNET_TUNE_H` / `#define` guard. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style guide violation; `#pragma once` is simpler and less error-prone.
+Suggested fix: Replace lines 25–27 and the closing `#endif` with `#pragma once`.
+
+### Medium item #2 : `#ifndef` include guard instead of `#pragma once` in wifi.h
+
+Location: src/tuning/wifi.h : 25–26
+Description: Same issue as Medium item #1 — `#ifndef _INCLUDE_GUARD_WIFI_TUNE_H` guard should be `#pragma once`.
+Severity rationale: Same as Medium item #1.
+Suggested fix: Replace with `#pragma once`.
+
+### Medium item #3 : `#ifndef` include guard instead of `#pragma once` in tuningusb.h
+
+Location: src/tuning/tuningusb.h : 25–26
+Description: Same issue — `#ifndef _INCLUDE_GUARD_USB_TUNE_H` guard should be `#pragma once`.
+Severity rationale: Same as Medium items #1 and #2.
+Suggested fix: Replace with `#pragma once`.
+
+### Medium item #4 : Duplicate and incorrectly-quoted `#include "unistd.h"` in wifi.cpp
+
+Location: src/tuning/wifi.cpp : 28 and 34
+Description: `unistd.h` is included twice: first as `#include "unistd.h"` (using quotes, which searches project-local directories first — incorrect for a system header), and again as the correct `#include <unistd.h>` (with angle brackets) at line 34. The first inclusion uses the wrong quoting style and is entirely redundant.
+Severity rationale: Wrong quoting for a system header (could accidentally pick up a local file shadowing unistd.h); duplicate include is dead code.
+Suggested fix: Remove the `#include "unistd.h"` at line 28 entirely; keep `#include <unistd.h>` at line 34.
+
+### Medium item #5 : Unchecked `ioctl` return values in `toggle()`
+
+Location: src/tuning/ethernet.cpp : 123 and 126
+Description: Both `ioctl(sock, SIOCETHTOOL, &ifr)` calls in `toggle()` — the ETHTOOL_GWOL read (line 123) and the ETHTOOL_SWOL write (line 126) — have their return values discarded. If ETHTOOL_GWOL fails, the subsequent ETHTOOL_SWOL write will use zeroed (unread) WoL data. If ETHTOOL_SWOL fails silently, the user receives no indication that the toggle had no effect.
+Severity rationale: Silent failure of a user-visible action (toggling WoL), and write based on potentially uninitialised data.
+Suggested fix: Check both return values; on failure for ETHTOOL_GWOL abort the toggle; log or surface ETHTOOL_SWOL failure.
+
+### Medium item #6 : readdir loop does not explicitly skip `.` and `..` entries
+
+Location: src/tuning/wifi.cpp : 86–95
+Description: The `readdir` loop in `add_wifi_tunables()` does not explicitly skip the "." and ".." directory entries. While the `strstr(entry->d_name, "wlan")` filter happens to exclude them (since "." and ".." do not contain "wlan"), the project rules (rules.md) require that all `opendir`/`readdir` code explicitly skip `.` and `..`. If the filter condition is ever relaxed or changed, the rule violation could become a real bug.
+Severity rationale: Explicit rule violation from rules.md; also fragile — depends on an incidental property of the filter rather than a deliberate guard.
+Suggested fix:
+```cpp
+if (entry->d_name[0] == '.')
+    continue;
+```
+
+## Review of tuningusb.cpp, tuning.cpp, tuning.h, bluetooth.cpp, bluetooth.h — batch 05
+
+### Medium item #1 : Dangling pointer comparison after `closedir()`
+
+Location: src/tuning/tuningusb.cpp : 112–125
+Description: The loop assigns `entry = readdir(dir)` on each iteration. When the loop exits via `break` (an interface without autosuspend support is found), `entry` holds a pointer into the DIR's internal buffer. `closedir(dir)` is then called on line 120, freeing that buffer. The comparison `if (entry)` on line 123 reads a dangling pointer. While comparing a dangling pointer to NULL is not a dereference and works in practice on Linux (the pointer value itself is still on the stack), it is undefined behaviour per the C++ standard and relies on the freed memory not having been immediately reused.
+Severity rationale: Undefined behaviour; correct only by coincidence on current Linux/glibc. A future allocator or sanitizer will flag this.
+Suggested fix: Use a boolean flag:
+```cpp
+bool has_non_autosuspend = false;
+while ((entry = readdir(dir))) {
+    if (!isdigit(entry->d_name[0]))
+        continue;
+    filename = std::format("...", d_name, entry->d_name);
+    if (access(filename.c_str(), R_OK) == 0 && read_sysfs(filename) == 0) {
+        has_non_autosuspend = true;
+        break;
+    }
+}
+closedir(dir);
+if (has_non_autosuspend)
+    return;
+```
+
+### Medium item #2 : `last_check_time` cache not updated on several error paths
+
+Location: src/tuning/bluetooth.cpp : 141–162
+Description: The 60-second cache for the expensive `popen` check is guarded by `if (time(NULL) - last_check_time > 60)`. Inside that block, `last_check_time = time(NULL)` is only reached if popen succeeds AND the first `fgets` succeeds AND the second `fgets` succeeds AND `strlen(line) == 0`. Every other path hits `goto out` without updating `last_check_time`. Consequently, if the first `fgets` returns NULL (empty file from hcitool), `popen` is called on every single invocation of `good_bad()` rather than being throttled to once per minute. This defeats the stated "this check is expensive" comment entirely.
+Severity rationale: Performance regression — an intentionally throttled system call is called at full rate on a common code path.
+Suggested fix: Update `last_check_time` at the top of the block, before the popen call, so that the 60-second window is always honoured regardless of outcome.
+
+### Medium item #3 : Fixed-size `char` buffer used for parsing popen output
+
+Location: src/tuning/bluetooth.cpp : 146–159
+Description: `char line[2048]` is used with `fgets(line, 2047, file)`. This is a C-idiom in C++ code. The size 2047 (instead of `sizeof(line)`) also means the buffer is read one byte short of its capacity without explanation. Beyond the style concern, a hypothetically long hcitool output line could be silently truncated, causing the `strlen(line) > 0` check to incorrectly conclude a connection exists.
+Severity rationale: Poor C++ practice; the buffer-size mismatch is an off-by-one that could produce incorrect results on long output lines.
+Suggested fix: Use `std::string line; std::getline(...)` after wrapping the FILE* in a `std::unique_ptr` or using `__gnu_cxx::stdio_filebuf`, or at minimum change `fgets(line, 2047, file)` to `fgets(line, sizeof(line), file)`.
+
+### Medium item #4 : Unsigned underflow when `all_tunables` is empty
+
+Location: src/tuning/tuning.cpp : 85
+Description: `w->cursor_max = all_tunables.size() - 1;` — `size()` returns `size_t` (unsigned). If `all_tunables` is empty (all tunable-detection functions found nothing), `0 - 1` wraps to `SIZE_MAX` (typically 2^64−1 on 64-bit). `cursor_max` is typed `int` in `tab_window`, so the assignment truncates, but the result is still a large positive number. The cursor can then be moved far beyond the end of the vector, causing undefined behaviour when `all_tunables[cursor_pos]` is later dereferenced.
+Severity rationale: Potential out-of-bounds vector access if the system has no tunables (e.g., in a restricted container environment).
+Suggested fix:
+```cpp
+w->cursor_max = all_tunables.empty() ? 0 : static_cast<int>(all_tunables.size()) - 1;
+```
+
+### Medium item #5 : Outdated `hci_usb` kernel module check
+
+Location: src/tuning/bluetooth.cpp : 128–130
+Description: The condition `access("/sys/module/hci_usb", F_OK)` checks for the `hci_usb` kernel module, which was replaced by `btusb` in Linux kernel 2.6.24 (circa 2008). On all modern kernels this path never exists, so `access()` always returns −1 (non-zero). The full guard `(devinfo.flags & 1) == 0 && access("/sys/module/hci_usb", F_OK)` therefore always evaluates to true when the interface is down, and `goto out` is taken, setting result to TUNE_GOOD. While this happens to be the correct result (BT down = power-efficient), the dead check makes the code misleading and could mask future logic errors.
+Severity rationale: Dead code that obscures the actual logic; the module it checks has not existed for 15+ years.
+Suggested fix: Remove the `access("/sys/module/hci_usb", F_OK)` part of the condition. If the intent is "interface is down → TUNE_GOOD", express it directly:
+```cpp
+if ((devinfo.flags & 1) == 0)  /* interface is down */
+    goto out;
+```
+
+### Medium item #6 : Use of `system()` for Bluetooth toggle
+
+Location: src/tuning/bluetooth.cpp : 180–185
+Description: `bt_tunable::toggle()` calls `system("/usr/sbin/hciconfig hci0 up &> /dev/null &")` and `system("/usr/sbin/hciconfig hci0 down &> /dev/null")` to toggle the interface. `system()` forks a shell, making the implementation dependent on `/bin/sh`, subject to environment variable manipulation, and unable to safely capture errors. The return value check only tests the shell's own exit code, not hciconfig's. Furthermore, hciconfig is deprecated (same issue as hcitool).
+Severity rationale: Use of deprecated tool; `system()` is considered poor practice for programmatic invocation of system commands.
+Suggested fix: Use the `HCIDEVDOWN`/`HCIDEVUP` ioctl directly on the already-opened socket, matching the pattern used in `good_bad()` and `add_bt_tunable()`.
+
+## Review of src/tuning/tuningsysfs.cpp, src/tuning/tuningsysfs.h, src/tuning/nl80211.h, src/tuning/iw.h, src/tuning/iw.c — batch 06
+
+### Medium item #1 : Non-thread-safe global variable enable_power_save
+
+Location: src/tuning/iw.c : 124
+Description: `static int enable_power_save;` is a file-scoped global that is written by `set_wifi_power_saving()` (before calling `__handle_cmd`) and by the netlink callback `print_power_save_handler`, and read by `set_power_save()` and `get_wifi_power_saving()`. Both public API functions are non-reentrant: if two threads (or two interfaces) invoke `get_wifi_power_saving` or `set_wifi_power_saving` concurrently, the results are unpredictable. Additionally, `get_wifi_power_saving` returns `1` on both an nl80211 init error *and* on a genuine "power saving enabled" state, making callers unable to distinguish the two outcomes.
+Severity rationale: Non-reentrant API using shared global state; incorrect result when called concurrently or when initialisation fails.
+Suggested fix: Pass the power-save state as an output parameter (or return value), eliminating the global. For the ambiguous-return issue, return a tri-state (`-1` = error, `0` = disabled, `1` = enabled).
+
+### Medium item #2 : User-visible error strings not wrapped in _() for i18n
+
+Location: src/tuning/iw.c : 86, 91, 97, 215, 221, 262
+Description: Six `fprintf(stderr, ...)` error messages are not wrapped in the gettext `_()` macro, making them untranslatable. Per `rules.md` and `style.md`, all user-visible strings must use `_()`. Affected strings include "Failed to allocate netlink socket.\n", "Failed to connect to generic netlink.\n", "Failed to allocate generic netlink cache.\n", "failed to allocate netlink message\n", "failed to allocate netlink callbacks\n", and "building message failed\n".
+Severity rationale: i18n rule violation; error messages presented to users are not translatable.
+Suggested fix: Wrap each string: `fprintf(stderr, _("Failed to allocate netlink socket.\n"));` etc.
+
+### Medium item #3 : `string` used without std:: prefix in tuningsysfs.cpp constructor
+
+Location: src/tuning/tuningsysfs.cpp : 39
+Description: The constructor signature uses the bare name `string` three times: `sysfs_tunable::sysfs_tunable(const string &str, const string &_sysfs_path, const string &target_content)`. This compiles only because `tuningsysfs.h` (included earlier) contains the banned `using namespace std;`. Per `style.md` and `general-c++.md`, `std::string` must always be used with its fully qualified name.
+Severity rationale: Relies on the `using namespace std` that is itself a rule violation; will break if the namespace pollution is removed.
+Suggested fix: Replace all three occurrences of `string` with `std::string` in the constructor signature.
+
+### Medium item #4 : Non-portable kernel header <asm/errno.h> included in userspace code
+
+Location: src/tuning/iw.c : 49
+Description: `#include <asm/errno.h>` pulls in an architecture-specific kernel header. Userspace code should use `<errno.h>` (already included at line 32) to access `errno` and the `E*` constants. The kernel `<asm/errno.h>` is not guaranteed to be available or consistent across all build environments and toolchain configurations.
+Severity rationale: Non-portable include; `<errno.h>` already provides everything needed.
+Suggested fix: Remove line 49 (`#include <asm/errno.h>`); `<errno.h>` on line 32 already provides all needed error constants.
+
+### Medium item #5 : Non-idiomatic empty-check: length() > 0 instead of !empty()
+
+Location: src/tuning/tuningsysfs.cpp : 67
+Description: `if (bad_value.length() > 0)` tests whether a `std::string` is non-empty by comparing its length to zero. The idiomatic C++ way is `if (!bad_value.empty())`. The `empty()` call is O(1)-guaranteed by the standard (whereas `length()` is also O(1) in practice for `std::string` but `empty()` expresses intent more clearly) and is the canonical form preferred by `general-c++.md` which says "Strongly prefer STL constructs".
+Severity rationale: Non-idiomatic use of std::string API; minor correctness gap.
+Suggested fix: `if (!bad_value.empty())`
+
+## Review of tuningi2c.h, tuningi2c.cpp, powerconsumer.h, powerconsumer.cpp, processdevice.h — batch 07
+
+### Medium item #1 : `using namespace std;` in tuningi2c.h
+
+Location: src/tuning/tuningi2c.h : 28
+Description: `using namespace std;` appears at file scope in a header. This injects the entire `std` namespace into every translation unit that includes this header, causing silent name collisions and making it impossible for includers to opt out.
+Severity rationale: Per style.md §4.2 this is explicitly forbidden in headers; it pollutes the namespace of all downstream TUs.
+Suggested fix: Remove the `using namespace std;` line. Replace any bare `string`, `vector`, etc. in the header with their fully-qualified `std::string`, `std::vector` equivalents.
+
+### Medium item #2 : `using namespace std;` in powerconsumer.h
+
+Location: src/process/powerconsumer.h : 33
+Description: Same problem as Medium item #1 above — `using namespace std;` at file scope in a header, polluting all includers.
+Severity rationale: Same as item #1.
+Suggested fix: Remove the `using namespace std;` line and qualify all standard-library names with `std::`.
+
+### Medium item #3 : Unqualified `vector` in `all_power` declaration
+
+Location: src/process/powerconsumer.h : 72
+Description: `extern vector <class power_consumer *> all_power;` uses the bare unqualified `vector` name, which only works because of the `using namespace std;` on line 33.  When that `using` is removed (as it should be), this declaration will fail to compile.
+Severity rationale: Directly coupled to the `using namespace std` violation; would become a compile error on cleanup.
+Suggested fix: `extern std::vector<class power_consumer *> all_power;`
+
+### Medium item #4 : Unqualified `vector` in `all_proc_devices` declaration
+
+Location: src/process/processdevice.h : 50
+Description: `extern vector<class device_consumer *> all_proc_devices;` similarly relies on the inherited `using namespace std;` from `powerconsumer.h`.
+Severity rationale: Same as item #3.
+Suggested fix: `extern std::vector<class device_consumer *> all_proc_devices;`
+
+### Medium item #5 : Non-translatable `"abstract"` strings in `name()` and `type()`
+
+Location: src/process/powerconsumer.h : 60, 61
+Description: The default implementations of `name()` and `type()` return bare string literals `"abstract"` without wrapping them in `_()`. If these base-class defaults are ever displayed to the user (e.g. as a fallback when a subclass doesn't override), the strings will be untranslatable.
+Severity rationale: Per rules.md, all user-visible strings must use the `_()` gettext pattern.
+Suggested fix: Return `_("abstract")` from both methods, or return an empty string if they are truly meant to be abstract placeholders that should never reach the UI.
+
+### Medium item #6 : Non-translatable `"Device"` string in `type()`
+
+Location: src/process/processdevice.h : 42
+Description: `virtual std::string type(void) { return "Device"; }` returns a bare untranslated string literal.
+Severity rationale: Per rules.md, all user-visible strings must use `_()`.
+Suggested fix: `return _("Device");`
+
+### Medium item #7 : Non-translatable unit strings in `usage_units()`
+
+Location: src/process/powerconsumer.cpp : 95, 97, 99
+Description: `" µs/s"`, `" us/s"`, and `" ms/s"` are returned as plain string literals. These unit strings are displayed in the PowerTOP UI and are not wrapped in `_()`, making them untranslatable.
+Severity rationale: Per rules.md, all user-visible strings must use `_()`.
+Suggested fix: Wrap each string in `_()`, e.g. `return _(" ms/s");`.
+
+### Medium item #8 : Unqualified `string` in constructor definition
+
+Location: src/tuning/tuningi2c.cpp : 35
+Description: The constructor definition `i2c_tunable::i2c_tunable(const string &path, const string &name, ...)` uses the unqualified `string` type, relying on the `using namespace std;` injected by included headers. This makes the code fragile and non-portable.
+Severity rationale: Violates style.md §4.2 (always use `std::` prefix); directly depends on the namespace pollution from the header.
+Suggested fix: Change to `const std::string &path, const std::string &name`.
+
+## Review of processdevice.cpp, process.h, process.cpp, work.cpp, work.h — batch 08
+
+### Medium item #1 : Debug printf left in production code, unlocalized, wrong output stream
+
+Location: src/process/process.cpp : 66-67
+Description: `printf("%llu time    %llu since \n", ...)` is a diagnostic trace that was never removed. It writes to stdout (not stderr), uses a non-localized format string, and fires on every measurement interval where an out-of-order timestamp is detected. The double-space in the format string also suggests it is unfinished debug output.
+Severity rationale: Any user-visible diagnostic string must use `_()` per rules.md; stdout is the wrong stream for error messages; leftover debug output is confusing and noisy in production.
+Suggested fix: Remove the printf entirely, or replace with `fprintf(stderr, _("..."), ...)` if the diagnostic is intentional, after first fixing the ordering bug (High item #1).
+
+### Medium item #2 : Explicit `using namespace std;` in work.cpp
+
+Location: src/process/work.cpp : 36
+Description: `using namespace std;` is explicitly declared at file scope. This is prohibited by style.md ("Avoid `using namespace std;`") and general-c++.md ("`using namespace std;` is a deprecated construct").
+Severity rationale: Direct violation of the project's stated coding rules; also masks which names come from `std::` versus the project.
+Suggested fix: Remove the `using namespace std;` line and qualify all standard library names with `std::` (e.g., `std::map`, `std::pair`, `std::for_each`).
+
+### Medium item #3 : `NULL` instead of `nullptr` in C++ code
+
+Location: src/process/process.cpp : 89-90
+Description: `last_waker = NULL;` and `waker = NULL;` use the C macro `NULL` instead of the C++ keyword `nullptr`. In C++11 and later (this project targets C++20), `nullptr` is the correct null-pointer constant.
+Severity rationale: Minor correctness issue — `NULL` is typically defined as `0` or `(void*)0`, both of which can cause subtle type issues. C++20 code should use `nullptr`.
+Suggested fix: Replace both with `nullptr`.
+
+### Medium item #4 : Narrowing conversion from `unsigned long long` to `int` for tgid
+
+Location: src/process/process.cpp : 104
+Description: `tgid = std::stoull(line.substr(pos + 1));` assigns an `unsigned long long` result to the `int` field `tgid`. On systems where PIDs approach `INT_MAX` (or if the file contains an unexpected large value) this silently truncates or produces undefined behavior prior to C++20 (implementation-defined in C++20).
+Severity rationale: Narrowing implicit conversion; `std::stoi` or a range-checked conversion is more appropriate. Medium because large PIDs are rare in practice but the root cause is incorrect.
+Suggested fix: Use `std::stoi` (which already returns `int`) and wrap in the existing try/catch:
+```cpp
+tgid = std::stoi(line.substr(pos + 1));
+```
+
+### Medium item #5 : `#ifndef` header guard instead of `#pragma once` in process.h
+
+Location: src/process/process.h : 25-27
+Description: The file uses a traditional `#ifndef _INCLUDE_GUARD_PROCESS_H` / `#define` guard. style.md §4.1 mandates `#pragma once`.
+Severity rationale: Direct violation of the project style guide.
+Suggested fix: Replace lines 25–27 and line 95 (`#endif`) approach with `#pragma once` at the top of the file.
+
+### Medium item #6 : `#ifndef` header guard instead of `#pragma once` in work.h
+
+Location: src/process/work.h : 25-27
+Description: Same as Medium item #5 — `#ifndef _INCLUDE_GUARD_WORK_H` guard instead of `#pragma once`.
+Severity rationale: Direct violation of the project style guide.
+Suggested fix: Replace with `#pragma once`.
+
+### Medium item #7 : User-facing description strings not wrapped in `_()` for i18n
+
+Location: src/process/process.cpp : 116, 122, 125
+Description: The three `std::format` calls that compose the process description strings (`"[PID {}] {}"`, `"[PID {}] [{}]"`) produce user-visible output but are not wrapped with `_()` / `pt_format(_(...), ...)`. rules.md requires all user-visible strings to be translatable.
+Severity rationale: Internationalization regression; any non-English-speaking user will see English-only process descriptions.
+Suggested fix: Change to `pt_format(_("[PID {}] {}"), pid, comm)` etc., using the `pt_format` helper required by style.md §4.3.
+
+### Medium item #8 : Unqualified `vector` in header process.h
+
+Location: src/process/process.h : 71
+Description: `extern vector <class process *> all_processes;` uses `vector` without the `std::` prefix. This compiles only because `powerconsumer.h` pollutes the global namespace via `using namespace std;`, but the declaration itself should be `std::vector`.
+Severity rationale: Header files should never rely on namespace pollution from transitively-included headers; this makes the declaration fragile and violates style.md §4.2.
+Suggested fix: Change to `extern std::vector<class process *> all_processes;`.
+
+## Review of interrupt.h, interrupt.cpp, timer.cpp, timer.h, do_process.cpp — batch 09
+
+### Medium item #1 : Header guards use #ifndef instead of #pragma once
+
+Location: src/process/interrupt.h : 25  /  src/process/timer.h : 25
+Description: Both headers use the old-style `#ifndef _INCLUDE_GUARD_XXX` / `#define` / `#endif` header guards. The project style guide (style.md §4.1) mandates `#pragma once`.
+Severity rationale: Style violation; inconsistent with the rest of the codebase.
+Suggested fix: Replace with `#pragma once` and remove the `#ifndef`/`#define`/`#endif` triplet.
+
+### Medium item #2 : Unqualified vector in interrupt.h extern declarations
+
+Location: src/process/interrupt.h : 54
+Description: The two `extern` declarations use unqualified `vector` instead of `std::vector`. They compile only because `powerconsumer.h` (transitively included) contains `using namespace std;`. The style guide forbids relying on implicit namespace injection.
+Severity rationale: Violates `std::` qualification rule; fragile — any reordering of includes could break compilation.
+Suggested fix: Change to `extern std::vector<class interrupt *> all_interrupts;` and `extern const std::vector<std::string> softirqs;`.
+
+### Medium item #3 : string::npos used without std:: prefix
+
+Location: src/process/do_process.cpp : 382
+Description: `string::npos` is written without the `std::` prefix. It resolves today only via the transitive `using namespace std;` from `powerconsumer.h`. This is a style violation per both style.md §4.2 and general-c++.md.
+Severity rationale: Style violation; implicit namespace injection should not be relied upon.
+Suggested fix: Change to `std::string::npos`.
+
+### Medium item #4 : timer_list class in timer.h appears to be dead/unused code
+
+Location: src/process/timer.h : 53
+Description: `class timer_list` with members `timer_address` and `timer_func` is declared but never referenced in the codebase. Shipping dead class definitions increases maintenance burden and may confuse readers.
+Severity rationale: Dead code; no functional impact but adds noise.
+Suggested fix: Remove `class timer_list` unless it is intentionally reserved for future use, in which case add a comment.
+
+### Medium item #5 : Type mismatch — find_create_timer(uint64_t) vs map<unsigned long, ...>
+
+Location: src/process/timer.cpp : 71
+Description: `all_timers` is declared `map<unsigned long, class timer *>` but `find_create_timer` accepts a `uint64_t` argument and the `timer` constructor takes `unsigned long`. On a 32-bit Linux kernel (where `unsigned long` is 32 bits), passing a 64-bit kernel function address silently truncates it, producing wrong lookups and spurious duplicate timers.
+Severity rationale: Incorrect behaviour on 32-bit systems; type mismatch is a latent bug.
+Suggested fix: Change `all_timers` to `std::map<uint64_t, class timer *>` and the constructor argument to `uint64_t`.
+
+### Medium item #6 : stderr diagnostic messages not wrapped in _()
+
+Location: src/process/do_process.cpp : 408, 445, 457
+Description: Three `fprintf(stderr, ...)` calls emit literal English strings without the `_()` gettext macro. The project rules (rules.md) require all user-visible strings to be translatable. While these are diagnostic/debug messages, they can appear on user terminals and should be translatable.
+Severity rationale: i18n policy violation.
+Suggested fix: Wrap each string in `_()`.
+
+### Medium item #7 : usage_units_summary returns "%" literal not wrapped in _()
+
+Location: src/process/interrupt.cpp : 89  /  src/process/timer.cpp : 107
+Description: Both `usage_units_summary()` implementations return the literal `"%"` without wrapping in `_()`. This string is user-visible (it appears in the overview display and reports). Even if `%` itself needs no translation, the method's contract is to return a units string, and as a pattern this sets a bad precedent for strings that do need translation.
+Severity rationale: i18n policy violation (rules.md).
+Suggested fix: Return `_("%")` or, if the percent sign is definitively not localised, document that explicitly.
+
+### Medium item #8 : Summary wprintw uses fragmented translated strings — untranslatable as a sentence
+
+Location: src/process/do_process.cpp : 846
+Description: The summary display line is built with multiple independent `_()` fragments embedded in a single C format string:
+```cpp
+wprintw(win, "%s: %3.1f %s,  %3.1f %s, %3.1f %s %3.1f%% %s\n\n",
+    _("Summary"), total_wakeups(), _("wakeups/second"), ...);
+```
+The structural word ordering is fixed by the C format string and cannot be changed by translators. Different languages require different word orders. This pattern makes a correct translation impossible.
+Severity rationale: Fundamental i18n correctness issue; directly affects all non-English users.
+Suggested fix: Combine into a single complete translatable sentence using `pt_format` with named arguments, or use a single `_()` string that contains all the labels and format specifiers.
+
+## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
+
+### Medium item #1 : `using namespace std;` in header perf.h
+
+Location: src/perf/perf.h : 37
+Description: `using namespace std;` is used in a header file. This pollutes the global namespace for every translation unit that includes this header, directly or transitively. The style guide and general-c++ rules both explicitly prohibit this. All standard-library names should be qualified with `std::`.
+Severity rationale: A `using namespace std;` in a header is a project-wide namespace pollution violation. Any identifier in `std::` can silently shadow or conflict with user identifiers in any file that includes this header.
+Suggested fix: Remove `using namespace std;` and use `std::string`, `std::vector`, etc. explicitly.
+
+### Medium item #2 : `using namespace std;` in header perf_bundle.h
+
+Location: src/perf/perf_bundle.h : 32
+Description: Same issue as Medium item #1 above. `using namespace std;` is used in a header file, polluting the namespace for all includers.
+Severity rationale: Same as above.
+Suggested fix: Remove `using namespace std;` and qualify `vector` and `map` usages with `std::`.
+
+### Medium item #3 : Non-translatable kernel configuration strings printed to stderr
+
+Location: src/perf/perf.cpp : 105
+Description: The string `"CONFIG_PERF_EVENTS=y\nCONFIG_PERF_COUNTERS=y\nCONFIG_TRACEPOINTS=y\nCONFIG_TRACING=y\n"` is a user-visible message printed to stderr but is not wrapped in `_()`. All user-visible strings must be translatable per the project rules.
+Severity rationale: User-facing strings not wrapped in `_()` will never be translated.
+Suggested fix: Wrap in `_()` or split into separate `fprintf` calls each wrapped in `_()`.
+
+### Medium item #4 : Non-translatable mmap failure message
+
+Location: src/perf/perf.cpp : 120
+Description: `fprintf(stderr, "failed to mmap with %d (%s)\n", ...)` — user-visible string not wrapped in `_()`.
+Severity rationale: Same as Medium item #3.
+Suggested fix: `fprintf(stderr, _("failed to mmap perf buffer: %d (%s)\n"), errno, strerror(errno));`
+
+### Medium item #5 : Non-translatable perf enable failure message
+
+Location: src/perf/perf.cpp : 127
+Description: `fprintf(stderr, "failed to enable perf \n");` — user-visible string not wrapped in `_()`.
+Severity rationale: Same as Medium item #3.
+Suggested fix: `fprintf(stderr, _("failed to enable perf\n"));`
+
+### Medium item #6 : Error output via `cout` instead of `stderr`, non-translatable
+
+Location: src/perf/perf.cpp : 221
+Description: `cout << "stop failing\n";` sends an error message to stdout rather than stderr, and the string is not wrapped in `_()` for translation. The project style guide requires `fprintf(stderr, ...)` for error reporting.
+Severity rationale: Error messages on stdout can be lost in automated pipelines; the string is also not translatable.
+Suggested fix: `fprintf(stderr, _("perf stop failed\n"));`
+
+### Medium item #7 : Non-translatable `printf` error in `handle_trace_point`
+
+Location: src/perf/perf_bundle.cpp : 282
+Description: `printf("UH OH... abstract handle_trace_point called\n")` is a user-visible diagnostic message that is not wrapped in `_()`, and uses `printf` instead of `fprintf(stderr, ...)`.
+Severity rationale: User-visible string not wrapped in `_()` will never be translated; sending to stdout also violates the error-reporting style.
+Suggested fix: `fprintf(stderr, _("abstract handle_trace_point called\n"));`
+
+### Medium item #8 : `perf_event::stop()` calls `ioctl` on potentially invalid file descriptor
+
+Location: src/perf/perf.cpp : 218
+Description: `stop()` unconditionally calls `ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0)` without first checking whether `perf_fd` is valid (>= 0). If an event was never started (or mmap failed leaving the fd valid but unusable), this can produce unexpected ioctl errors or act on an unintended fd.
+Severity rationale: Calling ioctl on fd -1 is safe (returns EBADF) but calling it on a leaked/stale fd could affect unrelated resources.
+Suggested fix:
+```cpp
+void perf_event::stop(void)
+{
+    if (perf_fd < 0)
+        return;
+    int ret = ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0);
+    if (ret)
+        fprintf(stderr, _("perf stop failed\n"));
+}
+```
+
+### Medium item #9 : `trace_type` is `unsigned int` but is assigned `-1` as a sentinel value
+
+Location: src/perf/perf.h : 54, src/perf/perf.cpp : 159, src/perf/perf_bundle.cpp : 112
+Description: `trace_type` is declared as `unsigned int` but `set_event_name` assigns `trace_type = -1` (which wraps to `UINT_MAX`), and `perf_bundle::add_event` then checks `(int)ev->trace_type >= 0` to detect this. This is a confusing misuse of an unsigned type as a signed sentinel, relying on implementation-defined signed/unsigned cast behavior.
+Severity rationale: The pattern is error-prone and reliant on cast behavior. Using `int` or an explicit `bool valid` flag would be clearer and correct.
+Suggested fix: Change `trace_type` to `int` (signed), or add a separate `bool valid` flag, and remove the cast in the add_event check.
+
+## Review of persistent.cpp, parameters.cpp, parameters.h, learn.cpp, report-formatter.h — batch 11
+
+### Medium item #1 : False null-check after `new` in `clone_results` and `clone_parameters`
+
+Location: src/parameters/parameters.cpp : 297 ; src/parameters/parameters.cpp : 318
+Description: Both `clone_results` and `clone_parameters` allocate with `new` and then check `if (!b2) return NULL;`. In standard C++, `new` either succeeds or throws `std::bad_alloc`; it never returns a null pointer. The null check therefore never triggers, giving the reader a false sense of safety. If `bad_alloc` is thrown the callers do not handle it, and the function's declared contract (returning nullptr on failure) is not fulfilled. Callers that do check the return value for null will not be protected from an allocation failure.
+Severity rationale: The guard is misleading and never executes, making it a latent correctness issue.
+Suggested fix: Either remove the null checks and let `std::bad_alloc` propagate, or use `new (std::nothrow)` and keep the null-check if null-return semantics are actually required by callers.
+
+### Medium item #2 : `get_param_directory` returns an empty string when no writable directory exists
+
+Location: src/parameters/parameters.cpp : 459
+Description: `get_param_directory` checks two candidate directories and returns `tempfilename`. If neither `/var/cache/powertop` nor `/data/local/powertop` is writable, `tempfilename` is never set and the function returns an empty string. Every caller (`save_parameters`, `load_parameters`, `save_all_results`, `load_results`) then attempts to open a file whose name is `""`, which will fail silently with a confusing empty-pathname error message. There is no fallback (e.g. the current directory or a user home-directory path).
+Severity rationale: Silent data loss / confusing errors in a common deployment scenario (e.g. container, read-only /var).
+Suggested fix: Return an error indicator or fall back to a default path, and have callers check for an empty return value explicitly.
+
+### Medium item #3 : User-facing string in `global_power_valid` not wrapped in `_()`
+
+Location: src/parameters/parameters.cpp : 450
+Description: The `printf` call `printf("To show power estimates do %ld measurement(s) connected to battery only\n", …)` is not wrapped in the `_()` gettext macro. This string is displayed directly to the user but will not be translated. All user-visible strings must use `_()` per rules.md and style.md.
+Severity rationale: Breaks internationalisation; message is never translated.
+Suggested fix: Change to `printf(_("To show power estimates do %ld measurement(s) connected to battery only\n"), …);`
+
+### Medium item #4 : Error/informational messages written to `cout` (stdout) instead of `stderr`
+
+Location: src/parameters/persistent.cpp : 47, 89, 183, 184
+Description: Four diagnostic messages use `cout <<` which writes to stdout. Per style.md ("Use `fprintf(stderr, ...)` for error reporting"), error and warning messages should go to stderr. Writing errors to stdout mixes them with program output and breaks piping / scripting.
+Severity rationale: Incorrect output stream for error messages; violates project style.
+Suggested fix: Replace `cout << _("…") << …` with `fprintf(stderr, "%s %s\n", _("…"), pathname.c_str());` (or equivalent).
+
+### Medium item #5 : `#include "string.h"` uses quotes and a C header in parameters.h
+
+Location: src/parameters/parameters.h : 33
+Description: The inclusion `#include "string.h"` uses double-quotes instead of angle-brackets for a system header, which causes the compiler to search the project include path first. Additionally, `string.h` is the C header; the C++ equivalent is `<cstring>`. In a C++20 project the C header should not be used directly.
+Severity rationale: Wrong include style for a system header and wrong header choice for C++.
+Suggested fix: Replace with `#include <cstring>` (angle brackets, C++ header) — or remove entirely if not needed.
+
+### Medium item #6 : Final `result_bundle` allocated in `load_results` is always leaked
+
+Location: src/parameters/persistent.cpp : 121
+Description: After the last `:` separator line is processed, the code allocates a new `result_bundle` (`bundle = new struct result_bundle;`) in preparation for the next record. If no further records follow (end of file), `bundle_saved` remains `1` from the previous record, so the `if (bundle_saved == 0) delete bundle;` guard at line 139 does NOT delete this final empty allocation. One empty `result_bundle` is leaked on every successful `load_results` call that processes at least one record.
+Severity rationale: Memory leak on every load of a non-empty results file.
+Suggested fix: After the loop, unconditionally `delete bundle;` (the empty partially-filled bundle should never be kept):
+```cpp
+delete bundle;   // always discard the last-allocated but unsaved bundle
+if (bundle_saved == 0)
+    return;      // or keep existing logging
+```
+
+## Review of report-formatter-html.h, report.cpp, report.h, report-formatter-csv.h, report-maker.cpp — batch 12
+
+### Medium item #1 : `using namespace std` in implementation file
+
+Location: report.cpp : 43
+Description: `using namespace std;` appears at file scope in the implementation file. While less harmful than in a header, the coding guidelines label this a deprecated construct and the style guide prohibits it. All standard-library names should be qualified with `std::`.
+Severity rationale: Explicit style violation; introduces risk of silent name collisions.
+Suggested fix: Remove the `using namespace std;` line and add `std::` prefixes throughout the file.
+
+### Medium item #2 : Old-style `#ifndef` include guards instead of `#pragma once`
+
+Location: report.h : 26, report-formatter-html.h : 27, report-formatter-csv.h : 26
+Description: All three headers use the legacy `#ifndef / #define / #endif` triple instead of `#pragma once` as required by the style guide (§4.1).
+Severity rationale: Style-guide violation; `#pragma once` is simpler, less error-prone, and universally supported.
+Suggested fix: Replace the guard triple in each header with a single `#pragma once`.
+
+### Medium item #3 : Fixed-size `char buf[128]` for `strftime` output
+
+Location: report.cpp : 104
+Description: `get_time_string` uses a 128-byte stack buffer for the `strftime` result. With certain locales and format strings (especially `%c`) the formatted date/time can exceed 127 characters. If it does, `strftime` returns 0 and the function returns an empty string silently rather than producing a truncated or complete result. Per the C++ guidelines, fixed-size buffer usage "must be provably correct to not overflow".
+Severity rationale: Not provably safe; an unusually verbose locale `%c` format could produce an empty field in the report without any diagnostic.
+Suggested fix: Use a `std::string` with a `strftime`-in-a-loop pattern or a sufficiently large initial estimate:
+```cpp
+static std::string get_time_string(const std::string &fmt, time_t t)
+{
+    struct tm *tm_info = localtime(&t);
+    if (!tm_info) return "";
+    std::string buf(256, '\0');
+    size_t n = strftime(buf.data(), buf.size(), fmt.c_str(), tm_info);
+    buf.resize(n);
+    return buf;
+}
+```
+
+### Medium item #4 : `private:` access specifier on the same line as a method declaration
+
+Location: report-formatter-html.h : 63, report-formatter-csv.h : 65
+Description: In both headers the `private:` label is appended to the end of the last `public` method declaration on the same source line, e.g. `void add_table(...);private:`. This is a formatting error: access specifiers must appear on their own line, consistent with the K&R/Linux-kernel brace style used throughout the project.
+Severity rationale: Style violation; degrades readability and makes the visibility boundary easy to miss in diffs.
+Suggested fix: Place `private:` on a new line after the semicolon.
+
+### Medium item #5 : Unqualified `string` (and `vector`) in report-maker.cpp
+
+Location: report-maker.cpp : 114, 140
+Description: `report-maker.cpp` does not declare `using namespace std` itself; the identifier `string` resolves only because `report-formatter-csv.h` (included earlier) leaks `using namespace std` into the translation unit. The style guide mandates `std::string` everywhere. The same applies to `vector` in signatures that take `const vector<std::string> &`.
+Severity rationale: Style violation that silently depends on an indirect `using` from a header; will break if that header is ever cleaned up.
+Suggested fix: Replace `const string &` and `const vector<...> &` with `const std::string &` and `const std::vector<...> &` throughout report-maker.cpp.
+
+## Review of report-maker.h, report-data-html.cpp, report-data-html.h, report-formatter-base.cpp, report-formatter-base.h — batch 13
+
+### Medium item #1 : Uninitialized `title_mod` field in `init_tune_table_attr`
+
+Location: src/report/report-data-html.cpp : 96–104
+Description: `init_tune_table_attr` sets all fields of `table_attributes` except `title_mod`, which is left at whatever value is in the caller's struct. Every other `init_*_table_attr` function explicitly sets `title_mod = 0`. If the struct is used after partial re-initialisation (i.e. was previously used for a TC/TLC table), `title_mod` will hold a stale non-zero value and may produce incorrect column-span or title-positioning output.
+Severity rationale: Uninitialized field that can silently corrupt table rendering.
+Suggested fix: Add `table_css->title_mod = 0;` before the `rows`/`cols` assignments.
+
+### Medium item #2 : Uninitialized `title_mod` field in `init_wakeup_table_attr`
+
+Location: src/report/report-data-html.cpp : 106–114
+Description: Same issue as Medium item #1 — `title_mod` is not initialized. All other table-attribute initializer functions set this field.
+Severity rationale: Same as Medium item #1.
+Suggested fix: Add `table_css->title_mod = 0;` to `init_wakeup_table_attr`.
+
+### Medium item #3 : Missing copyright/license header
+
+Location: src/report/report-data-html.h : 1  and  src/report/report-data-html.cpp : 1
+Description: Neither file contains the standard project copyright and GPL-2 license header required by style.md §3.1. All other files in the `src/report/` directory carry the header.
+Severity rationale: License compliance; all project files are required to carry the copyright notice.
+Suggested fix: Add the standard Samsung/PowerTOP copyright header to both files.
+
+### Medium item #4 : `get_type()` is not `const`
+
+Location: src/report/report-maker.h : 112
+Description: `get_type()` is a pure accessor — it returns the private `type` field without modifying the object. It is not declared `const`, preventing its use on `const report_maker` references and violating the general C++ rule "use `const` when possible".
+Severity rationale: Const-correctness violation; the accessor is callable in contexts where a const reference would be appropriate.
+Suggested fix: `report_type get_type() const;`
+
+### Medium item #5 : Non-`const` pointer parameters for read-only struct access in `report_maker`
+
+Location: src/report/report-maker.h : 125, 127, 130
+Description: `add_div(struct tag_attr *div_attr)`, `add_title(struct tag_attr *att_title, ...)`, and `add_table(..., struct table_attributes *tb_attr)` all take non-const pointers even though the functions only read the pointed-to data. This prevents passing pointers to `const`-qualified structs and falsely implies mutation.
+Severity rationale: Const-correctness rule violation; callers with `const`-qualified objects cannot call these methods.
+Suggested fix: Change all three parameter types to `const struct tag_attr *` / `const struct table_attributes *`.
+
+### Medium item #6 : `#ifndef` header guards use reserved identifiers; should use `#pragma once`
+
+Location: src/report/report-maker.h : 26–27  and  src/report/report-formatter-base.h : 26–27
+Description: Both files use `#ifndef _REPORT_MAKER_H_` / `#ifndef _REPORT_FORMATTER_BASE_H_`. Identifiers beginning with an underscore followed by an uppercase letter are reserved to the implementation in C++ (per \[lex.name\]), making these macro names technically undefined behaviour. The project style guide (style.md §4.1) mandates `#pragma once` instead.
+Severity rationale: Style guide violation; also uses reserved identifiers.
+Suggested fix: Replace both `#ifndef`/`#define`/`#endif` guard triples with `#pragma once`.
+
+### Medium item #7 : Virtual overrides in `report_formatter_string_base` lack `override` specifier
+
+Location: src/report/report-formatter-base.h : 34–38
+Description: `get_result()`, `clear_result()`, and `add()` are declared `virtual` in `report_formatter` and overridden in `report_formatter_string_base`, but none carry the `override` keyword. Without `override`, a signature mismatch (e.g., from a future base-class refactor) silently creates a new virtual function rather than overriding the intended one.
+Severity rationale: C++11 best practice; omitting `override` undermines static verification of virtual dispatch.
+Suggested fix: Replace each `virtual Ret method(...)` with `Ret method(...) override` (drop the `virtual` keyword in the derived class).
+
+## Review of report-formatter-csv.cpp, report-formatter-html.cpp, dram_rapl_device.cpp, dram_rapl_device.h, cpu_linux.cpp — batch 14
+
+### Medium item #1 : HTML table/title/summary data inserted without escaping
+
+Location: src/report/report-formatter-html.cpp : 305, 319-320, 351-369
+Description: `add_title()`, `add_summary_list()`, and `add_table()` all insert dynamic data (device names, power values, system strings) directly into the HTML output via `add_exact()`, which does **not** call `escape_string()`. The class defines a proper `escape_string()` that handles `<`, `>`, and `&` — but it is only invoked through the base class `add()` method, which none of these formatting methods use. If any device name or power label contains `<`, `>`, or `&` characters, the output HTML will be malformed or contain injected markup.
+Severity rationale: Output HTML corruption for any system with device names containing special characters. The class has the right tool (`escape_string`) but consistently fails to use it for dynamic content.
+Suggested fix: Replace direct use of `add_exact(std::format(..., data))` with `add_exact(std::format(..., escape_string(data)))` for all dynamic data fields in these methods.
+
+### Medium item #2 : `using namespace std` in a header file
+
+Location: src/cpu/dram_rapl_device.h : 31
+Description: `using namespace std;` appears at file scope in the header `dram_rapl_device.h`. This is explicitly prohibited by the style guide ("Avoid `using namespace std;`") and the C++ rules ("'using namespace std;' is a deprecated construct"). Placing it in a header silently forces the `std` namespace on every translation unit that includes this header, potentially causing name collisions in code that has no relation to this class.
+Severity rationale: Header-file namespace pollution affects all includers in the entire project, not just this file.
+Suggested fix: Remove `using namespace std;` and use `std::string`, `std::vector` etc. explicitly throughout the header.
+
+### Medium item #3 : `parse_cstates_start` / `parse_cstates_end` do not explicitly skip `.` and `..` entries
+
+Location: src/cpu/cpu_linux.cpp : 64, 143
+Description: Both `parse_cstates_start` and `parse_cstates_end` use `if (strlen(entry->d_name) < 3) continue;` as an implicit way to skip `.` and `..`. The PowerTOP-specific rules explicitly require: "When using opendir/readdir or equivalent, the code must skip the '.' and '..' entries in the directory and not process them as normal." The current check only works incidentally because both `.` and `..` happen to have lengths less than 3; it is not a deliberate skip, and the intent is not clear to a reader. A future refactor of the minimum-length check could inadvertently re-expose `.`/`..` processing.
+Severity rationale: Violates an explicit project rule. The implicit skip is fragile and unclear.
+Suggested fix: Add an explicit check before or instead of the length check:
+```cpp
+if (entry->d_name[0] == '.')
+    continue;
+```
+
+### Medium item #4 : `add_quotes()` declared but never defined
+
+Location: src/report/report-formatter-csv.h : 66
+Description: `add_quotes()` is declared as a private member of `report_formatter_csv` but has no definition anywhere in the codebase. It is also never called. This represents dead/incomplete code: the method cannot be linked if ever called, and the related state variables (`csv_need_quotes`, `text_start`) are orphaned. This suggests a feature was partially sketched and never completed or was deleted without cleaning up the declaration.
+Severity rationale: Dead declaration paired with uninitialized state variables indicates incomplete implementation that could cause a linker error if the function is ever invoked.
+Suggested fix: Either implement `add_quotes()` properly (initializing `csv_need_quotes` and `text_start`), or remove the declaration, the member variables, and the assignment in `escape_string()`.
+
+## Review of src/cpu/cpu_core.cpp, src/cpu/cpudevice.h, src/cpu/cpudevice.cpp, src/cpu/abstract_cpu.cpp, src/cpu/cpu_rapl_device.cpp — batch 15
+
+### Medium item #1 : Error reporting via `std::cout` instead of `fprintf(stderr, ...)`
+
+Location: src/cpu/abstract_cpu.cpp : 275, 375
+Description: Two error conditions — an invalid C-state finalize and an invalid P-state finalize —
+are reported by writing to `std::cout` (stdout). The project style guide (style.md §6) mandates
+`fprintf(stderr, ...)` for all error reporting. Using stdout means these messages are silently
+swallowed when the user redirects output (e.g. `powertop > report.txt`) and they also intermix
+with normal output in the ncurses UI.
+Severity rationale: Violates the explicit error-reporting rule; errors can be lost in typical
+usage scenarios.
+Suggested fix: Replace both `cout << "Invalid C state finalize ..."` and
+`cout << "Invalid P state finalize ..."` with `fprintf(stderr, "Invalid C state finalize %s\n", linux_name.c_str())` and `fprintf(stderr, "Invalid P state finalize %" PRIu64 "\n", freq)` respectively.
+
+### Medium item #2 : `std::stoull` result silently narrowed to `int line_level`
+
+Location: src/cpu/abstract_cpu.cpp : 220, 247
+Description: `state->line_level` is declared as `int` (see cpu.h `struct idle_state`).
+Both call sites use `std::stoull()` which returns `unsigned long long`, then assign it directly
+to the `int` field. This is a narrowing conversion: if the parsed number is larger than
+`INT_MAX` the result is implementation-defined (effectively UB in C++20 for values outside
+the destination range). The correct function to use for an `int` target is `std::stoi`.
+Severity rationale: Silent narrowing / potential UB; `std::stoi` is the semantically correct
+choice and any out-of-range value will throw `std::out_of_range` which is already caught by
+the surrounding `catch (...)` block.
+Suggested fix: Replace both occurrences of `std::stoull(...)` with `std::stoi(...)`.
+
+### Medium item #3 : User-visible strings `"CPU core"` not wrapped in `_()` for translation
+
+Location: src/cpu/cpu_rapl_device.h : 48, 49
+Description: `device_name()` and `human_name()` both return the hard-coded string `"CPU core"`.
+Both methods are virtual overrides in the device hierarchy whose return values are displayed
+to the user. The project rule (rules.md, style.md §5) requires all user-visible strings to be
+wrapped in the `_()` gettext macro to be translatable.
+Severity rationale: User-visible strings that are not wrapped in `_()` cannot be localised;
+this is an explicit project rule violation.
+Suggested fix: Change both return statements to `return _("CPU core");`.
+Note: since these are inline definitions in the header, `libintl.h` / the gettext macro must
+be available at the include site; consider moving the definitions to `cpu_rapl_device.cpp`.
+
+## Review of src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp — batch 16
+
+### Medium item #1 : Missing negative-cpunr check in handle_trace_point
+
+Location: src/cpu/cpu.cpp : 948
+Description: The bounds check `if (cpunr >= (int)all_cpus.size())` only guards the
+upper bound. If `cpunr` is negative (e.g. due to perf data corruption or an
+unexpected event), the check passes (negative < positive) and
+`all_cpus[cpunr]` accesses memory before the vector's buffer — undefined
+behaviour that can corrupt heap metadata or crash.
+Severity rationale: While perf normally gives non-negative CPU numbers, the
+defensive check is trivial and its absence is a latent safety issue.
+Suggested fix: `if (cpunr < 0 || cpunr >= (int)all_cpus.size()) return;`
+
+### Medium item #2 : User-facing strings in cpu_rapl_device.h not wrapped in _()
+
+Location: src/cpu/cpu_rapl_device.h : 48-49
+Description: Both `device_name()` (returns `"CPU core"`) and `human_name()`
+(returns `"CPU core"`) return string literals without the gettext `_()` macro.
+These strings are displayed to the user in the device list and power report.
+Per the project rules, all user-visible strings must be wrapped in `_()`.
+Severity rationale: Untranslatable user-visible strings; breaks i18n for all locales.
+Suggested fix: `return _("CPU core");` in both methods.
+
+### Medium item #3 : `#ifndef` header guards instead of `#pragma once`
+
+Location: src/cpu/cpu_rapl_device.h : 25-26  and  src/cpu/cpu.h : 26-27
+Description: Both headers use traditional `#ifndef`/`#define`/`#endif` include
+guards. The project style guide mandates `#pragma once` for all header files.
+Severity rationale: Style violation explicitly called out in style.md §4.1.
+Suggested fix: Replace the `#ifndef ... #define ... #endif` guards with a single `#pragma once`.
+
+### Medium item #4 : `#include <format>` placed mid-file
+
+Location: src/cpu/cpu_package.cpp : 41  and  src/cpu/intel_cpus.cpp : 345
+Description: The `#include <format>` directive appears after several other
+includes and function definitions. The project style guide requires all includes
+to appear at the top of the file, grouped as standard library headers first then
+project headers.
+Severity rationale: Style violation; also makes the dependency on `<format>` easy to miss.
+Suggested fix: Move `#include <format>` to the top-of-file include block in both files.
+
+### Medium item #5 : Error output via `cout` instead of `fprintf(stderr, ...)`
+
+Location: src/cpu/cpu.cpp : 949
+Description: `cout << "INVALID cpu nr in handle_trace_point\n"` uses C++ stream
+output to stdout for an error condition. The project style guide (§6) specifies
+`fprintf(stderr, ...)` for error reporting. Additionally the string is not wrapped
+in `_()` for translation.
+Severity rationale: Error goes to stdout (mixed with normal output), and is
+untranslatable; violates both the error-handling and i18n rules.
+Suggested fix: `fprintf(stderr, _("INVALID cpu nr in handle_trace_point\n"));`
+
+### Medium item #6 : `NULL` instead of `nullptr` in default parameter
+
+Location: src/cpu/cpu_rapl_device.h : 46
+Description: The constructor default parameter uses `NULL` (`class abstract_cpu *_cpu = NULL`).
+C++20 code should use `nullptr` for null pointer constants.
+Severity rationale: `NULL` is a C-style macro; `nullptr` is the C++11+ type-safe alternative and the correct form for C++20 code.
+Suggested fix: `class abstract_cpu *_cpu = nullptr`
+
+### Medium item #7 : `core_num` variable is always zero — dead-code branch
+
+Location: src/cpu/cpu.cpp : 436, 613
+Description: `core_num` is declared and initialised to `0` at line 436 and is
+never incremented anywhere in `report_display_cpu_cstates`. The branch
+`if (core_num > 0)` on line 613 is therefore permanently dead code; the title
+normalisation that was presumably intended never executes.
+Severity rationale: Logic bug; the title-row calculation is silently wrong for packages with multiple cores.
+Suggested fix: Either increment `core_num` alongside `num_cores` or remove the dead branch and unify the title computation.
+
+### Medium item #8 : TSC divide-by-zero in residency ratio computation
+
+Location: src/cpu/intel_cpus.cpp : 313, 604, 684
+Description: In `nhm_core::measurement_end`, `nhm_package::measurement_end`, and
+`nhm_cpu::measurement_end` the ratio is computed as:
+`ratio = 1.0 * time_delta / (tsc_after - tsc_before);`
+If `tsc_after == tsc_before` (possible on some hypervisors or immediately after
+system resume where TSC is reset), the denominator is zero. For double division
+this yields `Inf` or `NaN` which then silently propagates into all
+`duration_delta`/`usage_delta` values, corrupting the displayed data.
+Severity rationale: Silent data corruption on hypervisors or post-resume; no
+user-visible error is produced.
+Suggested fix: Guard with `if (tsc_after != tsc_before) { ratio = ...; }` and
+skip the loop or set deltas to zero otherwise.
+
+## Review of src/cpu/intel_gpu.cpp, src/cpu/rapl/rapl_interface.cpp, src/cpu/rapl/rapl_interface.h, src/wakeup/wakeup.h — batch 17
+
+### Medium item #1 : `using namespace std` in a header file
+
+Location: src/wakeup/wakeup.h : 33
+Description: The header declares `using namespace std;` at global scope. This injects the entire `std` namespace into every translation unit that includes `wakeup.h`, directly and transitively, causing potential name collisions and bypassing the project rule (style.md §4.2) that forbids `using namespace std`. Any downstream `.cpp` file that includes this header loses the protection of explicit namespace qualification.
+Severity rationale: Header-level `using namespace std` is an explicit project style violation that silently affects all includers and can hide naming conflicts throughout the codebase.
+Suggested fix: Remove the `using namespace std;` directive from the header and use `std::string`, `std::vector` explicitly throughout the file.
+
+### Medium item #2 : `string` used without `std::` qualifier in function parameter (intel_gpu.cpp)
+
+Location: src/cpu/intel_gpu.cpp : 57
+Description: The function definition `std::string i965_core::fill_cstate_line(int line_nr, const string &separator __unused)` uses the unqualified `string` for the parameter type, while the corresponding declaration in `intel_cpus.h` correctly uses `std::string`. This relies on `using namespace std` being injected transitively (likely from `wakeup.h`), which is itself a style violation.
+Severity rationale: Direct style violation per style.md §4.2/4.3; introduces implicit dependency on transitive namespace pollution.
+Suggested fix: Replace `const string &separator` with `const std::string &separator`.
+
+### Medium item #3 : `string` used without `std::` qualifier in class member declarations (rapl_interface.h)
+
+Location: src/cpu/rapl/rapl_interface.h : 32–34
+Description: Member variables `powercap_core_path`, `powercap_uncore_path`, and `powercap_dram_path` are declared as plain `string` without the `std::` prefix. The constructor declaration on line 54 in the same header correctly uses `std::string`. The unqualified `string` will only compile if `using namespace std` is brought in by a previously included header, creating a fragile implicit dependency.
+Severity rationale: Style violation per style.md §4.2/4.3; the header has no `#include <string>` of its own, relying entirely on transitive pollution.
+Suggested fix: Qualify all three as `std::string` and add `#include <string>` to the header.
+
+### Medium item #4 : Missing `#include <string>` and `#include <cstdint>` in rapl_interface.h
+
+Location: src/cpu/rapl/rapl_interface.h : 24 (after header guard)
+Description: `rapl_interface.h` uses `string` (lines 32–34) and `uint64_t` (lines 43–44, 64–82) but includes neither `<string>` nor `<stdint.h>` / `<cstdint>`. The file compiles only because other headers included before it in the translation unit happen to bring in these symbols. Any change to include ordering could silently break compilation.
+Severity rationale: Self-contained headers are a fundamental correctness requirement; missing includes create brittle build dependencies.
+Suggested fix: Add `#include <string>` and `#include <cstdint>` to `rapl_interface.h`.
+
+### Medium item #5 : `atof()` used without error detection for sysfs energy values
+
+Location: src/cpu/rapl/rapl_interface.cpp : 376, 467, 554
+Description: Three call sites convert sysfs energy strings to `double` using `atof(str.c_str())`. `atof` returns 0.0 on invalid input with no error indication, meaning a corrupt or unexpected sysfs value (e.g., an empty re-read race, or a kernel change to the format) would silently be treated as zero energy. This causes the downstream power-watt computation to report 0 W without any diagnostic.
+Severity rationale: Silent failure mode for a core measurement path; `stod` or `strtod` would allow error detection.
+Suggested fix: Replace `atof(str.c_str())` with `std::stod(str)` wrapped in a try/catch, or use `strtod` with an end-pointer check, and log/return an error on failure.
+
+### Medium item #6 : Redundant MSR reads — `get_energy_status_unit()` called instead of cached member
+
+Location: src/cpu/rapl/rapl_interface.cpp : 300, 390, 481, 569
+Description: Each of the four energy-status read functions (`get_pkg_energy_status`, `get_dram_energy_status`, `get_pp0_energy_status`, `get_pp1_energy_status`) calls `get_energy_status_unit()` to scale the raw MSR value. This method re-reads `MSR_RAPL_POWER_UNIT` on every invocation, performing a redundant MSR read. The constructor already reads and caches this value into the `energy_status_units` member variable (line 181). The cached value is never actually used for energy scaling.
+Severity rationale: Unnecessary MSR reads on every measurement cycle; using the cached `energy_status_units` member is both more efficient and more consistent.
+Suggested fix: Replace `get_energy_status_unit()` at those four sites with the cached `energy_status_units` member variable.
+
+## Review of wakeup_usb.h, wakeup_ethernet.h, waketab.cpp, wakeup_ethernet.cpp, wakeup.cpp — batch 18
+
+### Medium item #1 : `using namespace std` in wakeup.cpp and waketab.cpp
+
+Location: src/wakeup/wakeup.cpp : 32  and  src/wakeup/waketab.cpp : 16
+Description: Both .cpp files contain `using namespace std;` at file scope. The project style guide explicitly prohibits this construct, and the code already uses fully-qualified `std::` names for most things. It also creates confusion: `string` on line 59 of `wakeup_ethernet.cpp` is resolved only because wakeup.h (transitively) injects `std::`.
+Severity rationale: Medium — direct violation of the style guide; in .cpp files the blast radius is confined to that translation unit, but it is still explicitly prohibited.
+Suggested fix: Remove the `using namespace std;` lines and use `std::` everywhere.
+
+### Medium item #2 : TOCTOU race between counting and writing disabled-device rows in report_show_wakeup
+
+Location: src/wakeup/waketab.cpp : 131-159
+Description: `report_show_wakeup` calls `wakeup_value()` in a first loop to count disabled entries and dimension `wakeup_data`, then calls `wakeup_value()` again in a second loop to fill the vector. `wakeup_value()` reads from sysfs at runtime; if a device changes state between the two loops (hotplug, runtime PM, etc.) the second loop may write more rows than were allocated, causing an out-of-bounds `std::vector` access (undefined behaviour). Additionally the variable is named `tgb` in the first loop and `gb` in the second, making the relationship non-obvious.
+Severity rationale: Medium — the race is real and reachable (sysfs values can change at any time), and the consequence is UB that could corrupt heap or crash.
+Suggested fix: Capture all wakeup values once into a local `std::vector<int>` before either loop, then use the cached values for both counting and writing.
+
+### Medium item #3 : spaces used instead of tabs for indentation in wakeup.cpp
+
+Location: src/wakeup/wakeup.cpp : 39-50
+Description: The body of both `wakeup` constructors uses leading spaces (4-space indent) for the member assignments (`desc =`, `wakeup_enable =`, etc.) instead of the required tabs. The rest of the codebase uses tabs exclusively.
+Severity rationale: Medium — direct violation of the mandatory indentation rule; makes diffs noisy and inconsistent with the rest of the file.
+Suggested fix: Replace the leading spaces with a single tab character on each affected line.
+
+## Review of src/measurement/acpi.cpp, src/measurement/opal-sensors.cpp — batch 19
+
+### Medium item #1 : `using namespace std;` in acpi.cpp
+
+Location: src/measurement/acpi.cpp : 36
+Description: `acpi.cpp` explicitly includes `using namespace std;` at file scope. The coding style guide explicitly forbids this construct. All standard library identifiers must be referenced with the `std::` prefix.
+Severity rationale: Medium — explicit style-guide violation; promotes hidden name collisions and makes code harder to read and maintain.
+Suggested fix: Remove `using namespace std;`. Replace bare `string`, `getline`, `istringstream` usages with their `std::` qualified forms.
+
+### Medium item #2 : Integer overflow risk in `opal_sensors_power_meter::power()`
+
+Location: src/measurement/opal-sensors.cpp : 39-45
+Description: `read_sysfs()` returns a plain `int` (32-bit signed integer). OPAL sensors report power in microwatts. For a system consuming more than ~2147 W (INT_MAX / 1,000,000), the raw sysfs value would overflow a 32-bit signed integer before the division by 1,000,000.0 is applied. IBM POWER systems targeted by this driver can easily have power supplies exceeding this threshold when considering total system power. The overflow produces undefined behaviour and an incorrect (potentially negative) power reading.
+Severity rationale: Medium — affects correctness on high-power POWER systems; produces UB from signed integer overflow.
+Suggested fix: Change `value` to `long` or `int64_t` and update `read_sysfs()` call accordingly, or use a string-based read and parse with `strtoll()`.
+
+## Review of sysfs.h, sysfs.cpp, measurement.h, measurement.cpp, extech.h — batch 20
+
+### Medium item #1 : `end_thread` flag not atomic in extech_power_meter
+
+Location: src/measurement/extech.h : 38
+Description: `int end_thread` is written by the main thread (`end_measurement` sets it to 1) and read by the sampling thread in the `while (!end_thread)` loop, with no synchronization. Without `std::atomic` or a memory barrier the compiler and CPU are free to cache the value in a register and the sampling thread may never observe the update, looping forever.
+Severity rationale: Can cause `pthread_join` in `end_measurement` to hang indefinitely, blocking the entire measurement cycle.
+Suggested fix: Change to `std::atomic<bool> end_thread{false};` and update all uses accordingly.
+
+### Medium item #2 : Missing `override` specifier on virtual overrides in sysfs.h
+
+Location: src/measurement/sysfs.h : 46-50
+Description: `start_measurement`, `end_measurement`, `power`, and `dev_capacity` all override virtual methods from `power_meter` but none use the `override` keyword. Without `override`, a signature mismatch silently creates a new virtual function instead of overriding the intended one.
+Severity rationale: Compiler cannot catch accidental signature mismatches; incorrect overrides go undetected.
+Suggested fix: Add `override` to all four declarations, e.g. `virtual void start_measurement(void) override;`.
+
+### Medium item #3 : Missing `override` specifier on virtual overrides in extech.h
+
+Location: src/measurement/extech.h : 41-47
+Description: `start_measurement`, `end_measurement`, `power`, and `dev_capacity` override `power_meter` methods but lack the `override` keyword.
+Severity rationale: Same as medium item #2 above.
+Suggested fix: Add `override` to all four method declarations.
+
+### Medium item #4 : `#pragma once` not used — old-style include guards in three headers
+
+Location: src/measurement/measurement.h : 25-26; src/measurement/sysfs.h : 25-26; src/measurement/extech.h : 25-26
+Description: All three headers use `#ifndef / #define / #endif` guards instead of `#pragma once` required by style.md §4.1. The guards also use double-underscore prefixes (`__INCLUDE_GUARD_*`) which are reserved identifiers in C++.
+Severity rationale: Style violation and use of reserved names; `#pragma once` is simpler and avoids reserved-name UB.
+Suggested fix: Replace each `#ifndef / #define / #endif` triple with `#pragma once` at the top of the file.
+
+### Medium item #5 : `extech_power_meter` allocated without `std::nothrow` and without null check
+
+Location: src/measurement/measurement.cpp : 183
+Description: `meter = new class extech_power_meter(devnode);` uses throwing `new`, unlike the three similar allocations on lines 144, 152, and 165 which use `new(std::nothrow)` and check for null before pushing to `power_meters`. If allocation fails here the unhandled exception terminates the process; if `meter` were somehow null it would be pushed into `power_meters` and later dereferenced.
+Severity rationale: Inconsistency with surrounding code; missing null check creates potential null-pointer dereference.
+Suggested fix: Change to `meter = new(std::nothrow) extech_power_meter(devnode); if (meter) power_meters.push_back(meter);`.
+
+## Review of src/measurement/extech.cpp, src/devices/backlight.h, src/devices/backlight.cpp, src/devices/rfkill.cpp — batch 21
+
+### Medium item #1 : `using namespace std;` in extech.cpp, backlight.cpp, rfkill.cpp
+
+Location: src/measurement/extech.cpp : 64 | src/devices/backlight.cpp : 34 | src/devices/rfkill.cpp : 35
+Description: All three `.cpp` files contain `using namespace std;`, which is explicitly prohibited by both style.md §4.2 and general-c++.md. This pollutes the global namespace and can cause silent name collisions. The codebase already uses `std::` prefixes consistently in other files.
+Severity rationale: Violation of two separate coding-style rules; potential for subtle naming conflicts in a project that mixes C and C++ headers.
+Suggested fix: Remove all three `using namespace std;` directives and prefix all standard-library names with `std::`.
+
+### Medium item #2 : `decode_extech_value` return type is `unsigned int` but returns -1 on error
+
+Location: src/measurement/extech.cpp : 145, 201
+Description: The function is declared as returning `unsigned int`, yet the error path does `return -1;`. Due to implicit conversion, -1 becomes `UINT_MAX`. The caller checks `if (ret)` which accidentally works because `UINT_MAX != 0`, but the interface is semantically incorrect, misleading, and fragile. Any caller that compares the return value to -1 directly will get the wrong result.
+Severity rationale: Incorrect return type; error-detection relies on accidental unsigned arithmetic, a silent API contract violation.
+Suggested fix: Change the return type to `int` (or return a negative constant like `-1` explicitly as `int`).
+
+### Medium item #3 : parse_packet inner decode loop runs only once instead of four times
+
+Location: src/measurement/extech.cpp : 222
+Description: `for (i = 0; i < 1; i++)` iterates exactly once (i=0 only), decoding only the first five-byte block. The outer loop confirms that four blocks are expected. If all four blocks carry measurement data, only one-quarter of the available information is decoded; the remaining three blocks are silently discarded.
+Severity rationale: Potential logic error that limits the measurement to only the first of four data blocks, possibly discarding the actual watts field if it lives in a later block.
+Suggested fix: Change the loop bound to match the outer loop: `for (i = 0; i < 4; i++)`. Verify the op[] buffer is large enough (currently 32 bytes; 4 × 8 = 32 bytes — exactly fits).
+
+### Medium item #4 : `human_name()` returns non-translated string "Display backlight"
+
+Location: src/devices/backlight.h : 52
+Description: The `human_name()` method returns the literal string `"Display backlight"` without wrapping it in the `_()` gettext macro, violating the project rule that all user-visible strings must be translatable.
+Severity rationale: User-visible device name is never translated; breaks i18n for all backlight entries.
+Suggested fix: `virtual std::string human_name(void) { return _("Display backlight"); };`
+
+### Medium item #5 : rfkill humanname fallback is not translated
+
+Location: src/devices/rfkill.cpp : 56
+Description: When the `readlink()` calls both fail, `humanname` remains set to `std::format("radio:{}", _name)`, a hard-coded non-translated string. The translated form is only used when readlink succeeds (lines 64, 69). The fallback is therefore never localized.
+Severity rationale: User-visible device label is untranslated for any rfkill device whose driver symlink cannot be resolved.
+Suggested fix: Use a translated fallback, e.g. `humanname = pt_format(_("Radio device: {}"), _name);`.
+
+### Medium item #6 : Error messages in parse_packet use printf() and are not translated
+
+Location: src/measurement/extech.cpp : 217, 227, 291
+Description: Three error messages use `printf()` to write to stdout rather than `fprintf(stderr, ...)` as required by style.md §6. None of the strings are wrapped in `_()`. The message at line 291 in `measure()` also uses `printf` instead of `fprintf(stderr,...)`.
+Severity rationale: Violates the project style rule for error output; strings are not translatable.
+Suggested fix: Replace with `fprintf(stderr, _("Invalid packet\n"));` etc. (or simply remove diagnostic noise for internal protocol errors and return the error code silently).
+
+### Medium item #7 : Hardcoded `/sys/class/drm/card0` in dpms_screen_on()
+
+Location: src/devices/backlight.cpp : 69, 80, 84
+Description: `dpms_screen_on()` opens `/sys/class/drm/card0` and then constructs paths under `/sys/class/drm/card0/…`. On systems with multiple GPUs or where the primary display adapter is not `card0` (e.g., discrete NVIDIA where Intel is `card1`), the function will always report the screen as off, causing backlight utilization to be reported as 0% regardless of actual state.
+Severity rationale: Directly causes incorrect backlight power estimates on a common class of multi-GPU laptops — a material impact on measurement accuracy.
+Suggested fix: Enumerate all `/sys/class/drm/card*` top-level directories and search for an enabled+On connector under each of them, rather than hardcoding `card0`.
+
+## Review of src/devices/usb.h, src/devices/usb.cpp, src/devices/gpu_rapl_device.h, src/devices/gpu_rapl_device.cpp, src/devices/ahci.h — batch 22
+
+### Medium item #1 : `consumed_power` is uninitialized in gpu_rapl_device constructor
+
+Location: src/devices/gpu_rapl_device.cpp : 31-41
+Description: The constructor initializes `device_valid(false)` explicitly but never initializes `consumed_power`. In C++, non-static member variables of POD types are left with indeterminate values unless explicitly initialized. If `power_usage()` is called before `end_measurement()` has ever run (which sets `consumed_power = 0.0`), and the RAPL domain is present, the function returns the indeterminate value — undefined behaviour. The fix is to initialize `consumed_power` to `0.0` in the member initializer list.
+Severity rationale: UB via use of uninitialized memory; could produce garbage power readings on the first call.
+Suggested fix: Add `consumed_power(0.0)` to the member initializer list: `gpu_rapl_device::gpu_rapl_device(i915gpu *parent) : i915gpu(), consumed_power(0.0), device_valid(false)`.
+
+### Medium item #2 : Non-translatable user-facing strings "GPU core" in gpu_rapl_device.h
+
+Location: src/devices/gpu_rapl_device.h : 47-49
+Description: The methods `class_name()`, `device_name()`, and `human_name()` all return the hard-coded string `"GPU core"` without the `_()` gettext macro. `human_name()` in particular is the string shown to the user in device listings. The project rules (`rules.md`, `style.md §5`) require that all user-visible strings be wrapped with `_()` for internationalization. The other devices (usb, ahci) already use `pt_format(_("..."), ...)` for their human-readable names.
+Severity rationale: Breaks i18n for all users with non-English locales; explicitly required by project rules.
+Suggested fix: Change the return expressions: `return _("GPU core");` for `human_name()`. `class_name()` and `device_name()` are internal identifiers — if they are truly user-visible, apply `_()` as well; otherwise document that they are internal.
+
+### Medium item #3 : Missing `override` specifier on virtual methods in derived classes
+
+Location: src/devices/usb.h : 50-62, src/devices/gpu_rapl_device.h : 47-53, src/devices/ahci.h : 53-66
+Description: All three derived-class headers redeclare base-class virtual methods using the `virtual` keyword but omit `override`. In C++11 and later, `override` causes a compile-time error if the function signature does not match a virtual function in the base class, catching accidental signature mismatches. Without `override`, silent shadowing bugs (e.g., a parameter type mismatch) compile without warning. The project uses C++20 where `override` is idiomatic.
+Severity rationale: Absence of `override` is a C++ best-practice violation that can hide real signature bugs silently.
+Suggested fix: Replace `virtual` with `override` (or add `override` after the parameter list) on every overriding method declaration. Remove the leading `virtual` keyword as it is redundant when `override` is present.
+
+### Medium item #4 : Fixed-size C-style buffer in `register_power_with_devlist`
+
+Location: src/devices/usb.cpp : 115-118
+Description: `char devfs_name[1024]` is used with `snprintf` to produce a path of the form `"usb/NNN/NNN"`. The project rules (`general-c++.md`) require preferring `std::string` over C-style strings and char arrays except when interfacing with C-only libraries. `register_devpower` accepts a `const char *` (C interface), but the intermediate buffer should be avoided. The buffer is far larger than necessary and is a maintenance hazard.
+Severity rationale: Style/rule violation; the buffer is not at risk of overflow in practice, but fixed-size buffers are explicitly discouraged and the project has the std::format infrastructure to do this without a buffer.
+Suggested fix: Replace with `std::string devfs_name = std::format("usb/{:03}/{:03}", busnum, devnum);` and pass `devfs_name.c_str()` to `register_devpower`.
+
+### Medium item #5 : `start_measurement` / `end_measurement` call RAPL API without checking `device_valid`
+
+Location: src/devices/gpu_rapl_device.cpp : 43-61
+Description: Both `start_measurement()` and `end_measurement()` unconditionally call `rapl.get_pp1_energy_status()` regardless of whether `device_valid` is true. If the RAPL pp1 domain is not present, the call is a no-op in benign implementations, but the code relies on that assumption. Additionally, `last_energy` is only initialized in the constructor's `if (rapl.pp1_domain_present())` branch; if the domain is absent, `last_energy` is uninitialized and `end_measurement` would compute a meaningless `consumed_power` before writing it back.
+Severity rationale: Can interact with the uninitialized `last_energy` issue (M1) to produce UB or incorrect readings.
+Suggested fix: Guard both methods: `if (!device_valid) return;` at the top of `start_measurement()` and `end_measurement()`.
+
+### Medium item #6 : Unqualified `string` in usb.cpp constructor signature
+
+Location: src/devices/usb.cpp : 41
+Description: The constructor definition uses `const string &_name, const string &path, const string &devid` — bare `string` without the `std::` prefix. This compiles only because some transitively-included header introduces `using namespace std` (likely `gpu_rapl_device.h` via the include chain, or some system header). The project style (`style.md §4.2`, `general-c++.md`) requires explicit `std::` qualification throughout. The header declaration at `usb.h:48` correctly uses `std::string`.
+Severity rationale: Code relies on namespace pollution from another header to compile; fragile and style non-compliant.
+Suggested fix: Change line 41 to `usbdevice::usbdevice(const std::string &_name, const std::string &path, const std::string &devid)`.
+
+
+## Review of src/devices/ahci.cpp, src/devices/thinkpad-fan.h, src/devices/thinkpad-fan.cpp, src/devices/device.h, src/devices/device.cpp — batch 23
+
+### Medium item #1 : `using namespace std;` in ahci.cpp and device.cpp
+
+Location: src/devices/ahci.cpp : 34 ; src/devices/device.cpp : 35
+Description: Both source files contain `using namespace std;` at file scope. While less harmful than the identical construct in device.h (it does not affect other translation units), it is still explicitly prohibited by style.md §4.2 ("Avoid `using namespace std;`") and general-c++.md. The rest of the codebase uses the `std::` prefix consistently.
+Severity rationale: Style and correctness violation in two files; does not affect other TUs but sets a bad example and can hide name conflicts within the file.
+Suggested fix: Remove the `using namespace std;` lines and add `std::` prefixes where needed (the existing code already uses `std::` for most calls, so the change is minimal).
+
+### Medium item #2 : User-visible string "Laptop fan" not wrapped with `_()`
+
+Location: src/devices/thinkpad-fan.h : 48
+Description: The `human_name()` virtual method returns the hard-coded string `"Laptop fan"`. This string is displayed directly to the user in the device power table (it becomes the "Device name" column entry). Per rules.md: "All user visible strings must be translatable and use the _() gettext pattern". The string is currently not translatable.
+Severity rationale: Direct i18n violation for a string that is always shown to users on ThinkPad systems.
+Suggested fix: `virtual std::string human_name(void) { return _("Laptop fan"); };`
+
+### Medium item #3 : Override virtual methods lack `override` specifier
+
+Location: src/devices/thinkpad-fan.h : 40–52
+Description: All virtual methods in `thinkpad_fan` that override `device` base-class methods (`start_measurement`, `end_measurement`, `utilization`, `class_name`, `device_name`, `human_name`, `power_usage`, `util_units`, `power_valid`, `grouping_prio`) are declared with `virtual` but without the C++11 `override` keyword. The `override` specifier lets the compiler catch signature mismatches between override and base.
+Severity rationale: Missing `override` is a C++ best practice violation; a future signature change in the base class would silently stop the override from working.
+Suggested fix: Replace `virtual void start_measurement(void);` with `void start_measurement(void) override;` (and similarly for all other overrides). Drop the redundant `virtual` when `override` is present.
+
+### Medium item #4 : Old-style `#ifndef` include guards instead of `#pragma once`
+
+Location: src/devices/thinkpad-fan.h : 25–26 ; src/devices/device.h : 25–26
+Description: Both headers use the traditional `#ifndef _INCLUDE_GUARD_…` / `#define` / `#endif` pattern. style.md §4.1 states: "Use `#pragma once`".
+Severity rationale: Style guide violation in two headers.
+Suggested fix: Replace the `#ifndef` / `#define` / `#endif` trio with a single `#pragma once` directive.
+
+### Medium item #5 : Duplicate `#include <unistd.h>` in thinkpad-fan.cpp and device.cpp
+
+Location: src/devices/thinkpad-fan.cpp : 32 and 44 ; src/devices/device.cpp : 32 and 56
+Description: `<unistd.h>` is included twice in each of these files. In thinkpad-fan.cpp it appears at lines 32 and 44; in device.cpp at lines 32 and 56. Duplicate includes are harmless due to include guards but indicate copy-paste errors and reduce readability.
+Severity rationale: Code quality / maintenance issue.
+Suggested fix: Remove the second occurrence of `#include <unistd.h>` in each file.
+
+### Medium item #6 : Unused includes `<iostream>` and `<fstream>` in thinkpad-fan.cpp
+
+Location: src/devices/thinkpad-fan.cpp : 25–26
+Description: `<iostream>` and `<fstream>` are included but neither `std::cout`, `std::cin`, `std::ifstream`, nor any other entity from these headers is used anywhere in thinkpad-fan.cpp. This increases compilation time and obscures the file's true dependencies.
+Severity rationale: Code clarity violation; may mislead future maintainers into thinking stream I/O is being used.
+Suggested fix: Remove lines 25–26 (`#include <iostream>` and `#include <fstream>`).
+
+### Medium item #7 : Override virtual methods in device.h lack `override` specifier
+
+Location: src/devices/device.h : 45–72
+Description: The base class `device` declares all its interface methods as `virtual`. While being the base class it is not required to use `override` itself, derived classes (e.g. `thinkpad_fan`, `ahci`) do not use `override` either. This is a pervasive issue across the hierarchy — noting it at the base class level for context.
+Severity rationale: Same rationale as Medium item #3; a pattern that should be adopted hierarchy-wide.
+Suggested fix: Add `override` to all override declarations in all derived device classes.
+
+### Medium item #8 : Unused variable `cols` and `rows` default-initialized to 0 then immediately overwritten
+
+Location: src/devices/ahci.cpp : 262–264
+Description: `int cols=0; int rows=0;` are declared with initializers, then two lines later unconditionally assigned `cols=5; rows=links.size()+1;`. The zero-initialization is dead code that can confuse the reader.
+Severity rationale: Minor code clarity issue; initializers 0 are never observable.
+Suggested fix: Declare and initialise at point of use:
+```cpp
+int cols = 5;
+int rows = static_cast<int>(links.size()) + 1;
+```
+## Review of src/devices/devfreq.cpp, src/devices/devfreq.h, src/devices/alsa.h, src/devices/alsa.cpp, src/devices/runtime_pm.cpp — batch 24
+
+### Medium item #1 : Old-style `#ifndef` header guards instead of `#pragma once`
+
+Location: src/devices/devfreq.h : 25, src/devices/alsa.h : 25, src/devices/runtime_pm.h : 25
+Description: All three headers use the `#ifndef _INCLUDE_GUARD_xxx` / `#define` / `#endif` idiom. style.md §4.1 mandates `#pragma once` for header guards in this project.
+Severity rationale: Style rule violation across all three headers reviewed.
+Suggested fix: Replace the `#ifndef`/`#define`/`#endif` triple in each header with a single `#pragma once` at the top.
+
+### Medium item #2 : User-visible string `"Idle"` not wrapped in `_()`
+
+Location: src/devices/devfreq.cpp : 97
+Description: `state->human_name = "Idle";` assigns a hard-coded English string that is displayed directly in the ncurses UI and reports. All user-visible strings must use the `_()` gettext macro per style.md §5 and rules.md.
+Severity rationale: String cannot be localised; violates mandatory i18n rule.
+Suggested fix: `state->human_name = _("Idle");`
+
+### Medium item #3 : Untranslated user-visible error messages sent to stderr
+
+Location: src/devices/devfreq.cpp : 239, 249
+Description: Two calls `fprintf(stderr, "Devfreq not enabled\n")` output English-only text. While these go to stderr, they are user-visible diagnostic messages that should be translatable per the project's i18n rules. Similarly, the ncurses string `" Devfreq is not enabled"` at line 278 is already correctly wrapped but the stderr counterpart is not.
+Severity rationale: Inconsistency; stderr messages are user-visible and must be localisable.
+Suggested fix: `fprintf(stderr, _("Devfreq not enabled\n"));`
+
+### Medium item #4 : `uint64_t` arithmetic underflow in `alsa::end_measurement()` numerator
+
+Location: src/devices/alsa.cpp : 107
+Description: `(end_active - start_active)` is computed as `uint64_t - uint64_t`. If `end_active < start_active` (e.g., after a counter reset, driver reload, or suspend/resume), the result silently wraps to a very large `uint64_t`. When this large value is then divided by the (correctly computed double) denominator, `p` becomes a huge number (>> 100%) which gets stored and displayed as the utilisation. The same pattern also appears in `alsa::utilization()` at line 116.
+Severity rationale: Silent data corruption on counter wrap produces wildly incorrect power accounting.
+Suggested fix: Cast to signed 64-bit before subtraction, or clamp: `double active_delta = (end_active >= start_active) ? (double)(end_active - start_active) : 0.0;`
+
+### Medium item #5 : `dstates` is a public member of `devfreq`
+
+Location: src/devices/devfreq.h : 48
+Description: `vector<class frequency *> dstates` is declared `public`, allowing any external code to modify the internal state vector directly. `display_devfreq_devices()` in devfreq.cpp iterates over it externally (`df->dstates`). Exposing the raw vector violates encapsulation and makes it harder to change the implementation.
+Severity rationale: Design defect that exposes memory-managed internals; coupled to at least one direct external use.
+Suggested fix: Make `dstates` private and add a `size_t freq_state_count()` and `const frequency* freq_state(size_t idx)` accessor pair.
+
+### Medium item #6 : `static int index = 0` lazy-init fails when `get_param_index` returns 0
+
+Location: src/devices/alsa.cpp : 146-150
+Description: `power_usage()` uses a static local `index` initialised to 0 as a sentinel for "not yet looked up". If `get_param_index("alsa-codec-power")` legitimately returns 0 (i.e., it is the first registered parameter), the guard `if (!index)` is always true and the index is re-fetched on every call. At worst this is an O(n) lookup on every power calculation; at best it is silently correct by accident.
+Severity rationale: Logic error with a subtle trigger condition; incorrect parameter lookup on every power calculation if index happens to be 0.
+Suggested fix: Use `static int index = -1;` as the sentinel, or initialise the index in the constructor.
+
+### Medium item #7 : `do_bus()` adds all bus devices to device list without runtime PM check
+
+Location: src/devices/runtime_pm.cpp : 130-174
+Description: `do_bus()` creates a `runtime_pmdevice` for every entry in `/sys/bus/{bus}/devices/` unconditionally, including devices that have no `power/runtime_suspended_time` or `power/runtime_active_time` sysfs files. The helper `device_has_runtime_pm()` exists precisely to detect this but is never called inside `do_bus()`. Consequences: (1) potentially dozens of ghost devices appear in the UI with permanently 0% utilisation; (2) a power parameter entry is registered for each via `register_parameter(humanname)`, bloating the parameter registry.
+Severity rationale: Functional correctness issue — non-PM devices are silently included and pollute the device list and parameter registry.
+Suggested fix: After constructing `dev`, check `device_has_runtime_pm(path)` and `delete dev; continue;` if false, before pushing to `all_devices`.
+
+### Medium item #8 : `active_time` accumulator compared against `sample_time` without overflow guard
+
+Location: src/devices/devfreq.cpp : 82
+Description: In `process_time_stamps()`, `dstates[i]->time_after` (type `uint64_t`) is assigned `sample_time - active_time` where `sample_time` is `double` (microseconds) and `active_time` is a `uint64_t` accumulation of nanosecond-domain values (line 79 multiplies by 1000). If measurement jitter or counter imprecision causes `active_time > sample_time`, the double subtraction yields a negative value which is then silently truncated to a very large `uint64_t` on assignment — corrupting the idle-time accounting for the device.
+Severity rationale: Unsigned underflow on double-to-uint64_t conversion produces invalid idle time displayed to the user.
+Suggested fix:
+```cpp
+double idle = sample_time - (double)active_time;
+dstates[i]->time_after = (idle > 0.0) ? (uint64_t)idle : 0;
+```
+
+## Review of runtime_pm.h, network.cpp, network.h, i915-gpu.h, i915-gpu.cpp — batch 25
+
+### Medium item #1 : Non-translatable fallback `humanname` in `network` constructor
+
+Location: src/devices/network.cpp : 149
+Description: The constructor sets `humanname = std::format("nic:{}", _name)` as the initial (fallback) value. This string is user-visible (it appears in device listings and reports) but is not wrapped in `_()` for gettext translation. If the subsequent `readlink()` call (line 170) succeeds the string is overwritten with a properly translated one, but if the driver symlink is absent the untranslatable `"nic:{}"` fallback is displayed to the user.
+Severity rationale: User-visible string not marked for translation; violates rules.md and style.md §5.
+Suggested fix: `humanname = pt_format(_("nic:{}"), _name);`
+
+### Medium item #2 : Non-translatable `human_name()` return value in i915-gpu class
+
+Location: src/devices/i915-gpu.h : 52
+Description: `virtual std::string human_name(void) { return "Intel GPU"; }` returns a hard-coded English string that is user-facing (shown in reports and the TUI). It is not wrapped in `_()`.
+Severity rationale: User-visible string not marked for translation; violates rules.md and style.md §5.
+Suggested fix: `return _("Intel GPU");`
+
+### Medium item #3 : Non-translatable `device_name()` return values in i915-gpu class
+
+Location: src/devices/i915-gpu.h : 47–51
+Description: The `device_name()` override returns either `"GPU misc"` or `"GPU"` depending on whether child devices exist. Both strings are user-visible but not wrapped in `_()`.
+Severity rationale: User-visible strings not marked for translation; violates rules.md and style.md §5.
+Suggested fix:
+```cpp
+virtual std::string device_name(void) {
+    if (!child_devices.empty())
+        return _("GPU misc");
+    return _("GPU");
+};
+```
+
+### Medium item #4 : Non-translatable `util_units()` return value in i915-gpu class
+
+Location: src/devices/i915-gpu.h : 55
+Description: `virtual std::string util_units(void) { return " ops/s"; }` returns a user-visible units string that is not wrapped in `_()`.
+Severity rationale: User-visible string not marked for translation; violates rules.md and style.md §5.
+Suggested fix: `return _(" ops/s");`
+
+### Medium item #5 : Non-translatable `util_units()` return value in network class
+
+Location: src/devices/network.h : 73
+Description: `virtual std::string util_units(void) { return " pkts/s"; }` returns a user-visible units string that is not wrapped in `_()`.
+Severity rationale: User-visible string not marked for translation; violates rules.md and style.md §5.
+Suggested fix: `return _(" pkts/s");`
+
+### Medium item #6 : Missing explicit include for `<ctime>` / `time()` in network.cpp
+
+Location: src/devices/network.cpp : 66–69
+Description: `do_proc_net_dev()` calls `time(NULL)` (lines 66 and 69) but neither `<ctime>` nor `<time.h>` is explicitly included in network.cpp. The declaration is currently pulled in only transitively through other headers. If those headers change, this file will fail to compile.
+Severity rationale: Fragile dependency on transitive include; missing explicit include makes the file's dependencies unclear and risks future build breakage.
+Suggested fix: Add `#include <ctime>` to the include list in network.cpp.
+
+## Review of src/devices/thinkpad-light.cpp, src/devices/thinkpad-light.h — batch 26
+
+### Medium item #1 : Non-translatable `human_name()` return value
+
+Location: src/devices/thinkpad-light.h : 48
+Description: `human_name()` returns the hard-coded string `"Thinkpad light"` which is directly displayed to the user in the PowerTOP UI and reports. It is not wrapped in the `_()` gettext macro, so it will never be translated.
+Severity rationale: All user-visible strings must be wrapped in `_()` per rules.md and style.md §5.
+Suggested fix: `virtual std::string human_name(void) { return _("Thinkpad light"); };`
+
+### Medium item #2 : Missing `override` keyword on overriding virtual methods
+
+Location: src/devices/thinkpad-light.h : 40–52
+Description: All virtual methods in `thinkpad_light` that override `device` base-class methods (`start_measurement`, `end_measurement`, `utilization`, `class_name`, `device_name`, `human_name`, `power_usage`, `util_units`, `power_valid`, `grouping_prio`) are declared with `virtual` but lack `override`. The `override` specifier enables the compiler to catch signature mismatches at compile time.
+Severity rationale: Without `override`, a typo or signature change in the base class silently creates a new virtual function rather than an error. C++11 and later best practice requires `override` on all overriding methods.
+Suggested fix: Replace `virtual` with `override` (or add `override` after the parameter list) on every overriding declaration, e.g. `void start_measurement(void) override;`.
+
+### Medium item #3 : Missing `const` on logically const methods
+
+Location: src/devices/thinkpad-light.h : 43–52
+Description: Methods `utilization()`, `class_name()`, `device_name()`, `human_name()`, `util_units()`, `power_valid()`, and `grouping_prio()` do not modify any member state and should be declared `const`. The absence of `const` prevents calling these methods on `const thinkpad_light` objects and objects accessed via `const device *` pointers.
+Severity rationale: Missing `const` breaks const-correctness, a C++ best-practice requirement per general-c++.md.
+Suggested fix: Append `const` to each method signature, e.g. `virtual std::string human_name(void) const { return _("Thinkpad light"); };`.

--- a/logs/nit.md
+++ b/logs/nit.md
@@ -1,0 +1,991 @@
+# PowerTOP Nit Severity Review Findings
+
+## Review of calibrate.cpp, calibrate.h, lib.cpp, devlist.cpp, main.cpp — batch 01
+
+### Nit item #1 : Mixed `cout` and `printf` in calibrate.cpp
+
+Location: src/calibrate/calibrate.cpp : 389, 412
+
+Description:
+`calibrate()` uses `cout << _("...")` at lines 389 and 412 while every other print in the file uses `printf`. The project uses `printf`-style I/O throughout. Mixing the two output mechanisms is a style inconsistency and can cause unexpected ordering on buffered streams.
+
+Suggested fix: Replace the two `cout <<` calls with `printf(_("..."))`.
+
+---
+
+### Nit item #2 : Space indentation instead of tabs in calibrate.cpp
+
+Location: src/calibrate/calibrate.cpp : 387, 415, 419–420
+
+Description:
+Several lines inside `calibrate()` use leading spaces instead of the project-mandated tabs (style.md §1.1):
+- Line 387: `        save_sysfs(...)` — 8 spaces
+- Line 415: `        learn_parameters(...)` — 8 spaces
+- Lines 419–420: `        save_all_results(...)` — 8 spaces
+
+Suggested fix: Replace leading spaces with a single tab on each affected line.
+
+---
+
+### Nit item #3 : Space indentation instead of tabs in main.cpp
+
+Location: src/main.cpp : 313–314, 422
+
+Description:
+- Lines 313–314 (`fprintf` calls inside `make_report`) use 2-space and 3-space indentation instead of tabs.
+- Line 422 (`load_parameters` call inside `powertop_init`) uses 8 spaces instead of a tab.
+
+Suggested fix: Replace leading spaces with tabs to match the rest of the file.
+
+---
+
+### Nit item #4 : Missing space before `!= 0` / `==0` comparisons
+
+Location: src/calibrate/calibrate.cpp : 173; src/devlist.cpp : 88, 164
+
+Description:
+```cpp
+if (access(filename.c_str(), R_OK)!=0)   // calibrate.cpp:173
+if (strncmp(link, "/dev", 4)==0) {        // devlist.cpp:164
+```
+The project style follows Linux kernel formatting conventions which require spaces around binary operators. These lines are missing spaces around `!=` and `==`.
+
+Suggested fix:
+```cpp
+if (access(filename.c_str(), R_OK) != 0)
+if (strncmp(link, "/dev", 4) == 0) {
+```
+
+---
+
+### Nit item #5 : `set_refresh_timeout` returns `0`/`1` instead of `false`/`true`
+
+Location: src/main.cpp : 123–124
+
+Description:
+```cpp
+if (!time) return 0;
+...
+return 1;
+```
+The function signature declares `bool` as the return type, but integer literals `0` and `1` are returned. Prefer `false` and `true` for boolean returns to match the declared type.
+
+Suggested fix:
+```cpp
+if (!time) return false;
+...
+return true;
+```
+
+## Review of src/test_framework.h, src/test_framework.cpp, src/display.cpp, src/display.h, src/lib.h — batch 02
+
+### Nit item #1 : Spaces instead of tabs in `base64_encode` and `base64_decode`
+
+Location: src/test_framework.cpp : 200–231
+Description: Both `base64_encode` and `base64_decode` are indented with 4 spaces instead of the project-mandated tabs. Every line inside these functions is affected.
+Severity rationale: Style guide §1.1 mandates tabs only.
+Suggested fix: Re-indent with tabs.
+
+---
+
+### Nit item #2 : Spaces instead of tabs in `show_prev_tab()`, `cursor_left()`, `cursor_right()`
+
+Location: src/display.cpp : 192–208, 282–292, 295–306
+Description: `show_prev_tab()` and the two cursor functions use spaces for indentation on several lines, inconsistent with the rest of the file and the project style guide.
+Severity rationale: Style guide §1.1.
+Suggested fix: Convert affected lines to tab indentation.
+
+---
+
+### Nit item #3 : Missing space after `if` in `cursor_up()`
+
+Location: src/display.cpp : 271
+Description: `if(w->ypad_pos > 0)` is missing the space between `if` and `(`. The project style (K&R/Linux kernel variant) requires a space.
+Severity rationale: Style nit.
+Suggested fix: `if (w->ypad_pos > 0)`
+
+---
+
+### Nit item #4 : Missing space around `=` in `tab_window` constructor
+
+Location: src/display.h : 59
+Description: `xpad_pos =0;` has a space before `=` but not after. Should be `xpad_pos = 0;` for consistency with the other assignments in the same constructor.
+Severity rationale: Style nit.
+Suggested fix: `xpad_pos = 0;`
+
+---
+
+### Nit item #5 : Redundant `extern` on function declarations in display.h
+
+Location: src/display.h : 35–47
+Description: `extern` on function declarations in a C++ header is implicit and redundant. The project's other headers (e.g., lib.h) also use `extern` inconsistently, but removing it from display.h would align with modern C++ practice.
+Severity rationale: Cosmetic / modern C++ idiom.
+Suggested fix: Remove `extern` from all function declarations.
+
+---
+
+### Nit item #6 : Signed/unsigned comparison warning in `show_tab()` loop
+
+Location: src/display.cpp : 136
+Description: `for (i = 0; i < tab_names.size(); i++)` — `i` is declared as `unsigned int` (matching `tab`'s type) but `tab_names.size()` returns `size_t`. On a 64-bit platform `unsigned int` is 32 bits while `size_t` is 64 bits, producing a comparison between differently-sized unsigned types and potentially a compiler warning.
+Severity rationale: Minor; no current runtime risk but indicates imprecision.
+Suggested fix: Declare `i` as `size_t` or use a range-for loop.
+
+---
+
+### Nit item #7 : Magic number `7` in `cursor_down()` scroll guard
+
+Location: src/display.cpp : 248
+Description: `if ((w->cursor_pos + 7) >= LINES)` uses the literal `7` with no explanation. This appears to be an offset related to the reserved top/bottom display rows, but without a comment or named constant the intent is opaque.
+Severity rationale: Readability nit.
+Suggested fix: Define `constexpr int DISPLAY_MARGIN = 7;` and document its meaning, or add an inline comment.
+
+## Review of src/tuning/tunable.h, src/tuning/runtime.cpp — batch 03
+
+### Nit item #1 : Extra semicolon after virtual destructor definition
+
+Location: src/tuning/tunable.h : 61
+Description: `virtual ~tunable() {};` has a spurious semicolon after the closing brace. While harmless, it is non-idiomatic.
+Severity rationale: Cosmetic.
+Suggested fix: `virtual ~tunable() {}`
+
+### Nit item #2 : Opening brace on separate line for `for` loop body
+
+Location: src/tuning/runtime.cpp : 174–175
+Description: The `for (char blk = 'a'; blk <= 'z'; blk++)` statement has its opening brace on a new line, violating the project's K&R brace style (style.md §1.2).
+Severity rationale: Style nit.
+Suggested fix: `for (char blk = 'a'; blk <= 'z'; blk++) {`
+
+### Nit item #3 : Inconsistent spacing around `=` in variable declarations
+
+Location: src/tuning/runtime.cpp : 127
+Description: `int max_ports = 32, count=0;` — `count=0` lacks spaces around the `=` operator, inconsistent with `max_ports = 32`.
+Severity rationale: Cosmetic style inconsistency.
+Suggested fix: `int max_ports = 32, count = 0;`
+
+### Nit item #4 : Inconsistent spacing in `for` loop init expression
+
+Location: src/tuning/runtime.cpp : 158
+Description: `for (int i=0; i < max_ports; i++)` — `i=0` lacks spaces around `=`.
+Severity rationale: Cosmetic style inconsistency.
+Suggested fix: `for (int i = 0; i < max_ports; i++)`
+
+### Nit item #5 : Duplicate constant values for `TUNE_UNKNOWN` and `TUNE_NEUTRAL`
+
+Location: src/tuning/tunable.h : 39–40
+Description: `TUNE_UNKNOWN` and `TUNE_NEUTRAL` are both defined as `0`. Having two names for the same sentinel makes the codebase ambiguous — it is unclear whether the result of `good_bad()` returning `0` means "unknown state" or "neutral/not applicable".
+Severity rationale: Cosmetic / readability issue; could cause confusion when reading code.
+Suggested fix: Keep only one name, or add a comment explaining the deliberate dual alias.
+
+### Nit item #6 : C-style `void` in no-argument virtual method declarations
+
+Location: src/tuning/tunable.h : 63, 78, 80, 82
+Description: Virtual methods such as `good_bad(void)`, `toggle(void)`, `description(void)`, `toggle_script(void)` and `result_string(void)` use C-style `void` parameter syntax. In C++, empty parentheses `()` are preferred.
+Severity rationale: C++ style preference; C-style `(void)` is idiomatic C, not modern C++.
+Suggested fix: Change all `method(void)` declarations to `method()`.
+
+### Nit item #7 : Unqualified `string::npos` usage in runtime.cpp relies on namespace pollution
+
+Location: src/tuning/runtime.cpp : 81, 85
+Description: `path.find("ata") != string::npos` and `path.find("block") != string::npos` use unqualified `string::npos`. This compiles only because `using namespace std;` is injected via the included `runtime.h`. Once the `using namespace std;` is removed (per High items #1/#2), these must be updated.
+Severity rationale: Consequential nit — will become a compile error once the HIGH items are fixed.
+Suggested fix: Use `std::string::npos` explicitly.
+
+## Review of ethernet.cpp, ethernet.h, wifi.cpp, wifi.h, tuningusb.h — batch 04
+
+### Nit item #1 : Missing spaces around `<` in comparisons in ethernet.cpp
+
+Location: src/tuning/ethernet.cpp : 71, 78, 107, 114
+Description: `sock<0` and `ret<0` are written without spaces around the `<` operator. The project style (K&R/Linux kernel style) requires spaces around binary operators: `sock < 0` and `ret < 0`.
+Severity rationale: Minor style inconsistency.
+Suggested fix: `if (sock < 0)` and `if (ret < 0)`.
+
+### Nit item #2 : Leading-underscore parameter name `_iface` in wifi_tunable constructor
+
+Location: src/tuning/wifi.cpp : 46
+Description: The constructor parameter is named `_iface`. Leading underscores are conventionally reserved for implementation-defined identifiers. The project uses `snake_case` without leading underscores for parameters (e.g., `iface` in ethernet_tunable). Using `_iface` is non-idiomatic and potentially confusing.
+Severity rationale: Minor naming convention violation.
+Suggested fix: Rename the parameter to `iface` (matching ethernet.cpp's pattern).
+
+### Nit item #3 : Space-indented lines (not tab) on `ioctl` calls in ethernet.cpp
+
+Location: src/tuning/ethernet.cpp : 87, 123, 126
+Description: The three `ioctl(sock, SIOCETHTOOL, &ifr);` lines are indented with 8 spaces rather than a tab character. The project style guide mandates tab-only indentation.
+Severity rationale: Style guide violation (indentation).
+Suggested fix: Replace the leading 8 spaces with a single tab on each of the three lines.
+
+### Nit item #4 : C-style headers used in ethernet.cpp instead of C++ equivalents
+
+Location: src/tuning/ethernet.cpp : 30–32, 37
+Description: `<stdio.h>`, `<stdlib.h>`, `<string.h>`, and `<errno.h>` are C-style headers. The C++ equivalents `<cstdio>`, `<cstdlib>`, `<cstring>`, and `<cerrno>` place their declarations in the `std::` namespace and are the idiomatic choice in C++20 code.
+Severity rationale: Minor — both forms are standard in practice, but C++ headers are preferred per the C++20 standard and the project's use of C++ idioms elsewhere.
+Suggested fix: Replace each C-style header with its C++ equivalent (`<c*>` form).
+
+## Review of tuningusb.cpp, tuning.cpp, tuning.h, bluetooth.cpp, bluetooth.h — batch 05
+
+### Nit item #1 : Bare `string` instead of `std::string`
+
+Location: src/tuning/tuningusb.cpp : 40, 73; src/tuning/tuning.cpp : 247
+Description: Several locations use `string` without the `std::` prefix (e.g., `const string &path` in the constructor signature, `string content;` in `good_bad`). This works only because `tunable.h` contains `using namespace std;`, which is itself a style violation. The style guide requires explicit `std::` qualification everywhere.
+Severity rationale: Style guide violation; depends on a transitive `using namespace std;`.
+Suggested fix: Replace all bare `string` with `std::string` throughout these files.
+
+### Nit item #2 : Redundant `class` keyword in object declaration
+
+Location: src/tuning/tuningusb.cpp : 98
+Description: `class usb_tunable *usb;` uses the `class` keyword in a variable declaration. In C++ this is unnecessary (unlike C where `struct` tags require the keyword). The pattern is idiomatic C but not idiomatic C++.
+Severity rationale: Style inconsistency; the `class` keyword is superfluous in a variable declaration.
+Suggested fix: `usb_tunable *usb;`
+
+### Nit item #3 : Commented-out code block left in production source
+
+Location: src/tuning/bluetooth.cpp : 199–201
+Description: A three-line block checking `/sys/module/bluetooth` is commented out with a note explaining the intent. Commented-out code should not remain in production source; either the check should be re-enabled (the concern about triggering autoload is valid) or removed with a commit message explaining the decision.
+Severity rationale: Code hygiene; also the original concern (autoloading the bluetooth module) may still be valid.
+Suggested fix: If the autoload concern still applies, restore the check. Otherwise remove the dead code entirely.
+
+### Nit item #4 : Redundant explicit `string()` conversion
+
+Location: src/tuning/tuning.cpp : 247
+Description: `tunable_data[idx] = string(all_tunables[i]->toggle_script());` — `toggle_script()` already returns `std::string`, so the explicit `string()` constructor call is a no-op copy. It also uses bare `string` instead of `std::string`.
+Severity rationale: Unnecessary copy; style violation.
+Suggested fix: `tunable_data[idx] = all_tunables[i]->toggle_script();`
+
+### Nit item #5 : Use of POSIX `strcasecmp` instead of a C++ equivalent
+
+Location: src/tuning/tuning.cpp : 177
+Description: `strcasecmp(i->description().c_str(), j->description().c_str()) < 0` uses `strcasecmp`, which is a POSIX extension not part of the C++20 standard. The project targets C++20, so a portable alternative should be used.
+Severity rationale: Non-standard API; reduces portability.
+Suggested fix: Use a locale-aware comparison or a simple case-folding lambda:
+```cpp
+auto ci_less = [](unsigned char a, unsigned char b){ return std::tolower(a) < std::tolower(b); };
+return std::ranges::lexicographical_compare(ia, ib, ci_less);
+```
+where `ia`/`ib` are the description strings.
+
+### Nit item #6 : Missing space after comma in `wmove` call
+
+Location: src/tuning/tuning.cpp : 110
+Description: `wmove(win, 2,0)` — the second comma is not followed by a space, inconsistent with the surrounding code style and with the argument formatting used elsewhere in the file.
+Severity rationale: Trivial formatting inconsistency.
+Suggested fix: `wmove(win, 2, 0);`
+
+## Review of src/tuning/tuningsysfs.cpp, src/tuning/tuningsysfs.h, src/tuning/nl80211.h, src/tuning/iw.h, src/tuning/iw.c — batch 06
+
+### Nit item #1 : Typo "blatently" in iw.h and iw.c comment headers
+
+Location: src/tuning/iw.h : 2  /  src/tuning/iw.c : 2
+Description: Both files contain `"This code has been blatently stolen from"`. The correct spelling is "blatantly".
+Severity rationale: Spelling typo in a comment.
+Suggested fix: Change "blatently" to "blatantly" in both files.
+
+### Nit item #2 : Missing blank line between last #include and first function definition
+
+Location: src/tuning/tuningsysfs.cpp : 38–39
+Description: `#include "../lib.h"` (line 38) is immediately followed by the `sysfs_tunable` constructor definition on line 39 with no separating blank line. Per the project's K&R-style layout convention, a blank line should separate the include block from the first declaration.
+Severity rationale: Minor formatting inconsistency.
+Suggested fix: Add a blank line between `#include "../lib.h"` and the constructor.
+
+### Nit item #3 : Double-underscore prefix on internal function __handle_cmd
+
+Location: src/tuning/iw.c : 200
+Description: The function is named `__handle_cmd`. Per the C and C++ standards, all identifiers beginning with two underscores (`__`) are reserved for the implementation (compiler/standard library). Using such a name in application/library code is technically undefined behaviour and may silently conflict with compiler builtins or future standard library additions.
+Severity rationale: Minor standards compliance issue; unlikely to cause practical problems in this codebase.
+Suggested fix: Rename to `handle_cmd_internal` or simply `do_handle_cmd`.
+
+## Review of tuningi2c.h, tuningi2c.cpp, powerconsumer.h, powerconsumer.cpp, processdevice.h — batch 07
+
+### Nit item #1 : Redundant `class` keyword in variable declaration and `new` expression
+
+Location: src/tuning/tuningi2c.cpp : 87, 96
+Description: `class i2c_tunable *i2c;` and `new class i2c_tunable(...)` use the redundant `class` keyword. In C++ the `class` elaborated-type-specifier is not needed when the type is already declared.
+Suggested fix: `i2c_tunable *i2c;` and `new i2c_tunable(...)`.
+
+### Nit item #2 : Redundant forward declaration of `power_consumer`
+
+Location: src/process/powerconsumer.h : 37
+Description: `class power_consumer;` is declared on line 37 and then immediately defined starting on line 39. The forward declaration is redundant.
+Suggested fix: Remove line 37.
+
+### Nit item #3 : Unused includes in tuningi2c.cpp
+
+Location: src/tuning/tuningi2c.cpp : 27, 28, 29
+Description: `<utility>`, `<iostream>`, and `<ctype.h>` are included but no symbols from these headers appear to be used in the file.
+Suggested fix: Remove the unused `#include` directives.
+
+### Nit item #4 : Mixed include order in tuningi2c.cpp
+
+Location: src/tuning/tuningi2c.cpp : 20-34
+Description: Per style.md §4.4, standard library headers should come first, followed by project-specific headers. Currently project headers (`"tuning.h"`, `"tunable.h"`, `"tuningi2c.h"`) are interleaved with system and C++ headers.
+Suggested fix: Reorder into two groups — (1) system/standard headers, (2) project headers — separated by a blank line.
+
+## Review of processdevice.cpp, process.h, process.cpp, work.cpp, work.h — batch 08
+
+### Nit item #1 : Trailing semicolons after closing brace of inline virtual methods
+
+Location: src/process/process.h : 63-64 ; src/process/work.h : 44-47
+Description: Inline virtual method definitions end with `};` (e.g., `virtual std::string name(void) { return "process"; };`). The semicolon after `}` is legal but redundant and inconsistent with the rest of the codebase.
+Severity rationale: Minor style nit.
+Suggested fix: Remove the trailing semicolons.
+
+### Nit item #2 : Unnecessary `class` keyword in `new` expressions and declarations
+
+Location: src/process/processdevice.cpp : 52, 79 ; src/process/process.cpp : 154, 161 ; src/process/work.cpp : 127
+Description: Expressions like `new class device_consumer(device)`, `class process *new_proc`, and `class work * work` use the `class` keyword redundantly. In C++ the `class` keyword is not needed when the class name is already in scope.
+Severity rationale: Style nit; no functional impact.
+Suggested fix: Remove the redundant `class` keyword: `new device_consumer(device)`, `process *new_proc`, etc.
+
+### Nit item #3 : Constructor implementation uses bare `string` instead of `std::string`
+
+Location: src/process/process.cpp : 83
+Description: The constructor definition `process::process(const string &_comm, ...)` uses the unqualified `string` while the declaration in `process.h` correctly uses `std::string`. This only compiles due to namespace pollution from `powerconsumer.h`.
+Severity rationale: Style inconsistency; should be `const std::string &_comm`.
+Suggested fix: Change to `process::process(const std::string &_comm, int _pid, int _tid)`.
+
+### Nit item #4 : `std::for_each` with a named helper function; range-for is more idiomatic
+
+Location: src/process/work.cpp : 89-97
+Description: `add_work` is a tiny static helper used only to bridge `std::for_each` into pushing to `all_power`. A range-based for loop is clearer and avoids the extra function:
+```cpp
+void all_work_to_all_power(void)
+{
+    for (auto &[key, w] : all_work)
+        all_power.push_back(w);
+}
+```
+Severity rationale: Readability nit.
+
+## Review of interrupt.h, interrupt.cpp, timer.cpp, timer.h, do_process.cpp — batch 09
+
+### Nit item #1 : Trailing semicolons after closing braces in inline method definitions
+
+Location: src/process/interrupt.h : 48, 49  /  src/process/timer.h : 46, 47
+Description: Inline method definitions end with `};` (a semicolon after the closing brace of the function body). This is valid C++ but the trailing semicolon is redundant and not present elsewhere in the codebase.
+Severity rationale: Minor style inconsistency.
+Suggested fix: Remove the trailing semicolons: `{ return "interrupt"; }` not `{ return "interrupt"; };`.
+
+### Nit item #2 : Mixed space+tab indentation on line 330
+
+Location: src/process/do_process.cpp : 330
+Description: Line 330 (`return;` inside the `sched_wakeup` handler's field check) starts with a space character followed by tabs, inconsistent with the tab-only indentation rule.
+Severity rationale: Trivial whitespace inconsistency.
+Suggested fix: Replace leading space+tabs with pure tabs.
+
+### Nit item #3 : Double space in static pointer declaration
+
+Location: src/process/do_process.cpp : 50
+Description: `static  class perf_bundle * perf_events;` has two consecutive spaces between `static` and `class`.
+Severity rationale: Trivial cosmetic issue.
+Suggested fix: `static class perf_bundle *perf_events;`
+
+### Nit item #4 : raw_count is int but is only ever incremented
+
+Location: src/process/interrupt.h : 39  /  src/process/timer.h : 36
+Description: `raw_count` is declared as `int` in both `interrupt` and `timer`. It is only ever incremented, never assigned a negative value, and compared/used as a count. Using `unsigned int` (or `uint32_t`) would better express the invariant that it is always non-negative.
+Severity rationale: Minor type-semantics mismatch.
+Suggested fix: Change to `unsigned int raw_count;` in both classes.
+
+## Review of src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp — batch 10
+
+### Nit item #1 : Old-style `#ifndef` include guards instead of `#pragma once`
+
+Location: src/perf/perf.h : 25, src/perf/perf_bundle.h : 25
+Description: Both headers use traditional `#ifndef/#define/#endif` include guards. The project style guide specifies `#pragma once`.
+Suggested fix: Replace the guard triplet with `#pragma once` at the top of each header.
+
+### Nit item #2 : `#include <errno.h>` duplicated in perf.cpp
+
+Location: src/perf/perf.cpp : 29, 33
+Description: `<errno.h>` is included twice. The second inclusion is redundant.
+Suggested fix: Remove the duplicate include on line 33.
+
+### Nit item #3 : `int event_added = false;` — wrong type for boolean
+
+Location: src/perf/perf_bundle.cpp : 98
+Description: `event_added` is used as a boolean flag but declared as `int` and initialized with `false`. Should be `bool`.
+Suggested fix: `bool event_added = false;`
+
+### Nit item #4 : `records.resize(0)` should be `records.clear()`
+
+Location: src/perf/perf_bundle.cpp : 162
+Description: `records.resize(0)` is a roundabout way to empty a vector. `records.clear()` is the idiomatic and more readable form.
+Suggested fix: `records.clear();`
+
+### Nit item #5 : Double semicolon in `struct trace_entry` declaration
+
+Location: src/perf/perf_bundle.cpp : 171
+Description: `} __attribute__((packed));;` — there are two semicolons ending the struct declaration. One is redundant.
+Suggested fix: Remove the extra semicolon: `} __attribute__((packed));`
+
+### Nit item #6 : Zero-length array `data[0]` is non-standard C++
+
+Location: src/perf/perf_bundle.cpp : 177
+Description: `unsigned char data[0];` is a GCC extension. In standard C99/C11 the flexible array member syntax is `unsigned char data[];`; in C++ flexible array members are not standard at all. Since this is a `__attribute__((packed))` kernel-ABI struct used only for casting, a comment explaining the situation would be helpful.
+Suggested fix: At minimum, change to `unsigned char data[];` for C99 conformance; add a comment noting this is a zero-length trailing array for direct pointer arithmetic into the mmap ring buffer.
+
+### Nit item #7 : `#if 0` dead debug code block
+
+Location: src/perf/perf_bundle.cpp : 188
+Description: A large `#if 0 ... #endif` block containing `printf` debug statements is left in the source. This should be removed.
+Suggested fix: Delete lines 188–212.
+
+### Nit item #8 : `#include <iostream>` in headers where it is unused
+
+Location: src/perf/perf.h : 28, src/perf/perf_bundle.h : 28
+Description: Both headers include `<iostream>` but do not use anything from it directly (no `std::cin`, `std::cout`, or `std::cerr` declarations). This header is heavy and slows compilation.
+Suggested fix: Remove `#include <iostream>` from both headers. Include it in `.cpp` files that actually use stream I/O.
+
+### Nit item #9 : Missing blank line between consecutive function definitions
+
+Location: src/perf/perf_bundle.cpp : 134
+Description: The `start()` and `stop()` function definitions are not separated by a blank line. Similarly `stop()` and `clear()` run together. Consistent blank lines between function definitions improve readability.
+Suggested fix: Add a blank line between the closing `}` of `start()` and the opening of `stop()`, and between `stop()` and `clear()`.
+
+### Nit item #10 : Unused `#include <map>` in perf_bundle.h
+
+Location: src/perf/perf_bundle.h : 31
+Description: `<map>` is included but `std::map` is not used anywhere in `perf_bundle.h` or `perf_bundle.cpp`.
+Suggested fix: Remove the `#include <map>` line.
+
+## Review of persistent.cpp, parameters.cpp, parameters.h, learn.cpp, report-formatter.h — batch 11
+
+### Nit item #1 : Typo "patameters" in `dump_parameter_bundle` declaration
+
+Location: src/parameters/parameters.h : 94
+Description: The function declaration reads `void dump_parameter_bundle(struct parameter_bundle *patameters = &all_parameters);` — the parameter name is misspelled "patameters" instead of "parameters".
+Severity rationale: Cosmetic typo in a parameter name.
+Suggested fix: Rename to `parameters`.
+
+### Nit item #2 : `int` used as boolean for `first` and `bundle_saved` in `load_results`
+
+Location: src/parameters/persistent.cpp : 79, 82
+Description: `int first = 1;` and `int bundle_saved = 0;` use plain `int` to represent boolean state. C++ has `bool` for this purpose.
+Severity rationale: Minor style issue.
+Suggested fix: Declare as `bool first = true;` and `bool bundle_saved = false;`.
+
+### Nit item #3 : Inconsistent indentation inside `if (debug_learning)` block in `learn_parameters`
+
+Location: src/parameters/learn.cpp : 254
+Description: The `printf("delta is %5.4f\n", delta);` line at line 254 has an extra level of indentation compared to the surrounding `printf` calls within the same `if` block, breaking the consistent tab-based indentation of the file.
+Severity rationale: Pure style nit.
+Suggested fix: Align the line with its neighbours inside the `if (debug_learning)` block.
+
+### Nit item #4 : Multiple blocks of commented-out code left in place
+
+Location: src/parameters/learn.cpp : 121–122, 199, 223, 280 ; src/parameters/persistent.cpp : 151
+Description: Several blocks of commented-out `printf` / debug statements and a commented-out early-return guard are left in production code. Dead code hurts readability.
+Severity rationale: Readability nit.
+Suggested fix: Remove all commented-out code. If debug dumps are sometimes needed, guard them with `if (debug_learning)` instead.
+
+## Review of report-formatter-html.h, report.cpp, report.h, report-formatter-csv.h, report-maker.cpp — batch 12
+
+### Nit item #1 : Space indentation instead of tabs on one line
+
+Location: report.cpp : 126
+Description: `        init_title_attr(&title_attr);` uses 8 spaces for indentation rather than a single tab. The style guide mandates tab-only indentation throughout.
+Severity rationale: Minor, single-line style inconsistency.
+Suggested fix: Replace the 8 leading spaces with a single tab character.
+
+### Nit item #2 : Missing braces and misaligned bodies on consecutive `if` statements
+
+Location: report.cpp : 153-155
+Description: Three `if` statements share a pattern where the body is on the same line as the condition with no braces and without indentation, e.g.:
+```cpp
+if (str.length() < 1)
+str = read_sysfs_string("/etc/redhat-release");
+```
+The K&R/Linux style used throughout the project requires braces for all multi-line control-flow blocks, and the body must be indented one level. Also, `str.length() < 1` is better written as `str.empty()`.
+Severity rationale: Style violation; the missing indentation could confuse a reader into thinking the body is unconditional.
+Suggested fix:
+```cpp
+if (str.empty())
+    str = read_sysfs_string("/etc/redhat-release");
+if (str.empty())
+    str = read_os_release("/etc/os-release");
+```
+(Use tabs for indentation.)
+
+## Review of report-maker.h, report-data-html.cpp, report-data-html.h, report-formatter-base.cpp, report-formatter-base.h — batch 13
+
+### Nit item #1 : Inconsistent indentation (spaces instead of tab) in `report-maker.h`
+
+Location: src/report/report-maker.h : 110
+Description: The destructor declaration `~report_maker();` is indented with 7 spaces instead of a single tab. Every other declaration in the class is tab-indented. Style guide mandates tabs only (style.md §1.1).
+Suggested fix: Replace the leading spaces with a single tab character.
+
+### Nit item #2 : Missing spaces around `=` in assignments in `report-data-html.cpp`
+
+Location: src/report/report-data-html.cpp : 5–6, 23–24, 29–35, and throughout
+Description: Many assignments lack spaces around the `=` operator, e.g. `div_attr->css_class=css_class;` and `str= dtmp.str();` (line 123). The project style follows standard K&R/Linux conventions that place spaces around binary operators.
+Suggested fix: Add spaces around `=` consistently, e.g. `div_attr->css_class = css_class;`.
+
+### Nit item #3 : `table_size` struct appears to be dead code
+
+Location: src/report/report-data-html.h : 27–30
+Description: The `table_size` struct (fields `rows` and `cols`) is declared but not referenced anywhere in the reviewed files or in the wider `src/report/` directory. It duplicates a subset of `table_attributes`.
+Suggested fix: Remove the unused `table_size` struct, or document its intended use.
+
+### Nit item #4 : Opening brace on same line as function parameter list in `report-data-html.cpp`
+
+Location: src/report/report-data-html.cpp : 10, 27, 37, 49, 61, 72, 85, 96, 106
+Description: Multiple function definitions place `{` on the same line as the closing `)` of the parameter list (e.g., `int rows, int cols){`). The project style guide (style.md §1.2) requires the opening brace of a function definition to be on its own line.
+Suggested fix: Move the `{` to the next line for each affected function.
+
+## Review of report-formatter-csv.cpp, report-formatter-html.cpp, dram_rapl_device.cpp, dram_rapl_device.h, cpu_linux.cpp — batch 14
+
+### Nit item #1 : Empty `init_markup()` body with placeholder comment
+
+Location: src/report/report-formatter-html.cpp : 61-63
+Description: `init_markup()` contains only the comment `/*here all html code*/` and is otherwise empty. It is called from the constructor but does nothing. This is dead placeholder code that adds noise without value.
+Severity rationale: Code quality nit; no functional impact.
+Suggested fix: Either populate the function or remove it and remove the call from the constructor.
+
+### Nit item #2 : C-style `(void)` parameter syntax in C++ code
+
+Location: src/cpu/dram_rapl_device.h : 52-53
+Description: `start_measurement(void)` and `end_measurement(void)` use the C-style explicit `void` parameter list. In C++, empty parentheses `()` are idiomatic and mean the same thing. This is a style inconsistency.
+Severity rationale: Purely cosmetic; no semantic difference in C++.
+Suggested fix:
+```cpp
+void start_measurement();
+void end_measurement();
+```
+
+### Nit item #3 : Trailing semicolons on method bodies in `dram_rapl_device.h`
+
+Location: src/cpu/dram_rapl_device.h : 48-49
+Description: The inline method definitions `{return "DRAM";}` are followed by an extra `;` after the closing brace (e.g., `virtual std::string device_name(void) {return "DRAM";};`). While harmless in C++, the trailing semicolons are unnecessary and inconsistent with the rest of the codebase.
+Severity rationale: Cosmetic nit.
+Suggested fix: Remove the trailing `;` after each method body's closing `}`.
+
+## Review of src/cpu/cpu_core.cpp, src/cpu/cpudevice.h, src/cpu/cpudevice.cpp, src/cpu/abstract_cpu.cpp, src/cpu/cpu_rapl_device.cpp — batch 15
+
+### Nit item #1 : Double semicolons `;;` in cpudevice.cpp constructor
+
+Location: src/cpu/cpudevice.cpp : 39-42
+Description: Each of the four index-initialisation lines ends with `;;` (double semicolons):
+e.g. `wake_index = get_param_index("cpu-wakeups");;`. This is a harmless no-op (an empty
+statement), but is clearly a typo and looks sloppy.
+Suggested fix: Remove the extra semicolons so each line ends with a single `;`.
+
+### Nit item #2 : Missing space around `==` operator in cpu_core.cpp
+
+Location: src/cpu/cpu_core.cpp : 78
+Description: `if (total_stamp ==0)` is missing a space before `==`. The project style (K&R /
+Linux kernel variant) requires spaces around binary operators.
+Suggested fix: Change to `if (total_stamp == 0)`.
+
+### Nit item #3 : `last_stamp = 0` assigned twice in `measurement_start`
+
+Location: src/cpu/abstract_cpu.cpp : 98, 127
+Description: `last_stamp = 0;` appears on line 98 and again on line 127 in the same function
+body with no intervening code that could change it. The second assignment is redundant.
+Suggested fix: Remove the duplicate assignment on line 127.
+
+### Nit item #4 : Unqualified `string` used in function signatures
+
+Location: src/cpu/cpu_core.cpp : 33; src/cpu/abstract_cpu.cpp : 262, 284, 343, 383
+Description: Several function signatures use unqualified `string` (e.g.
+`const string &linux_name`) rather than `std::string`. This only compiles because `cpu.h`
+contains `using namespace std;` (a separate violation). Style.md §4.3 and general-c++.md
+both require the `std::` prefix.
+Suggested fix: Use `const std::string &` consistently in all signatures.
+
+### Nit item #5 : Redundant loop-variable initialisation in destructor
+
+Location: src/cpu/abstract_cpu.cpp : 37-38
+Description: The destructor declares `unsigned int i=0;` and then immediately re-initialises
+it in the `for` statement (`for (i=0; ...)`). The separate declaration with `=0` is redundant.
+Suggested fix: Declare `i` inside the `for` statement: `for (unsigned int i = 0; i < cstates.size(); i++)`.
+
+## Review of src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp — batch 16
+
+### Nit item #1 : Missing spaces around operators and after commas
+
+Location: src/cpu/cpu_package.cpp : 88; src/cpu/cpu.cpp : 500, 708, 837, 466-468
+Description: Several places have missing spaces around operators and assignment:
+- `total_stamp ==0` (cpu_package.cpp:88, also intel_cpus.cpp:352, 484, 712)
+- `cpu_tbl_size.cols=(2 * ...` — no space around `=` (cpu.cpp:500)
+- `wmove(win, 2,0)` — no space after comma (cpu.cpp:837)
+- `idx1=0; idx2=0; idx3=0;` — no spaces around `=` (cpu.cpp:466-468)
+The project style uses spaces around operators consistently throughout other files.
+Severity rationale: Pure cosmetic style issue.
+Suggested fix: Add spaces to match project style: `total_stamp == 0`, `idx1 = 0`, etc.
+
+### Nit item #2 : Bare `string` without `std::` in .cpp files
+
+Location: src/cpu/cpu.cpp : 462, 661; src/cpu/cpu_package.cpp : 43
+Description: `string tmp_str;` (cpu.cpp:462, 661) and `const string &separator`
+(cpu_package.cpp:43) use unqualified `string` instead of `std::string`. These work
+only because of the `using namespace std;` in the included headers; once that is
+corrected these will need to be qualified.
+Severity rationale: Style issue that will become a compile error once `using namespace std` is removed from headers.
+Suggested fix: Use `std::string` consistently.
+
+### Nit item #3 : Mixed indentation (spaces instead of tabs) in cpu.cpp
+
+Location: src/cpu/cpu.cpp : 461, 656, 837
+Description: Several lines use leading spaces instead of tabs for indentation
+(e.g. `       \tint idx1, idx2, idx3;` at line 461, `        report.add_div(...)` at line
+656, `        wmove(win, 2,0)` at line 837). The project style mandates tabs only.
+Severity rationale: Pure cosmetic style issue.
+Suggested fix: Convert leading spaces to tabs in these lines.
+
+## Review of src/cpu/intel_cpus.h, src/cpu/intel_gpu.cpp, src/cpu/rapl/rapl_interface.cpp, src/wakeup/wakeup.h — batch 17
+
+### Nit item #1 : Trailing semicolon after inline method closing brace
+
+Location: src/cpu/intel_cpus.h : 86, 109, 128
+Description: Three inline method definitions end with `{ return 0;};` — the trailing semicolon after `}` is redundant. Example: `virtual int can_collapse(void) { return 0;};`. In standard C++ the semicolon after a function body's `}` is only required for class/struct definitions, not for member function definitions.
+Severity rationale: Minor style noise; superfluous punctuation.
+Suggested fix: Remove the trailing semicolons: `virtual int can_collapse(void) { return 0; }`.
+
+### Nit item #2 : Typo in MSR define names — `ENERY` instead of `ENERGY`
+
+Location: src/cpu/rapl/rapl_interface.cpp : 50, 55, 60, 66
+Description: Four `#define` constants are misspelled: `MSR_PKG_ENERY_STATUS`, `MSR_DRAM_ENERY_STATUS`, `MSR_PP0_ENERY_STATUS`, `MSR_PP1_ENERY_STATUS`. The word "ENERGY" is missing its second 'G'.
+Severity rationale: Cosmetic typo in macro names; no functional impact since the names are used consistently.
+Suggested fix: Rename all four macros to use `ENERGY` and update all references.
+
+### Nit item #3 : Trailing whitespace in intel_gpu.cpp switch statement
+
+Location: src/cpu/intel_gpu.cpp : 68
+Description: The line `switch (line_nr) {` is followed by a trailing tab character, violating the "no trailing whitespace" rule from style.md §1.1.
+Severity rationale: Trailing whitespace style violation.
+Suggested fix: Remove the trailing tab.
+
+### Nit item #4 : Missing space in `#include<vector>` directive
+
+Location: src/wakeup/wakeup.h : 28
+Description: The include directive is written as `#include<vector>` without the conventional space between `#include` and the angle-bracket filename. All other includes in the project and file use `#include <...>`.
+Severity rationale: Minor inconsistency in formatting.
+Suggested fix: Change to `#include <vector>`.
+
+## Review of wakeup_usb.h, wakeup_ethernet.h, waketab.cpp, wakeup_ethernet.cpp, wakeup.cpp — batch 18
+
+### Nit item #1 : missing spaces around `=` and before `{` in report_show_wakeup
+
+Location: src/wakeup/waketab.cpp : 141-142
+Description: Line 141 has `if (rows > 0){` (missing space before `{`), and line 142 has `rows= rows + 1;` (missing space after `=`). Both are style violations per the K&R/Linux coding style used by the project.
+Severity rationale: Nit — purely cosmetic, but inconsistent with the surrounding code.
+Suggested fix:
+```cpp
+if (rows > 0) {
+    rows = rows + 1;
+```
+
+### Nit item #2 : redundant `string(...)` cast in report_show_wakeup
+
+Location: src/wakeup/waketab.cpp : 158
+Description: `wakeup_data[idx] = string(wakeup_all[i]->wakeup_toggle_script())` — the explicit `string()` constructor call is redundant because `wakeup_toggle_script()` already returns `std::string`, and the assignment operator would copy-assign it directly.
+Severity rationale: Nit — no functional issue; just unnecessary noise.
+Suggested fix:
+```cpp
+wakeup_data[idx] = wakeup_all[i]->wakeup_toggle_script();
+```
+
+### Nit item #3 : inconsistent loop variable names (tgb vs gb) in report_show_wakeup
+
+Location: src/wakeup/waketab.cpp : 133, 153
+Description: The first loop uses `int tgb` and the second loop uses `int gb` for the same logical value (result of `wakeup_value()`). The inconsistency makes the relationship between the two loops harder to see and suggests the code was written in separate passes.
+Severity rationale: Nit — no functional impact; purely a readability issue.
+Suggested fix: Use a consistent name, e.g., `val`, in both loops.
+
+### Nit item #4 : missing space after comma in wmove call
+
+Location: src/wakeup/waketab.cpp : 69
+Description: `wmove(win, 1,0)` is missing a space after the second comma. The rest of the codebase consistently puts a space after each comma in argument lists.
+Severity rationale: Nit — cosmetic style inconsistency.
+Suggested fix: `wmove(win, 1, 0);`
+
+## Review of src/wakeup/wakeup_usb.cpp, src/measurement/acpi.cpp, src/measurement/acpi.h, src/measurement/opal-sensors.cpp, src/measurement/opal-sensors.h — batch 19
+
+### Nit item #1 : Redundant `class` keyword in `new` expression
+
+Location: src/wakeup/wakeup_usb.cpp : 104
+Description: `usb = new class usb_wakeup(filename, d_name);` — the `class` keyword before the type name in a `new` expression is valid C++ but entirely redundant and unusual. This is a C-ism not needed in C++.
+Severity rationale: Nit — purely stylistic, no functional impact.
+Suggested fix: `usb = new usb_wakeup(filename, d_name);`
+
+### Nit item #2 : GCC `__unused` attribute instead of C++17 `[[maybe_unused]]`
+
+Location: src/wakeup/wakeup_usb.cpp : 48
+Description: The `path` constructor parameter uses the GCC-specific `__unused` macro instead of the standard C++17 (and C++20) attribute `[[maybe_unused]]`. The project targets C++20 and should use standard attributes.
+Severity rationale: Nit — non-portable; `[[maybe_unused]]` is the correct C++ idiom.
+Suggested fix: `usb_wakeup::usb_wakeup(const std::string &path [[maybe_unused]], const std::string &iface)`
+
+### Nit item #3 : Unprofessional comment in `acpi_power_meter::measure()`
+
+Location: src/measurement/acpi.cpp : 111
+Description: The comment reads `/* BIOS report random crack-inspired units. Lets try to get to the Si-system units */`. The phrase "crack-inspired" is unprofessional and inappropriate in a project codebase. Minor grammar issue: "Lets" should be "Let's".
+Severity rationale: Nit — code quality and professionalism.
+Suggested fix: Replace with: `/* BIOS firmware may report non-SI units; normalise to SI. */`
+
+### Nit item #4 : Old-style `#ifndef` header guard in acpi.h
+
+Location: src/measurement/acpi.h : 25-26
+Description: Uses `#ifndef __INCLUDE_GUARD_ACPI_H` / `#define __INCLUDE_GUARD_ACPI_H` instead of `#pragma once` as required by the project style guide (style.md §4.1).
+Severity rationale: Nit — direct style-guide violation; `#pragma once` is simpler and universally supported by all targeted compilers.
+Suggested fix: Replace lines 25-26 and 44 with a single `#pragma once`.
+
+### Nit item #5 : Old-style `#ifndef` header guard in opal-sensors.h
+
+Location: src/measurement/opal-sensors.h : 25-26
+Description: Same as Nit item #4 above — uses `#ifndef INCLUDE_GUARD_OPAL_SENSORS_H` instead of `#pragma once`.
+Severity rationale: Nit — same rationale.
+Suggested fix: Replace with `#pragma once`.
+
+### Nit item #6 : Trailing semicolon after empty function bodies in opal-sensors.h
+
+Location: src/measurement/opal-sensors.h : 34-35
+Description: `virtual void start_measurement(void) {};` and `virtual void end_measurement(void) {};` have a trailing `;` after the closing brace. While syntactically valid (it is an empty statement), this is not idiomatic C++ and is not used consistently elsewhere.
+Severity rationale: Nit — minor style inconsistency.
+Suggested fix: Remove the trailing `;` from both lines.
+
+### Nit item #7 : Unnecessary `#include <iostream>` in acpi.cpp
+
+Location: src/measurement/acpi.cpp : 27
+Description: `<iostream>` is included but no `std::cin`, `std::cout`, `std::cerr`, or any other iostream symbol is used anywhere in the file. This is a dead include.
+Severity rationale: Nit — dead include, minor readability issue.
+Suggested fix: Remove `#include <iostream>`.
+
+## Review of sysfs.h, sysfs.cpp, measurement.h, measurement.cpp, extech.h — batch 20
+
+### Nit item #1 : Redundant `this->` in sysfs_power_meter::measure
+
+Location: src/measurement/sysfs.cpp : 133, 139
+Description: `this->set_discharging(false)` and `this->set_discharging(true)` use an explicit `this->` that is unnecessary in non-template context. The calls are unambiguous without it.
+Severity rationale: Purely cosmetic; no functional impact.
+Suggested fix: Remove `this->` and write `set_discharging(false);` / `set_discharging(true);`.
+
+### Nit item #2 : Redundant default-initialization of `name` in power_meter default constructor
+
+Location: src/measurement/measurement.h : 38
+Description: `power_meter() : name("") {}` explicitly initializes `std::string name` to an empty string. `std::string` already default-initializes to `""`, so the explicit initializer is redundant.
+Severity rationale: Cosmetic/clarity.
+Suggested fix: `power_meter() = default;` or simply `power_meter() {}`.
+
+### Nit item #3 : Stray semicolons after closing brace `}` in class bodies
+
+Location: src/measurement/measurement.h : 39; src/measurement/extech.h : 47
+Description: Both `virtual ~power_meter() {};` and `virtual double dev_capacity(void) { return 0.0; };` have a trailing semicolon after the closing `}` of the inline body. The semicolon is syntactically harmless (empty declaration) but is not idiomatic and may confuse readers.
+Severity rationale: Cosmetic.
+Suggested fix: Remove the trailing semicolons.
+
+### Nit item #4 : `new class extech_power_meter` uses C-style `class` keyword
+
+Location: src/measurement/measurement.cpp : 183
+Description: `new class extech_power_meter(devnode)` prefixes the type name with `class`, which is a C-style elaborated type specifier. In idiomatic C++ the `class` keyword is omitted in expressions.
+Severity rationale: Cosmetic; compiles correctly but is non-idiomatic.
+Suggested fix: `new extech_power_meter(devnode)` (also apply `std::nothrow` per Medium item #5).
+
+### Nit item #5 : Local variable names shadow virtual method names in sysfs.cpp
+
+Location: src/measurement/sysfs.cpp : 72, 86, 102, 115
+Description: Local variable names `power`, `current`, `energy`, and `charge` shadow the inherited virtual method `power_meter::power()`. The code compiles correctly because C++ disambiguates method calls from variables, but the shadowing makes the code harder to read at a glance.
+Severity rationale: Readability; no functional impact.
+Suggested fix: Rename the locals to e.g. `power_uw`, `current_ua`, `energy_uwh`, `charge_uah` to reflect their units and avoid shadowing.
+
+## Review of src/measurement/extech.cpp, src/devices/backlight.cpp — batch 21
+
+### Nit item #1 : C-style cast and `return 0` instead of `nullptr` in thread_proc
+
+Location: src/measurement/extech.cpp : 321-323
+Description: `thread_proc` uses a C-style cast `(class extech_power_meter*)arg` instead of `static_cast<extech_power_meter*>(arg)`, and returns `0` instead of `nullptr` for a `void *` return type.
+Severity rationale: Style nit; C-style casts are discouraged in C++20.
+Suggested fix: `return static_cast<extech_power_meter*>(arg);` pattern plus `return nullptr;`.
+
+### Nit item #2 : `&p.buf` passed to read() instead of `p.buf`
+
+Location: src/measurement/extech.cpp : 258
+Description: `read(fd, &p.buf, 250)` takes the address of the array `p.buf`, yielding a `char (*)[256]` rather than a `char *`. Both decay to the same pointer value, so it works, but it is technically taking the address of the array object, not a pointer to the first element.
+Severity rationale: Cosmetic; no practical impact due to pointer equivalence.
+Suggested fix: Change to `read(fd, p.buf, 250)`.
+
+### Nit item #3 : `bl_boost_index80` and `bl_boost_index100` not explicitly zero-initialized
+
+Location: src/devices/backlight.cpp : 143
+Description: The static local variables `bl_boost_index80` and `bl_boost_index100` are declared without an explicit initializer in the same declaration that zero-initializes the other four variables. They are implicitly zero-initialized because they are `static`, but the omission is inconsistent and confusing.
+Severity rationale: Cosmetic inconsistency.
+Suggested fix: Add `= 0` to both: `static int bl_index = 0, blp_index = 0, bl_boost_index40 = 0, bl_boost_index80 = 0, bl_boost_index100 = 0;`.
+
+### Nit item #4 : Extra space before `<` operator in rfkill::utilization()
+
+Location: src/devices/rfkill.cpp : 97
+Description: `if (rfk <  start_hard+end_hard)` has two spaces before `start_hard`, and no spaces around the `+` operators. Inconsistent spacing.
+Severity rationale: Formatting nit.
+Suggested fix: `if (rfk < start_hard + end_hard)`.
+
+### Nit item #5 : `for (i = 0; i < 1; i++)` is an unnecessary loop for a single iteration
+
+Location: src/measurement/extech.cpp : 222
+Description: A `for` loop that always executes exactly once (bound of `< 1`) adds no value and obscures the intent. Either the bound is wrong (see Medium item #3) or the loop should be removed.
+Severity rationale: Clarity nit.
+Suggested fix: If only one iteration is intended, remove the loop and use `i = 0` directly. If four iterations are intended, fix the bound as noted in Medium item #3.
+
+## Review of src/devices/usb.h, src/devices/usb.cpp, src/devices/gpu_rapl_device.h, src/devices/gpu_rapl_device.cpp, src/devices/ahci.h — batch 22
+
+### Nit item #1 : Spaces instead of tabs on usb.cpp line 120
+
+Location: src/devices/usb.cpp : 120
+Description: The line `        register_devpower(devfs_name, power_usage(results, bundle), this);` uses 8 spaces for indentation instead of a tab character. Every other line in the file uses tabs. The project style (`style.md §1.1`) mandates tabs only.
+Severity rationale: Style nit; single inconsistent indentation character.
+Suggested fix: Replace the leading 8 spaces with a single tab.
+
+### Nit item #2 : C-style `(void)` parameter notation in method declarations
+
+Location: src/devices/usb.h : 50-61, src/devices/ahci.h : 53-56, src/devices/gpu_rapl_device.h : 47-53
+Description: Methods are declared with `(void)` to indicate no parameters (e.g., `virtual void start_measurement(void);`). In C++ the idiomatic form is empty parentheses `()`. The `(void)` form is a C90 convention to distinguish "no parameters" from "unspecified parameters" — a distinction that does not apply in C++.
+Severity rationale: Style nit; C idiom in C++ code.
+Suggested fix: Change all `(void)` parameter lists to `()` in method declarations.
+
+### Nit item #3 : Extra blank line inside usb.cpp constructor body
+
+Location: src/devices/usb.cpp : 63
+Description: There is a blank line between the `cached_valid = 0;` statement and the `/* root ports and hubs ... */` comment inside the constructor. While a single blank line for visual grouping is fine, the line at 63 is entirely redundant as line 62 already provides separation. Minor visual noise.
+Severity rationale: Style nit.
+Suggested fix: Remove the extra blank line.
+
+
+## Review of src/devices/ahci.cpp, src/devices/thinkpad-fan.h, src/devices/thinkpad-fan.cpp, src/devices/device.h, src/devices/device.cpp — batch 23
+
+### Nit item #1 : Space indentation instead of tabs in `report_devices`
+
+Location: src/devices/device.cpp : 155–156, 160–161
+Description: Lines `if (!win)`, `return;`, `wclear(win);`, and `wmove(win, 2,0);` are indented with 8 spaces instead of a tab. style.md §1.1 requires "Tabs only" for indentation.
+Severity rationale: Style inconsistency; does not affect behaviour.
+Suggested fix: Replace the leading spaces on those lines with a single tab character.
+
+### Nit item #2 : Missing spaces around `==` operator in character comparisons
+
+Location: src/devices/ahci.cpp : 61, 91
+Description: `d_name[0]=='.'` (line 61 and similarly line 91) omits spaces around the `==` operator. The project consistently uses spaces around binary operators elsewhere.
+Severity rationale: Minor style inconsistency.
+Suggested fix: `d_name[0] == '.'`
+
+### Nit item #3 : Missing space before `{` in `for` loop
+
+Location: src/devices/ahci.cpp : 299
+Description: `for (i = 0; i < links.size(); i++){` — the opening brace immediately follows `)` with no space. style.md §1.2 (K&R style) requires a space before `{`.
+Severity rationale: Style inconsistency.
+Suggested fix: `for (i = 0; i < links.size(); i++) {`
+
+### Nit item #4 : Extra semicolons after inline method definition closing braces in thinkpad-fan.h
+
+Location: src/devices/thinkpad-fan.h : 45–52
+Description: Inline methods such as `virtual std::string class_name(void) { return "fan";};` have a redundant `;` after the closing `}`. The `;` is not illegal (it is an empty declaration) but is unnecessary and inconsistent with common style.
+Severity rationale: Cosmetic; harmless.
+Suggested fix: Remove the trailing `;` after each inline method body's `}`.
+
+### Nit item #5 : String parameter `shortname` marked `__unused` but passed to recursive helper
+
+Location: src/devices/ahci.cpp : 47
+Description: `disk_name` accepts `const string &shortname __unused`, marking the parameter as unused. However, the function does use `shortname` conceptually (it was passed for fallback use); the `__unused` attribute suppresses the warning but also obscures intent. More precisely, the variable is genuinely unused inside `disk_name` — it was passed in but the code never reads it. Consider removing the parameter entirely and updating the call site in `model_name` at line 98 (`disk_name(pathname, d_name, shortname)` → `disk_name(pathname, d_name)`).
+Severity rationale: Interface clarity nit; unused parameter that is silently ignored.
+Suggested fix: Remove `shortname` from the `disk_name` signature and its call site.
+## Review of src/devices/devfreq.cpp, src/devices/devfreq.h, src/devices/alsa.h, src/devices/alsa.cpp, src/devices/runtime_pm.cpp — batch 24
+
+### Nit item #1 : Trailing semicolons after closing braces on inline virtual functions in devfreq.h
+
+Location: src/devices/devfreq.h : 59-65
+Description: Inline virtual method definitions end with `};` (semicolon after the closing brace), e.g. `virtual std::string class_name(void) { return "devfreq";};`. The trailing semicolon is not required and inconsistent with the rest of the codebase.
+Severity rationale: Minor style nit; not a correctness issue.
+Suggested fix: Remove the trailing semicolons: `virtual std::string class_name(void) { return "devfreq"; }`
+
+### Nit item #2 : Missing spaces around operators in `for` loop in devfreq.cpp
+
+Location: src/devices/devfreq.cpp : 76, 108, 164, 213, 220, 287, 292, 315, 318
+Description: Several `for` loops use compact forms like `for (i=0; i<all_devfreq.size(); i++)` without spaces around `=` and `<`. The project style follows Linux kernel conventions which use `i = 0`, `i < n`, `i++` with spaces.
+Severity rationale: Cosmetic style inconsistency.
+Suggested fix: `for (i = 0; i < all_devfreq.size(); i++)`
+
+### Nit item #3 : `parse_devfreq_trans_stat()` parameter `dname` is unused
+
+Location: src/devices/devfreq.cpp : 121
+Description: The function signature is `void devfreq::parse_devfreq_trans_stat(const string &dname __unused)` but the function always uses the member variable `dir_name` instead of the parameter. The `__unused` annotation confirms the parameter is never read. The parameter should either be removed or the function refactored to use it.
+Severity rationale: Dead parameter causes confusion about the function's interface.
+Suggested fix: Remove the `dname` parameter and update the declaration in devfreq.h accordingly; the function uses `dir_name` exclusively.
+
+### Nit item #4 : `update_devfreq_freq_state()` does not break early on match
+
+Location: src/devices/devfreq.cpp : 108-111
+Description: The loop in `update_devfreq_freq_state()` scans the entire `dstates` vector even after finding the matching frequency. A `break` after the assignment on line 110 would avoid unnecessary iterations.
+Severity rationale: Minor inefficiency; no correctness impact.
+Suggested fix: Add `break;` after `state = dstates[i];` inside the `if` branch.
+
+## Review of runtime_pm.h, network.cpp, network.h, i915-gpu.h, i915-gpu.cpp — batch 25
+
+### Nit item #1 : Old-style `#ifndef` include guards instead of `#pragma once`
+
+Location: src/devices/runtime_pm.h : 25–26; src/devices/network.h : 25–26; src/devices/i915-gpu.h : 25–26
+Description: All three header files use `#ifndef _INCLUDE_GUARD_…` / `#define` / `#endif` include guards. The project style guide (style.md §4.1) specifies `#pragma once`.
+Suggested fix: Replace the `#ifndef`/`#define`/`#endif` triple with `#pragma once` at the top of each header.
+
+### Nit item #2 : C header `<limits.h>` included in C++ files
+
+Location: src/devices/runtime_pm.h : 28; src/devices/network.h : 29
+Description: Both headers include `<limits.h>` (the C header) rather than the C++ equivalent `<climits>`. In C++ code, C++ standard headers should be preferred.
+Suggested fix: Replace `#include <limits.h>` with `#include <climits>`.
+
+### Nit item #3 : C-style `(void)` parameter list in C++ virtual method declarations
+
+Location: src/devices/runtime_pm.h : 46, 47, 49, 51–59; src/devices/network.h : 69–81; src/devices/i915-gpu.h : 40–55
+Description: Method declarations use the C idiom `(void)` for parameterless functions (e.g., `virtual void start_measurement(void)`). In C++ the canonical form is empty parentheses `()`. This is a pervasive style inconsistency across all three headers.
+Suggested fix: Replace `(void)` with `()` in all C++ method declarations.
+
+### Nit item #4 : Duplicate `#include <unistd.h>` in network.cpp and i915-gpu.cpp
+
+Location: src/devices/network.cpp : 35 and 56; src/devices/i915-gpu.cpp : 31 and 45
+Description: `<unistd.h>` is included twice in each of these two translation units. The second inclusion (inside the `extern "C" { }` block in i915-gpu.cpp, and in the second include group in network.cpp) is redundant due to header guards.
+Suggested fix: Remove the duplicate `#include <unistd.h>` from each file.
+
+### Nit item #5 : Use `.empty()` instead of `.size()` for emptiness test
+
+Location: src/devices/i915-gpu.h : 48
+Description: `if (child_devices.size())` tests whether the vector is non-empty by checking its size. The idiomatic C++ expression is `if (!child_devices.empty())`, which is potentially O(1) and more expressive.
+Suggested fix: `if (!child_devices.empty())`
+
+### Nit item #6 : Index-based loop should be a range-based for loop
+
+Location: src/devices/i915-gpu.cpp : 105
+Description: `for (unsigned int i = 0; i < child_devices.size(); ++i)` is an index-based loop over a vector. In C++11 and later (this project uses C++20), a range-based for loop is cleaner and avoids the repeated index dereference.
+Suggested fix:
+```cpp
+for (auto *child : child_devices) {
+    child_power = child->power_usage(result, bundle);
+    if ((power - child_power) > 0.0)
+        power -= child_power;
+}
+```
+
+### Nit item #7 : Redundant `class` keyword in `new` expressions
+
+Location: src/devices/i915-gpu.cpp : 83, 86
+Description: `new class i915gpu()` and `new class gpu_rapl_device(gpu)` use the redundant `class` keyword before the type name in `new` expressions. In C++ the `class` keyword is not needed here.
+Suggested fix: `gpu = new i915gpu();` and `rapl_dev = new gpu_rapl_device(gpu);`
+
+## Review of src/devices/thinkpad-light.cpp, src/devices/thinkpad-light.h — batch 26
+
+### Nit item #1 : Duplicate `#include <unistd.h>` in thinkpad-light.cpp
+
+Location: src/devices/thinkpad-light.cpp : 32, 44
+Description: `<unistd.h>` is included twice; the first occurrence is at line 32 among the other system headers and the second at line 44 at the bottom of the include block.
+Suggested fix: Remove the duplicate `#include <unistd.h>` at line 44.
+
+### Nit item #2 : C standard headers appended after project headers — wrong include order
+
+Location: src/devices/thinkpad-light.cpp : 43–44
+Description: `#include <string.h>` and `#include <unistd.h>` appear at lines 43–44, after all project-specific headers. Per style.md §4.4, standard-library headers should come first, followed by project headers. These two includes should be moved up with the other system headers (lines 28–33).
+Suggested fix: Move `#include <string.h>` to the C-header block at the top of the file.
+
+### Nit item #3 : Stale comment "read the rpms of the light" in `start_measurement()`
+
+Location: src/devices/thinkpad-light.cpp : 57
+Description: The comment `/* read the rpms of the light */` is a copy-paste artefact from the fan device. The ThinkPad light has no RPMs; the code reads the LED brightness value.
+Suggested fix: Replace with `/* read brightness of the ThinkPad light */` or remove the comment entirely.
+
+### Nit item #4 : Redundant `class` keyword when declaring and allocating the device pointer
+
+Location: src/devices/thinkpad-light.cpp : 77, 86
+Description: `class thinkpad_light *light;` and `light = new class thinkpad_light();` use the unnecessary `class` keyword before the type name. This is a C-ism that is not required in C++ and is inconsistent with how allocations are done elsewhere in the codebase.
+Suggested fix: `thinkpad_light *light;` and `light = new thinkpad_light();`.

--- a/logs/summary.md
+++ b/logs/summary.md
@@ -1,0 +1,67 @@
+# PowerTOP Code Review — Summary
+
+## Batch 01 — src/calibrate/calibrate.cpp, src/calibrate/calibrate.h, src/lib.cpp, src/devlist.cpp, src/main.cpp
+- Critical: 0  High: 5  Medium: 10  Low: 7  Nit: 5
+
+## Batch 02 — src/test_framework.h, src/test_framework.cpp, src/display.cpp, src/display.h, src/lib.h
+- Critical: 0  High: 4  Medium: 11  Low: 7  Nit: 7
+
+## Batch 03 — src/devlist.h, src/tuning/tunable.cpp, src/tuning/tunable.h, src/tuning/runtime.h, src/tuning/runtime.cpp
+- Critical: 0  High: 3  Medium: 7  Low: 7  Nit: 7
+
+## Batch 04 — src/tuning/ethernet.cpp, src/tuning/ethernet.h, src/tuning/wifi.cpp, src/tuning/wifi.h, src/tuning/tuningusb.h
+- Critical: 0  High: 6  Medium: 6  Low: 5  Nit: 4
+
+## Batch 05 — src/tuning/tuningusb.cpp, src/tuning/tuning.cpp, src/tuning/tuning.h, src/tuning/bluetooth.cpp, src/tuning/bluetooth.h
+- Critical: 0  High: 3  Medium: 6  Low: 8  Nit: 6
+
+## Batch 06 — src/tuning/tuningsysfs.cpp, src/tuning/tuningsysfs.h, src/tuning/nl80211.h, src/tuning/iw.h, src/tuning/iw.c
+- Critical: 0  High: 3  Medium: 5  Low: 8  Nit: 3
+
+## Batch 07 — src/tuning/tuningi2c.h, src/tuning/tuningi2c.cpp, src/process/powerconsumer.h, src/process/powerconsumer.cpp, src/process/processdevice.h
+- Critical: 0  High: 1  Medium: 8  Low: 7  Nit: 4
+
+## Batch 08 — src/process/processdevice.cpp, src/process/process.h, src/process/process.cpp, src/process/work.cpp, src/process/work.h
+- Critical: 0  High: 2  Medium: 8  Low: 4  Nit: 4
+## Batch 09 — src/process/interrupt.h, src/process/interrupt.cpp, src/process/timer.cpp, src/process/timer.h, src/process/do_process.cpp
+- Critical: 2  High: 7  Medium: 8  Low: 6  Nit: 4
+
+## Batch 10 — src/perf/perf.h, src/perf/perf_event.h, src/perf/perf_bundle.cpp, src/perf/perf_bundle.h, src/perf/perf.cpp
+- Critical: 3  High: 3  Medium: 9  Low: 7  Nit: 10
+
+## Batch 11 — src/parameters/persistent.cpp, src/parameters/parameters.cpp, src/parameters/parameters.h, src/parameters/learn.cpp, src/report/report-formatter.h
+- Critical: 0  High: 5  Medium: 6  Low: 5  Nit: 4
+
+## Batch 12 — src/report/report-formatter-html.h, src/report/report.cpp, src/report/report.h, src/report/report-formatter-csv.h, src/report/report-maker.cpp
+- Critical: 0  High: 3  Medium: 5  Low: 4  Nit: 2
+## Batch 13 — src/report/report-maker.h, src/report/report-data-html.cpp, src/report/report-data-html.h, src/report/report-formatter-base.cpp, src/report/report-formatter-base.h
+- Critical: 0  High: 2  Medium: 7  Low: 3  Nit: 4
+## Batch 14 — src/report/report-formatter-html.cpp, src/report/report-formatter-csv.cpp, src/cpu/dram_rapl_device.cpp, src/cpu/dram_rapl_device.h, src/cpu/cpu_linux.cpp
+- Critical: 0  High: 2  Medium: 4  Low: 7  Nit: 3
+## Batch 15 — src/cpu/cpu_core.cpp, src/cpu/cpudevice.h, src/cpu/cpudevice.cpp, src/cpu/abstract_cpu.cpp, src/cpu/cpu_rapl_device.cpp
+- Critical: 0  High: 2  Medium: 3  Low: 5  Nit: 5
+## Batch 16 — src/cpu/cpu_rapl_device.h, src/cpu/cpu_package.cpp, src/cpu/cpu.h, src/cpu/cpu.cpp, src/cpu/intel_cpus.cpp
+- Critical: 1  High: 4  Medium: 8  Low: 5  Nit: 3
+## Batch 17 — src/cpu/intel_cpus.h, src/cpu/intel_gpu.cpp, src/cpu/rapl/rapl_interface.cpp, src/cpu/rapl/rapl_interface.h, src/wakeup/wakeup.h
+- Critical: 0  High: 2  Medium: 6  Low: 6  Nit: 4
+## Batch 18 — src/wakeup/wakeup_usb.h, src/wakeup/wakeup_ethernet.h, src/wakeup/waketab.cpp, src/wakeup/wakeup_ethernet.cpp, src/wakeup/wakeup.cpp
+- Critical: 0  High: 3  Medium: 3  Low: 5  Nit: 4
+## Batch 19 — src/wakeup/wakeup_usb.cpp, src/measurement/acpi.cpp, src/measurement/acpi.h, src/measurement/opal-sensors.cpp, src/measurement/opal-sensors.h
+- Critical: 0  High: 1  Medium: 2  Low: 4  Nit: 7
+## Batch 20 — src/measurement/sysfs.h, src/measurement/sysfs.cpp, src/measurement/measurement.h, src/measurement/measurement.cpp, src/measurement/extech.h
+- Critical: 0  High: 3  Medium: 5  Low: 4  Nit: 5
+## Batch 21 — src/measurement/extech.cpp, src/devices/backlight.h, src/devices/backlight.cpp, src/devices/rfkill.h, src/devices/rfkill.cpp
+- Critical: 1  High: 3  Medium: 7  Low: 5  Nit: 5
+## Batch 22 — src/devices/usb.h, src/devices/usb.cpp, src/devices/gpu_rapl_device.h, src/devices/gpu_rapl_device.cpp, src/devices/ahci.h
+- Critical: 0  High: 2  Medium: 6  Low: 7  Nit: 3
+## Batch 23 — src/devices/ahci.cpp, src/devices/thinkpad-fan.h, src/devices/thinkpad-fan.cpp, src/devices/device.h, src/devices/device.cpp
+- Critical: 0  High: 3  Medium: 8  Low: 6  Nit: 5
+## Batch 24 — src/devices/devfreq.cpp, src/devices/devfreq.h, src/devices/alsa.h, src/devices/alsa.cpp, src/devices/runtime_pm.cpp
+- Critical: 0  High: 3  Medium: 8  Low: 6  Nit: 4
+## Batch 25 — src/devices/runtime_pm.h, src/devices/network.cpp, src/devices/network.h, src/devices/i915-gpu.h, src/devices/i915-gpu.cpp
+- Critical: 0  High: 3  Medium: 6  Low: 9  Nit: 7
+## Batch 26 — src/devices/thinkpad-light.cpp, src/devices/thinkpad-light.h
+- Critical: 0  High: 0  Medium: 3  Low: 4  Nit: 4
+
+## GRAND TOTAL (all 26 batches)
+- Critical: 7  High: 78  Medium: 165  Low: 151  Nit: 123

--- a/src/calibrate/calibrate.cpp
+++ b/src/calibrate/calibrate.cpp
@@ -46,13 +46,13 @@ extern "C" {
 #include <string>
 
 
-static vector<string> usb_devices;
-static vector<string> rfkill_devices;
-static vector<string> backlight_devices;
-static vector<string> scsi_link_devices;
+static std::vector<std::string> usb_devices;
+static std::vector<std::string> rfkill_devices;
+static std::vector<std::string> backlight_devices;
+static std::vector<std::string> scsi_link_devices;
 static int blmax;
 
-static map<string, string> saved_sysfs;
+static std::map<std::string, std::string> saved_sysfs;
 
 
 static volatile int stop_measurement;
@@ -67,7 +67,7 @@ static void save_sysfs(const std::string &filename)
 
 static void restore_all_sysfs(void)
 {
-	map<string, string>::iterator it;
+	std::map<std::string, std::string>::iterator it;
 
 	for (it = saved_sysfs.begin(); it != saved_sysfs.end(); it++)
 		write_sysfs(it->first, it->second);
@@ -384,7 +384,7 @@ void calibrate(void)
 
         save_sysfs("/sys/module/snd_hda_intel/parameters/power_save");
 
-	cout << _("Starting PowerTOP power estimate calibration \n");
+	std::cout << _("Starting PowerTOP power estimate calibration \n");
 	suspend_all_usb_devices();
 	rfkill_all_radios();
 	lower_backlight();
@@ -407,7 +407,7 @@ void calibrate(void)
 	usb_calibration();
 	rfkill_calibration();
 
-	cout << _("Finishing PowerTOP power estimate calibration \n");
+	std::cout << _("Finishing PowerTOP power estimate calibration \n");
 
 	restore_all_sysfs();
         learn_parameters(300, 1);

--- a/src/calibrate/calibrate.cpp
+++ b/src/calibrate/calibrate.cpp
@@ -238,17 +238,22 @@ static void *burn_disk(void *dummy __unused)
 static void cpu_calibration(int threads)
 {
 	int i;
-	pthread_t thr;
+	std::vector<pthread_t> thr_vec;
 
 	printf(_("Calibrating: CPU usage on %i threads\n"), threads);
 
 	stop_measurement = 0;
-	for (i = 0; i < threads; i++)
+	for (i = 0; i < threads; i++) {
+		pthread_t thr;
 		pthread_create(&thr, NULL, burn_cpu, NULL);
+		thr_vec.push_back(thr);
+	}
 
 	one_measurement(15, 15, "");
 	stop_measurement = 1;
 	sleep(1);
+	for (auto &thr : thr_vec)
+		pthread_join(thr, NULL);
 }
 
 static void wakeup_calibration(unsigned long interval)
@@ -264,6 +269,7 @@ static void wakeup_calibration(unsigned long interval)
 	one_measurement(15, 15, "");
 	stop_measurement = 1;
 	sleep(1);
+	pthread_join(thr, NULL);
 }
 
 static void usb_calibration(void)
@@ -337,20 +343,20 @@ static void backlight_calibration(void)
 		sleep(1);
 	}
 	printf(_("Calibrating idle\n"));
-	if(!system("DISPLAY=:0 /usr/bin/xset dpms force off"))
+	if (system("DISPLAY=:0 /usr/bin/xset dpms force off") != 0)
 		printf("System is not available\n");
 	one_measurement(15, 15, "");
-	if(!system("DISPLAY=:0 /usr/bin/xset dpms force on"))
+	if (system("DISPLAY=:0 /usr/bin/xset dpms force on") != 0)
 		printf("System is not available\n");
 }
 
 static void idle_calibration(void)
 {
 	printf(_("Calibrating idle\n"));
-	if(!system("DISPLAY=:0 /usr/bin/xset dpms force off"))
+	if (system("DISPLAY=:0 /usr/bin/xset dpms force off") != 0)
 		printf("System is not available\n");
 	one_measurement(15, 15, "");
-	if(!system("DISPLAY=:0 /usr/bin/xset dpms force on"))
+	if (system("DISPLAY=:0 /usr/bin/xset dpms force on") != 0)
 		printf("System is not available\n");
 }
 
@@ -369,6 +375,7 @@ static void disk_calibration(void)
 	one_measurement(15, 15, "");
 	stop_measurement = 1;
 	sleep(1);
+	pthread_join(thr, NULL);
 
 
 }

--- a/src/calibrate/calibrate.cpp
+++ b/src/calibrate/calibrate.cpp
@@ -45,8 +45,6 @@ extern "C" {
 #include <vector>
 #include <string>
 
-using namespace std;
-
 
 static vector<string> usb_devices;
 static vector<string> rfkill_devices;

--- a/src/calibrate/calibrate.h
+++ b/src/calibrate/calibrate.h
@@ -22,11 +22,8 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef __INCLUDE_GUARD_CALIBRATE_H
-#define __INCLUDE_GUARD_CALIBRATE_H
+#pragma once
 
 extern void one_measurement(int seconds, int sample_interval, const std::string &workload);
 extern void calibrate(void);
 
-
-#endif

--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -226,7 +226,7 @@ void abstract_cpu::insert_cstate(const std::string &linux_name, const std::strin
 						if (cstates[pos]->human_name.length() > 2) {
 							if(c == cstates[pos]->human_name[1]){
 								if(i + 1 < human_name.length() && human_name[i+1] != cstates[pos]->human_name[2]){
-									greater_line_level = max(greater_line_level, cstates[pos]->line_level);
+									greater_line_level = std::max(greater_line_level, cstates[pos]->line_level);
 									state->line_level = greater_line_level + 1;
 								}
 							}
@@ -259,7 +259,7 @@ void abstract_cpu::insert_cstate(const std::string &linux_name, const std::strin
 	state->before_count = count;
 }
 
-void abstract_cpu::finalize_cstate(const string &linux_name, uint64_t usage, uint64_t duration, int count)
+void abstract_cpu::finalize_cstate(const std::string &linux_name, uint64_t usage, uint64_t duration, int count)
 {
 	unsigned int i;
 	struct idle_state *state = NULL;
@@ -272,7 +272,7 @@ void abstract_cpu::finalize_cstate(const string &linux_name, uint64_t usage, uin
 	}
 
 	if (!state) {
-		cout << "Invalid C state finalize " << linux_name << " \n";
+		std::cout << "Invalid C state finalize " << linux_name << " \n";
 		return;
 	}
 
@@ -281,7 +281,7 @@ void abstract_cpu::finalize_cstate(const string &linux_name, uint64_t usage, uin
 	state->after_count += count;
 }
 
-void abstract_cpu::update_cstate(const string &linux_name, const string &human_name, uint64_t usage, uint64_t duration, int count, int level)
+void abstract_cpu::update_cstate(const std::string &linux_name, const std::string &human_name, uint64_t usage, uint64_t duration, int count, int level)
 {
 	unsigned int i;
 	struct idle_state *state = NULL;
@@ -340,7 +340,7 @@ int abstract_cpu::has_pstate_level(int level)
 
 
 
-void abstract_cpu::insert_pstate(uint64_t freq, const string &human_name, uint64_t duration, int count)
+void abstract_cpu::insert_pstate(uint64_t freq, const std::string &human_name, uint64_t duration, int count)
 {
 	class frequency *state;
 
@@ -372,7 +372,7 @@ void abstract_cpu::finalize_pstate(uint64_t freq, uint64_t duration, int count)
 	}
 
 	if (!state) {
-		cout << "Invalid P state finalize " << freq << " \n";
+		std::cout << "Invalid P state finalize " << freq << " \n";
 		return;
 	}
 	state->time_after += duration;
@@ -380,7 +380,7 @@ void abstract_cpu::finalize_pstate(uint64_t freq, uint64_t duration, int count)
 
 }
 
-void abstract_cpu::update_pstate(uint64_t freq, const string &human_name, uint64_t duration, int count)
+void abstract_cpu::update_pstate(uint64_t freq, const std::string &human_name, uint64_t duration, int count)
 {
 	unsigned int i;
 	class frequency *state = NULL;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -620,7 +620,7 @@ void report_display_cpu_cstates(void)
 
 		init_pkg_table_attr(&std_table_css, pkg_tbl_size.rows,  pkg_tbl_size.cols);
 		report.add_table(pkg_data, &std_table_css);
-		if (!_core->can_collapse()){
+		if (_core && !_core->can_collapse()) {
 			init_core_table_attr(&std_table_css, title+1, core_tbl_size.rows,
 				core_tbl_size.cols);
 			report.add_table(core_data, &std_table_css);

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -46,7 +46,7 @@
 
 static class abstract_cpu system_level;
 
-vector<class abstract_cpu *> all_cpus;
+std::vector<class abstract_cpu *> all_cpus;
 
 static	class perf_bundle * perf_events;
 
@@ -367,7 +367,7 @@ static std::string fill_state_name(class abstract_cpu *acpu, int state, int line
 }
 
 static std::string fill_state_line(class abstract_cpu *acpu, int state, int line,
-					const string &sep = "")
+					const std::string &sep = "")
 {
 	switch (state) {
 		case PSTATE:
@@ -459,7 +459,7 @@ void report_display_cpu_cstates(void)
 
 	/* Set array of data in row Major order */
        	int idx1, idx2, idx3;
-	string tmp_str;
+	std::string tmp_str;
 
 	for (package = 0; package < system_level.children.size(); package++) {
 		bool first_core = true;
@@ -658,7 +658,7 @@ void report_display_cpu_pstates(void)
 
         /* Set array of data in row Major order */
 	int idx1, idx2, idx3, num_cpus=0, num_cores=0;
-        string tmp_str;
+        std::string tmp_str;
 
 	for (i = 0, pstates_num = 0; i < all_cpus.size(); i++) {
 		if (all_cpus[i])
@@ -946,7 +946,7 @@ void perf_power_bundle::handle_trace_point(void *trace, int cpunr, uint64_t time
 		return;
 
 	if (cpunr >= (int)all_cpus.size()) {
-		cout << "INVALID cpu nr in handle_trace_point\n";
+		std::cout << "INVALID cpu nr in handle_trace_point\n";
 		return;
 	}
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -951,14 +951,9 @@ void perf_power_bundle::handle_trace_point(void *trace, int cpunr, uint64_t time
 	}
 
 	cpu = all_cpus[cpunr];
+	if (!cpu)
+		return;
 
-#if 0
-	unsigned int i;
-	printf("Time is %llu \n", time);
-	for (i = 0; i < system_level.children.size(); i++)
-		if (system_level.children[i])
-			system_level.children[i]->validate();
-#endif
 	unsigned long long val;
 	int ret;
 	if (strcmp(event->name, "cpu_idle")==0) {

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -497,7 +497,10 @@ void report_display_cpu_cstates(void)
 				num_cpus+=1;
 			}
 		}
-		cpu_tbl_size.cols=(2 * (num_cpus / num_cores)) + 1;
+		if (num_cores > 0)
+			cpu_tbl_size.cols = (2 * (num_cpus / num_cores)) + 1;
+		else
+			cpu_tbl_size.cols = 1;
 		cpu_tbl_size.rows = ((cstates_num+1-LEVEL_HEADER) * _package->children.size())
 				+ _package->children.size();
 		std::vector<std::string> cpu_data(cpu_tbl_size.cols * cpu_tbl_size.rows);
@@ -705,7 +708,10 @@ void report_display_cpu_pstates(void)
 				num_cpus+=1;
 			}
 		}
-		cpu_tbl_size.cols= (num_cpus/ num_cores) + 1;
+		if (num_cores > 0)
+			cpu_tbl_size.cols = (num_cpus / num_cores) + 1;
+		else
+			cpu_tbl_size.cols = 1;
 		cpu_tbl_size.rows= (pstates_num+2) * _package->children.size()
 				+ _package->children.size();
 		std::vector<std::string> cpu_data(cpu_tbl_size.cols * cpu_tbl_size.rows);

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -44,18 +44,18 @@ struct idle_state {
 	std::string linux_name; /* state0 etc.. cpuidle name */
 	std::string human_name;
 
-	uint64_t usage_before;
-	uint64_t usage_after;
-	uint64_t usage_delta;
+	uint64_t usage_before = 0;
+	uint64_t usage_after = 0;
+	uint64_t usage_delta = 0;
 
-	uint64_t duration_before;
-	uint64_t duration_after;
-	uint64_t duration_delta;
+	uint64_t duration_before = 0;
+	uint64_t duration_after = 0;
+	uint64_t duration_delta = 0;
 
-	int before_count;
-	int after_count;
+	int before_count = 0;
+	int after_count = 0;
 
-	int line_level;
+	int line_level = 0;
 };
 
 class frequency {
@@ -78,9 +78,9 @@ public:
 class abstract_cpu
 {
 protected:
-	int	first_cpu;
+	int	first_cpu = 0;
 	struct timeval	stamp_before, stamp_after;
-	double  time_factor;
+	double  time_factor = 0.0;
 	uint64_t max_frequency = 0;
 	uint64_t max_minus_one_frequency = 0;
 
@@ -88,14 +88,14 @@ protected:
 	virtual void	freq_updated(uint64_t time);
 
 public:
-	uint64_t	last_stamp;
-	uint64_t	total_stamp;
-	int	number;
-	int	childcount;
+	uint64_t	last_stamp = 0;
+	uint64_t	total_stamp = 0;
+	int	number = 0;
+	int	childcount = 0;
 	std::string    name;
-	bool	idle, old_idle, has_intel_MSR;
-	uint64_t	current_frequency;
-	uint64_t	effective_frequency;
+	bool	idle = false, old_idle = false, has_intel_MSR = false;
+	uint64_t	current_frequency = 0;
+	uint64_t	effective_frequency = 0;
 
 	std::vector<class abstract_cpu *> children;
 	std::vector<struct idle_state *> cstates;
@@ -103,7 +103,7 @@ public:
 
 	virtual ~abstract_cpu();
 
-	class abstract_cpu *parent;
+	class abstract_cpu *parent = nullptr;
 
 
 	int	get_first_cpu() { return first_cpu; }

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -98,9 +98,9 @@ public:
 	uint64_t	current_frequency;
 	uint64_t	effective_frequency;
 
-	vector<class abstract_cpu *> children;
-	vector<struct idle_state *> cstates;
-	vector<struct frequency *> pstates;
+	std::vector<class abstract_cpu *> children;
+	std::vector<struct idle_state *> cstates;
+	std::vector<struct frequency *> pstates;
 
 	virtual ~abstract_cpu();
 
@@ -161,7 +161,7 @@ public:
 	virtual void reset_pstate_data(void);
 };
 
-extern vector<class abstract_cpu *> all_cpus;
+extern std::vector<class abstract_cpu *> all_cpus;
 
 class cpu_linux: public abstract_cpu
 {

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -33,8 +33,6 @@
 #include <sys/time.h>
 #include "../lib.h"
 
-using namespace std;
-
 class abstract_cpu;
 
 #define LEVEL_C0 -1

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -23,8 +23,7 @@
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
 
-#ifndef __INCLUDE_GUARD_CPUDEV_H
-#define __INCLUDE_GUARD_CPUDEV_H
+#pragma once
 
 #include <iostream>
 #include <vector>
@@ -225,4 +224,3 @@ extern void end_cpu_data(void);
 extern void clear_cpu_data(void);
 extern void clear_all_cpus(void);
 
-#endif

--- a/src/cpu/cpu_core.cpp
+++ b/src/cpu/cpu_core.cpp
@@ -30,7 +30,7 @@
 
 #include <format>
 
-std::string cpu_core::fill_cstate_line(int line_nr, const string &separator __unused)
+std::string cpu_core::fill_cstate_line(int line_nr, const std::string &separator __unused)
 {
 	unsigned int i;
 

--- a/src/cpu/cpu_linux.cpp
+++ b/src/cpu/cpu_linux.cpp
@@ -191,7 +191,7 @@ void cpu_linux::measurement_end(void)
 }
 #include <format>
 
-std::string cpu_linux::fill_cstate_line(int line_nr, const string &separator)
+std::string cpu_linux::fill_cstate_line(int line_nr, const std::string &separator)
 {
 	unsigned int i;
 

--- a/src/cpu/cpu_package.cpp
+++ b/src/cpu/cpu_package.cpp
@@ -40,7 +40,7 @@ void cpu_package::freq_updated(uint64_t time)
 
 #include <format>
 
-std::string cpu_package::fill_cstate_line(int line_nr, const string &separator __unused)
+std::string cpu_package::fill_cstate_line(int line_nr, const std::string &separator __unused)
 {
 	unsigned int i;
 

--- a/src/cpu/cpu_rapl_device.cpp
+++ b/src/cpu/cpu_rapl_device.cpp
@@ -28,7 +28,7 @@
 #include "../parameters/parameters.h"
 #include "cpu_rapl_device.h"
 
-cpu_rapl_device::cpu_rapl_device(cpudevice *parent, const string &classname, const string &dev_name, class abstract_cpu *_cpu)
+cpu_rapl_device::cpu_rapl_device(cpudevice *parent, const std::string &classname, const std::string &dev_name, class abstract_cpu *_cpu)
 	: cpudevice(classname, dev_name, _cpu),
 	  device_valid(false)
 {

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -33,11 +33,11 @@
 
 class cpu_rapl_device: public cpudevice {
 
-	c_rapl_interface *rapl;
-	time_t		last_time;
-	double		last_energy;
-	double 		consumed_power;
-	bool		device_valid;
+	c_rapl_interface *rapl = nullptr;
+	time_t		last_time = 0;
+	double		last_energy = 0.0;
+	double 		consumed_power = 0.0;
+	bool		device_valid = false;
 
 public:
 	cpu_rapl_device(cpudevice *parent, const std::string &classname = "cpu_core", const std::string &device_name = "cpu_core", class abstract_cpu *_cpu = NULL);

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -28,8 +28,6 @@
 #include <vector>
 #include <string>
 
-using namespace std;
-
 #include <sys/time.h>
 #include "cpudevice.h"
 #include "rapl/rapl_interface.h"

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Srinivas Pandruvada <Srinivas.Pandruvada@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_CPU_RAPL_DEVICE_H
-#define _INCLUDE_GUARD_CPU_RAPL_DEVICE_H
+#pragma once
 
 #include <vector>
 #include <string>
@@ -52,5 +51,3 @@ public:
 
 };
 
-
-#endif

--- a/src/cpu/cpudevice.h
+++ b/src/cpu/cpudevice.h
@@ -36,11 +36,11 @@ protected:
 	std::string _cpuname;
 
 	std::vector<std::string> params;
-	class abstract_cpu *cpu;
-	int wake_index;
-	int consumption_index;
-	int r_wake_index;
-	int r_consumption_index;
+	class abstract_cpu *cpu = nullptr;
+	int wake_index = 0;
+	int consumption_index = 0;
+	int r_wake_index = 0;
+	int r_consumption_index = 0;
 
 	std::vector<device *>child_devices;
 

--- a/src/cpu/cpudevice.h
+++ b/src/cpu/cpudevice.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_CPUDEVICE_H
-#define _INCLUDE_GUARD_CPUDEVICE_H
+#pragma once
 
 #include <vector>
 #include <string>
@@ -58,5 +57,3 @@ public:
 	void add_child(device *dev_ptr) { child_devices.push_back(dev_ptr);}
 };
 
-
-#endif

--- a/src/cpu/cpudevice.h
+++ b/src/cpu/cpudevice.h
@@ -28,8 +28,6 @@
 #include <vector>
 #include <string>
 
-using namespace std;
-
 #include "../devices/device.h"
 #include "cpu.h"
 

--- a/src/cpu/dram_rapl_device.cpp
+++ b/src/cpu/dram_rapl_device.cpp
@@ -29,7 +29,7 @@
 #include "dram_rapl_device.h"
 
 
-dram_rapl_device::dram_rapl_device(cpudevice *parent, const string &classname, const string &dev_name, class abstract_cpu *_cpu)
+dram_rapl_device::dram_rapl_device(cpudevice *parent, const std::string &classname, const std::string &dev_name, class abstract_cpu *_cpu)
 	: cpudevice(classname, dev_name, _cpu),
 	  device_valid(false)
 {

--- a/src/cpu/dram_rapl_device.h
+++ b/src/cpu/dram_rapl_device.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Srinivas Pandruvada <Srinivas.Pandruvada@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_DRAM_RAPL_DEVICE_H
-#define _INCLUDE_GUARD_DRAM_RAPL_DEVICE_H
+#pragma once
 
 #include <vector>
 #include <string>
@@ -52,5 +51,3 @@ public:
 
 };
 
-
-#endif

--- a/src/cpu/dram_rapl_device.h
+++ b/src/cpu/dram_rapl_device.h
@@ -33,11 +33,11 @@
 
 class dram_rapl_device: public cpudevice {
 
-	c_rapl_interface *rapl;
-	time_t		last_time;
-	double		last_energy;
-	double 		consumed_power;
-	bool		device_valid;
+	c_rapl_interface *rapl = nullptr;
+	time_t		last_time = 0;
+	double		last_energy = 0.0;
+	double 		consumed_power = 0.0;
+	bool		device_valid = false;
 
 public:
 	dram_rapl_device(cpudevice *parent, const std::string &classname = "dram_core", const std::string &device_name = "dram_core", class abstract_cpu *_cpu = NULL);

--- a/src/cpu/dram_rapl_device.h
+++ b/src/cpu/dram_rapl_device.h
@@ -28,8 +28,6 @@
 #include <vector>
 #include <string>
 
-using namespace std;
-
 #include <sys/time.h>
 #include "cpudevice.h"
 #include "rapl/rapl_interface.h"

--- a/src/cpu/intel_cpus.h
+++ b/src/cpu/intel_cpus.h
@@ -1,5 +1,4 @@
-#ifndef PowerTop_INTEL_CPUS_H_84F09FB4F519470FA914AA9B02453221
-#define PowerTop_INTEL_CPUS_H_84F09FB4F519470FA914AA9B02453221
+#pragma once
 /*
  * Copyright 2010, Intel Corporation
  *
@@ -178,4 +177,3 @@ int byt_has_ahci();
 
 int is_intel_pstate_driver_loaded();
 
-#endif

--- a/src/cpu/intel_cpus.h
+++ b/src/cpu/intel_cpus.h
@@ -51,8 +51,8 @@
 class intel_util
 {
 protected:
-	int byt_ahci_support;
-        DIR *dir;
+	int byt_ahci_support = 0;
+        DIR *dir = nullptr;
 public:
 	intel_util();
 	virtual void byt_has_ahci();
@@ -62,23 +62,23 @@ public:
 class nhm_package: public cpu_package, public intel_util
 {
 private:
-	uint64_t	c2_before, c2_after;
-	uint64_t	c3_before, c3_after;
-	uint64_t	c6_before, c6_after;
-	uint64_t	c7_before, c7_after;
-	uint64_t	c8_before, c8_after;
-	uint64_t	c9_before, c9_after;
-	uint64_t	c10_before, c10_after;
-	uint64_t	tsc_before, tsc_after;
+	uint64_t	c2_before = 0, c2_after = 0;
+	uint64_t	c3_before = 0, c3_after = 0;
+	uint64_t	c6_before = 0, c6_after = 0;
+	uint64_t	c7_before = 0, c7_after = 0;
+	uint64_t	c8_before = 0, c8_after = 0;
+	uint64_t	c9_before = 0, c9_after = 0;
+	uint64_t	c10_before = 0, c10_after = 0;
+	uint64_t	tsc_before = 0, tsc_after = 0;
 
-	uint64_t	last_stamp;
-	uint64_t	total_stamp;
+	uint64_t	last_stamp = 0;
+	uint64_t	total_stamp = 0;
 public:
-	int		has_c7_res;
-	int		has_c2c6_res;
-	int		has_c3_res;
-	int		has_c6c_res;		/* BSW */
-	int		has_c8c9c10_res;
+	int		has_c7_res = 0;
+	int		has_c2c6_res = 0;
+	int		has_c3_res = 0;
+	int		has_c6c_res = 0;		/* BSW */
+	int		has_c8c9c10_res = 0;
 	nhm_package(int model);
 	virtual void	measurement_start(void);
 	virtual void	measurement_end(void);
@@ -90,18 +90,18 @@ public:
 class nhm_core: public cpu_core, public intel_util
 {
 private:
-	uint64_t	c1_before, c1_after;
-	uint64_t	c3_before, c3_after;
-	uint64_t	c6_before, c6_after;
-	uint64_t	c7_before, c7_after;
-	uint64_t	tsc_before, tsc_after;
+	uint64_t	c1_before = 0, c1_after = 0;
+	uint64_t	c3_before = 0, c3_after = 0;
+	uint64_t	c6_before = 0, c6_after = 0;
+	uint64_t	c7_before = 0, c7_after = 0;
+	uint64_t	tsc_before = 0, tsc_after = 0;
 
-	uint64_t	last_stamp;
-	uint64_t	total_stamp;
+	uint64_t	last_stamp = 0;
+	uint64_t	total_stamp = 0;
 public:
-	int		has_c1_res;
-	int		has_c7_res;
-	int		has_c3_res;
+	int		has_c1_res = 0;
+	int		has_c7_res = 0;
+	int		has_c3_res = 0;
 	nhm_core(int model);
 	virtual void	measurement_start(void);
 	virtual void	measurement_end(void);
@@ -113,14 +113,14 @@ public:
 class nhm_cpu: public cpu_linux, public intel_util
 {
 private:
-	uint64_t	aperf_before;
-	uint64_t	aperf_after;
-	uint64_t	mperf_before;
-	uint64_t	mperf_after;
-	uint64_t	tsc_before, tsc_after;
+	uint64_t	aperf_before = 0;
+	uint64_t	aperf_after = 0;
+	uint64_t	mperf_before = 0;
+	uint64_t	mperf_after = 0;
+	uint64_t	tsc_before = 0, tsc_after = 0;
 
-	uint64_t	last_stamp;
-	uint64_t	total_stamp;
+	uint64_t	last_stamp = 0;
+	uint64_t	total_stamp = 0;
 public:
 	virtual void	measurement_start(void);
 	virtual void	measurement_end(void);
@@ -151,9 +151,9 @@ public:
 class i965_core: public cpu_core
 {
 private:
-	uint64_t	rc6_before, rc6_after;
-	uint64_t	rc6p_before, rc6p_after;
-	uint64_t	rc6pp_before, rc6pp_after;
+	uint64_t	rc6_before = 0, rc6_after = 0;
+	uint64_t	rc6p_before = 0, rc6p_after = 0;
+	uint64_t	rc6pp_before = 0, rc6pp_after = 0;
 
 	struct timeval	before;
 	struct timeval	after;

--- a/src/cpu/intel_gpu.cpp
+++ b/src/cpu/intel_gpu.cpp
@@ -54,7 +54,7 @@ void i965_core::measurement_start(void)
 	update_cstate("gpu rc6pp", "RC6pp", 0, rc6pp_before, 1, 3);
 }
 
-std::string i965_core::fill_cstate_line(int line_nr, const string &separator __unused)
+std::string i965_core::fill_cstate_line(int line_nr, const std::string &separator __unused)
 {
 	double ratio, d = -1.0, time_delta;
 

--- a/src/cpu/rapl/rapl_interface.cpp
+++ b/src/cpu/rapl/rapl_interface.cpp
@@ -70,7 +70,7 @@
 #define PP0_DOMAIN_PRESENT	0x04
 #define PP1_DOMAIN_PRESENT	0x08
 
-c_rapl_interface::c_rapl_interface(const string &dev_name, int cpu) :
+c_rapl_interface::c_rapl_interface(const std::string &dev_name, int cpu) :
 	powercap_sysfs_present(false),
 	powercap_core_path(),
 	powercap_uncore_path(),
@@ -84,7 +84,7 @@ c_rapl_interface::c_rapl_interface(const string &dev_name, int cpu) :
 {
 	uint64_t value;
 	int ret;
-	string package_path;
+	std::string package_path;
 	DIR *dir;
 	struct dirent *entry;
 
@@ -93,11 +93,11 @@ c_rapl_interface::c_rapl_interface(const string &dev_name, int cpu) :
 	rapl_domains = 0;
 
 	if (!dev_name.empty()) {
-		string base_path = "/sys/class/powercap/intel-rapl/";
+		std::string base_path = "/sys/class/powercap/intel-rapl/";
 		if ((dir = opendir(base_path.c_str())) != NULL) {
 			while ((entry = readdir(dir)) != NULL) {
-				string path = base_path + entry->d_name + "/name";
-				string str = read_sysfs_string(path);
+				std::string path = base_path + entry->d_name + "/name";
+				std::string str = read_sysfs_string(path);
 				if (str.length() > 0) {
 					if (str == dev_name) {
 						package_path = base_path + entry->d_name + "/";
@@ -114,8 +114,8 @@ c_rapl_interface::c_rapl_interface(const string &dev_name, int cpu) :
 	if (powercap_sysfs_present) {
 		if ((dir = opendir(package_path.c_str())) != NULL) {
 			while ((entry = readdir(dir)) != NULL) {
-				string path = package_path + entry->d_name;
-				string str = read_sysfs_string(path + "/name");
+				std::string path = package_path + entry->d_name;
+				std::string str = read_sysfs_string(path + "/name");
 				if (str.length() > 0) {
 					if (str == "core") {
 						rapl_domains |= PP0_DOMAIN_PRESENT;
@@ -371,7 +371,7 @@ int c_rapl_interface::get_dram_energy_status(double *status)
 	}
 
 	if (powercap_sysfs_present) {
-		string str = read_sysfs_string(powercap_dram_path + "energy_uj");
+		std::string str = read_sysfs_string(powercap_dram_path + "energy_uj");
 		if (str.length() > 0) {
 			*status =  atof(str.c_str()) / 1000000; // uj to Js
 			return 0;
@@ -462,7 +462,7 @@ int c_rapl_interface::get_pp0_energy_status(double *status)
 	}
 
 	if (powercap_sysfs_present) {
-		string str = read_sysfs_string(powercap_core_path + "energy_uj");
+		std::string str = read_sysfs_string(powercap_core_path + "energy_uj");
 		if (str.length() > 0) {
 			*status = atof(str.c_str()) / 1000000; // uj to Js
 			return 0;
@@ -550,7 +550,7 @@ int c_rapl_interface::get_pp1_energy_status(double *status)
 	}
 
 	if (powercap_sysfs_present) {
-		string str = read_sysfs_string(powercap_uncore_path + "energy_uj");
+		std::string str = read_sysfs_string(powercap_uncore_path + "energy_uj");
 		if (str.length() > 0) {
 			*status =  atof(str.c_str()) / 1000000; // uj to Js
 			return 0;

--- a/src/cpu/rapl/rapl_interface.cpp
+++ b/src/cpu/rapl/rapl_interface.cpp
@@ -96,6 +96,8 @@ c_rapl_interface::c_rapl_interface(const std::string &dev_name, int cpu) :
 		std::string base_path = "/sys/class/powercap/intel-rapl/";
 		if ((dir = opendir(base_path.c_str())) != NULL) {
 			while ((entry = readdir(dir)) != NULL) {
+				if (std::string_view(entry->d_name).starts_with('.'))
+					continue;
 				std::string path = base_path + entry->d_name + "/name";
 				std::string str = read_sysfs_string(path);
 				if (str.length() > 0) {
@@ -114,6 +116,8 @@ c_rapl_interface::c_rapl_interface(const std::string &dev_name, int cpu) :
 	if (powercap_sysfs_present) {
 		if ((dir = opendir(package_path.c_str())) != NULL) {
 			while ((entry = readdir(dir)) != NULL) {
+				if (std::string_view(entry->d_name).starts_with('.'))
+					continue;
 				std::string path = package_path + entry->d_name;
 				std::string str = read_sysfs_string(path + "/name");
 				if (str.length() > 0) {

--- a/src/cpu/rapl/rapl_interface.h
+++ b/src/cpu/rapl/rapl_interface.h
@@ -29,9 +29,9 @@ class c_rapl_interface
 private:
 	static const int def_sampling_interval = 1; //In seconds
 	bool powercap_sysfs_present;
-	string powercap_core_path;
-	string powercap_uncore_path;
-	string powercap_dram_path;
+	std::string powercap_core_path;
+	std::string powercap_uncore_path;
+	std::string powercap_dram_path;
 
 	unsigned char rapl_domains;
 	int first_cpu;

--- a/src/cpu/rapl/rapl_interface.h
+++ b/src/cpu/rapl/rapl_interface.h
@@ -21,8 +21,7 @@
  *
  */
 
-#ifndef RAPL_INTERFACE_H
-#define RAPL_INTERFACE_H
+#pragma once
 
 class c_rapl_interface
 {
@@ -88,4 +87,3 @@ public:
 	void rapl_measure_energy();
 };
 
-#endif

--- a/src/cpu/rapl/rapl_interface.h
+++ b/src/cpu/rapl/rapl_interface.h
@@ -27,27 +27,27 @@ class c_rapl_interface
 {
 private:
 	static const int def_sampling_interval = 1; //In seconds
-	bool powercap_sysfs_present;
+	bool powercap_sysfs_present = false;
 	std::string powercap_core_path;
 	std::string powercap_uncore_path;
 	std::string powercap_dram_path;
 
-	unsigned char rapl_domains;
-	int first_cpu;
+	unsigned char rapl_domains = 0;
+	int first_cpu = 0;
 
-	double power_units;
-	double energy_status_units;
-	double time_units;
+	double power_units = 0.0;
+	double energy_status_units = 0.0;
+	double time_units = 0.0;
 
 	int read_msr(int cpu, unsigned int idx, uint64_t *val);
 	int write_msr(int cpu, unsigned int idx, uint64_t val);
 
 protected:
-	int measurment_interval;
-	double last_pkg_energy_status;
-	double last_dram_energy_status;
-	double last_pp0_energy_status;
-	double last_pp1_energy_status;
+	int measurment_interval = 0;
+	double last_pkg_energy_status = 0.0;
+	double last_dram_energy_status = 0.0;
+	double last_pp0_energy_status = 0.0;
+	double last_pp1_energy_status = 0.0;
 
 public:
 	c_rapl_interface(const std::string &dev_name = "package-0", int cpu = 0);

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -40,14 +40,14 @@
 #include <string.h>
 #include <format>
 
-vector <class ahci *> links;
+std::vector <class ahci *> links;
 
-static string disk_name(const string &path, const string &target, const string &shortname __unused)
+static std::string disk_name(const std::string &path, const std::string &target, const std::string &shortname __unused)
 {
 
 	DIR *dir;
 	struct dirent *dirent;
-	string diskname = "";
+	std::string diskname = "";
 	std::string pathname;
 
 	pathname = std::format("{}/{}", path, target);
@@ -71,7 +71,7 @@ static string disk_name(const string &path, const string &target, const string &
 	return diskname;
 }
 
-static string model_name(const string &path, const string &shortname)
+static std::string model_name(const std::string &path, const std::string &shortname)
 {
 
 	DIR *dir;
@@ -100,7 +100,7 @@ static string model_name(const string &path, const string &shortname)
 	return "";
 }
 
-ahci::ahci(const string &_name, const string &path): device()
+ahci::ahci(const std::string &_name, const std::string &path): device()
 {
 	std::string diskname;
 

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -31,8 +31,6 @@
 #include <limits.h>
 
 
-using namespace std;
-
 #include "device.h"
 #include "report/report.h"
 #include "report/report-maker.h"

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -310,6 +310,9 @@ void ahci::report_device_stats(std::vector<std::string> &ahci_data, int idx)
 	double slumber_util = get_result_value(slumber_rindex, &all_results);
 	double devslp_util = get_result_value(devslp_rindex, &all_results);
 
+	ahci_data[offset] = humanname;
+	offset += 1;
+
 	ahci_data[offset]= std::format("{:5.1f}",  active_util);
 	offset +=1;
 

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -93,7 +93,9 @@ static std::string model_name(const std::string &path, const std::string &shortn
 			continue;
 		if (d_name.find("target") == std::string::npos)
 			continue;
-		return disk_name(pathname, d_name, shortname);
+		std::string result = disk_name(pathname, d_name, shortname);
+		closedir(dir);
+		return result;
 	}
 	closedir(dir);
 

--- a/src/devices/ahci.h
+++ b/src/devices/ahci.h
@@ -32,18 +32,18 @@
 #include <stdint.h>
 
 class ahci: public device {
-	uint64_t start_active, end_active;
-	uint64_t start_partial, end_partial;
-	uint64_t start_slumber, end_slumber;
-	uint64_t start_devslp, end_devslp;
+	uint64_t start_active = 0, end_active = 0;
+	uint64_t start_partial = 0, end_partial = 0;
+	uint64_t start_slumber = 0, end_slumber = 0;
+	uint64_t start_devslp = 0, end_devslp = 0;
 	std::string sysfs_path;
 	std::string name;
-	int partial_rindex;
-	int active_rindex;
-	int slumber_rindex;
-	int devslp_rindex;
-	int partial_index;
-	int active_index;
+	int partial_rindex = 0;
+	int active_rindex = 0;
+	int slumber_rindex = 0;
+	int devslp_rindex = 0;
+	int partial_index = 0;
+	int active_index = 0;
 	std::string humanname;
 public:
 

--- a/src/devices/ahci.h
+++ b/src/devices/ahci.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_AHCI_H
-#define _INCLUDE_GUARD_AHCI_H
+#pragma once
 
 
 #include <string>
@@ -68,5 +67,3 @@ public:
 extern void create_all_ahcis(void);
 extern void ahci_create_device_stats_table(void);
 
-
-#endif

--- a/src/devices/ahci.h
+++ b/src/devices/ahci.h
@@ -59,7 +59,7 @@ public:
 	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual int power_valid(void) { return utilization_power_valid(partial_rindex) + utilization_power_valid(active_rindex);};
+	virtual bool power_valid(void) { return utilization_power_valid(partial_rindex) || utilization_power_valid(active_rindex);};
 	virtual int grouping_prio(void) { return 1; };
 	virtual void report_device_stats(std::vector<std::string> &ahci_data, int idx);
 };

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -39,7 +39,7 @@
 #include <unistd.h>
 #include <format>
 
-alsa::alsa(const string &_name, const string &path): device()
+alsa::alsa(const std::string &_name, const std::string &path): device()
 {
 	std::string model;
 	std::string vendor;

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -29,8 +29,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-using namespace std;
-
 #include "device.h"
 #include "alsa.h"
 #include "../parameters/parameters.h"

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_ALSA_H
-#define _INCLUDE_GUARD_ALSA_H
+#pragma once
 
 
 #include "device.h"
@@ -63,5 +62,3 @@ public:
 
 extern void create_all_alsa(void);
 
-
-#endif

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -53,7 +53,7 @@ public:
 	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual int power_valid(void) { return utilization_power_valid(rindex);};
+	virtual bool power_valid(void) { return utilization_power_valid(rindex);};
 
 	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle);
 	virtual int grouping_prio(void) { return 0; };

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -33,12 +33,12 @@
 #include <string>
 
 class alsa: public device {
-	uint64_t start_active, end_active;
-	uint64_t start_inactive, end_inactive;
+	uint64_t start_active = 0, end_active = 0;
+	uint64_t start_inactive = 0, end_inactive = 0;
 	std::string sysfs_path;
 	std::string name;
 	std::string humanname;
-	int rindex;
+	int rindex = 0;
 public:
 
 	alsa(const std::string &_name, const std::string &path);

--- a/src/devices/backlight.cpp
+++ b/src/devices/backlight.cpp
@@ -39,7 +39,7 @@
 #include <format>
 
 
-backlight::backlight(const string &_name, const string &path): device()
+backlight::backlight(const std::string &_name, const std::string &path): device()
 {
 	min_level = 0;
 	max_level = 0;

--- a/src/devices/backlight.cpp
+++ b/src/devices/backlight.cpp
@@ -97,7 +97,10 @@ void backlight::end_measurement(void)
 	end_level = read_sysfs(std::format("{}/actual_brightness", sysfs_path));
 
 	if (dpms_screen_on()) {
-		p = 100.0 * (end_level + start_level) / 2 / max_level;
+		if (max_level > 0)
+			p = 100.0 * (end_level + start_level) / 2 / max_level;
+		else
+			p = 0;
 		_backlight = 100;
 	} else {
 		p = 0;
@@ -110,10 +113,9 @@ void backlight::end_measurement(void)
 
 double backlight::utilization(void)
 {
-	double p;
-
-	p = 100.0 * (end_level + start_level) / 2 / max_level;
-	return p;
+	if (max_level <= 0)
+		return 0.0;
+	return 100.0 * (end_level + start_level) / 2 / max_level;
 }
 
 static void create_all_backlights_callback(const std::string &d_name)

--- a/src/devices/backlight.cpp
+++ b/src/devices/backlight.cpp
@@ -31,8 +31,6 @@
 #include <limits.h>
 
 
-using namespace std;
-
 #include "device.h"
 #include "backlight.h"
 #include "../parameters/parameters.h"

--- a/src/devices/backlight.h
+++ b/src/devices/backlight.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_BACKLIGHT_H
-#define _INCLUDE_GUARD_BACKLIGHT_H
+#pragma once
 
 #include <limits.h>
 #include <string>
@@ -56,5 +55,3 @@ public:
 
 extern void create_all_backlights(void);
 
-
-#endif

--- a/src/devices/backlight.h
+++ b/src/devices/backlight.h
@@ -30,12 +30,12 @@
 #include "device.h"
 
 class backlight: public device {
-	int min_level, max_level;
-	int start_level, end_level;
+	int min_level = 0, max_level = 0;
+	int start_level = 0, end_level = 0;
 	std::string sysfs_path;
 	std::string name;
-	int r_index;
-	int r_index_power;
+	int r_index = 0;
+	int r_index_power = 0;
 public:
 
 	backlight(const std::string &_name, const std::string &path);

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -70,6 +70,9 @@ void devfreq::process_time_stamps()
 	unsigned int i;
 	uint64_t active_time = 0;
 
+	if (dstates.empty())
+		return;
+
 	sample_time = (1000000.0 * (stamp_after.tv_sec - stamp_before.tv_sec))
 			+ ((stamp_after.tv_usec - stamp_before.tv_usec) );
 

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -196,6 +196,8 @@ std::string devfreq::fill_freq_utilization(unsigned int idx)
 {
 	if (idx < dstates.size() && dstates[idx]) {
 		class frequency *state = dstates[idx];
+		if (sample_time < 0.00001)
+			return "";
 		return std::format(" {:5.1f}% ", percentage(1.0 * state->time_after / sample_time));
 	}
 	return "";

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -43,20 +43,20 @@
 static bool is_enabled = true;
 static DIR *dir = NULL;
 
-static vector<class devfreq *> all_devfreq;
+static std::vector<class devfreq *> all_devfreq;
 
-devfreq::devfreq(const string &dpath): device()
+devfreq::devfreq(const std::string &dpath): device()
 {
 	dir_name = dpath;
 }
 
-uint64_t devfreq::parse_freq_time(const string &pchr_s)
+uint64_t devfreq::parse_freq_time(const std::string &pchr_s)
 {
 	uint64_t ctime = 0;
 	size_t pos;
 
 	pos = pchr_s.find_last_of(" :");
-	if (pos != string::npos) {
+	if (pos != std::string::npos) {
 		try {
 			ctime = std::stoull(pchr_s.substr(pos + 1));
 		} catch (...) {}
@@ -118,7 +118,7 @@ void devfreq::update_devfreq_freq_state(uint64_t freq, uint64_t time)
 	state->time_after = time;
 }
 
-void devfreq::parse_devfreq_trans_stat(const string &dname __unused)
+void devfreq::parse_devfreq_trans_stat(const std::string &dname __unused)
 {
 	std::string filename;
 	std::string content;
@@ -189,7 +189,7 @@ double devfreq::utilization(void)
 	return 0;
 }
 
-string devfreq::fill_freq_utilization(unsigned int idx)
+std::string devfreq::fill_freq_utilization(unsigned int idx)
 {
 	if (idx < dstates.size() && dstates[idx]) {
 		class frequency *state = dstates[idx];
@@ -198,7 +198,7 @@ string devfreq::fill_freq_utilization(unsigned int idx)
 	return "";
 }
 
-string devfreq::fill_freq_name(unsigned int idx)
+std::string devfreq::fill_freq_name(unsigned int idx)
 {
 	if (idx < dstates.size() && dstates[idx]) {
 		return std::format("{:<15}", dstates[idx]->human_name);

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -45,7 +45,7 @@ class devfreq: public device {
 
 public:
 
-	vector<class frequency *> dstates;
+	std::vector<class frequency *> dstates;
 
 	devfreq(const std::string &c);
 	std::string fill_freq_utilization(unsigned int idx);

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -34,7 +34,7 @@ class frequency;
 class devfreq: public device {
 	std::string dir_name;
 	struct timeval  stamp_before, stamp_after;
-	double sample_time;
+	double sample_time = 0.0;
 
 	uint64_t parse_freq_time(const std::string &ptr);
 	void add_devfreq_freq_state(uint64_t freq, uint64_t time);

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -61,7 +61,7 @@ public:
 	virtual std::string human_name(void) { return "devfreq";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual std::string util_units(void) { return " rpm"; };
-	virtual int power_valid(void) { return 0; /*utilization_power_valid(r_index);*/};
+	virtual bool power_valid(void) { return false; /*utilization_power_valid(r_index);*/};
 	virtual int grouping_prio(void) { return 1; };
 };
 

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Rajagopal Venkat <rajagopal.venkat@linaro.org>
  */
-#ifndef _INCLUDE_GUARD_DEVFREQ_H
-#define _INCLUDE_GUARD_DEVFREQ_H
+#pragma once
 
 #include "device.h"
 #include "../parameters/parameters.h"
@@ -74,4 +73,3 @@ extern void initialize_devfreq(void);
 extern void start_devfreq_measurement(void);
 extern void end_devfreq_measurement(void);
 
-#endif

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -127,7 +127,7 @@ static bool power_device_sort(class device * i, class device * j)
 	pJ = j->power_usage(&all_results, &all_parameters);
 
 	if (equals(pI, pJ)) {
-		int vI, vJ;
+		bool vI, vJ;
 		vI = i->power_valid();
 		vJ = j->power_valid();
 

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -32,8 +32,6 @@
 #include <unistd.h>
 #include <format>
 
-using namespace std;
-
 #include "backlight.h"
 #include "usb.h"
 #include "ahci.h"

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -96,7 +96,7 @@ double	device::utilization(void)
 
 
 
-vector<class device *> all_devices;
+std::vector<class device *> all_devices;
 
 
 void devices_start_measurement(void)

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -71,8 +71,6 @@ public:
 	virtual int grouping_prio(void) { return 0; }; /* priority of this device class if multiple classes match to the same underlying device. 0 is lowest */
 };
 
-using namespace std;
-
 extern std::vector<class device *> all_devices;
 
 extern void devices_start_measurement(void);

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -35,8 +35,8 @@ struct result_bundle;
 
 class device {
 public:
-	int cached_valid;
-	bool hide;
+	int cached_valid = 0;
+	bool hide = false;
 
 	std::string guilty;
 	std::string real_path;

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_DEVICE_H
-#define _INCLUDE_GUARD_DEVICE_H
+#pragma once
 
 
 #include <vector>
@@ -82,4 +81,3 @@ extern void report_devices(void);
 extern void create_all_devices(void);
 extern void clear_all_devices(void);
 
-#endif

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -35,7 +35,7 @@ struct result_bundle;
 
 class device {
 public:
-	int cached_valid = 0;
+	bool cached_valid = false;
 	bool hide = false;
 
 	std::string guilty;
@@ -63,7 +63,7 @@ public:
 
 	virtual bool show_in_list(void) {return !hide;};
 
-	virtual int power_valid(void) { return 1;};
+	virtual bool power_valid(void) { return true;};
 
 	virtual void register_power_with_devlist(struct result_bundle *results __unused, struct parameter_bundle *bundle __unused) { ; };
 

--- a/src/devices/gpu_rapl_device.h
+++ b/src/devices/gpu_rapl_device.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Srinivas Pandruvada <Srinivas.Pandruvada@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_GPU_RAPL_DEVICE_H
-#define _INCLUDE_GUARD_GPU_RAPL_DEVICE_H
+#pragma once
 
 #include <vector>
 #include <string>
@@ -52,5 +51,3 @@ public:
 
 };
 
-
-#endif

--- a/src/devices/gpu_rapl_device.h
+++ b/src/devices/gpu_rapl_device.h
@@ -34,10 +34,10 @@
 class gpu_rapl_device: public i915gpu {
 
 	c_rapl_interface rapl;
-	time_t		last_time;
-	double		last_energy;
-	double 		consumed_power;
-	bool		device_valid;
+	time_t		last_time = 0;
+	double		last_energy = 0.0;
+	double 		consumed_power = 0.0;
+	bool		device_valid = false;
 
 public:
 	gpu_rapl_device(i915gpu *parent);

--- a/src/devices/gpu_rapl_device.h
+++ b/src/devices/gpu_rapl_device.h
@@ -28,8 +28,6 @@
 #include <vector>
 #include <string>
 
-using namespace std;
-
 #include <sys/time.h>
 #include "i915-gpu.h"
 #include "cpu/rapl/rapl_interface.h"

--- a/src/devices/i915-gpu.cpp
+++ b/src/devices/i915-gpu.cpp
@@ -84,6 +84,8 @@ void create_i915_gpu(void)
 	rapl_dev = new class gpu_rapl_device(gpu);
 	if (rapl_dev->device_present())
 		all_devices.push_back(rapl_dev);
+	else
+		delete rapl_dev;
 }
 
 

--- a/src/devices/i915-gpu.cpp
+++ b/src/devices/i915-gpu.cpp
@@ -32,8 +32,6 @@
 #include <limits.h>
 #include "../lib.h"
 
-using namespace std;
-
 #include "device.h"
 #include "i915-gpu.h"
 #include "../parameters/parameters.h"

--- a/src/devices/i915-gpu.h
+++ b/src/devices/i915-gpu.h
@@ -28,8 +28,8 @@
 #include "device.h"
 
 class i915gpu: public device {
-	int index;
-	int rindex;
+	int index = 0;
+	int rindex = 0;
 	std::vector<device *>child_devices;
 
 public:

--- a/src/devices/i915-gpu.h
+++ b/src/devices/i915-gpu.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_i915_GPU_H
-#define _INCLUDE_GUARD_i915_GPU_H
+#pragma once
 
 
 #include "device.h"
@@ -59,5 +58,3 @@ public:
 
 extern void create_i915_gpu(void);
 
-
-#endif

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -36,8 +36,6 @@
 
 #include <linux/ethtool.h>
 
-using namespace std;
-
 #include "device.h"
 #include "network.h"
 #include "../lib.h"

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -54,7 +54,7 @@ extern "C" {
 #include <unistd.h>
 #include <sstream>
 
-static map<string, class network *> nics;
+static std::map<std::string, class network *> nics;
 
 static void do_proc_net_dev(void)
 {
@@ -82,7 +82,7 @@ static void do_proc_net_dev(void)
 		uint64_t pkt = 0;
 
 		size_t pos = line.find(':');
-		if (pos == string::npos)
+		if (pos == std::string::npos)
 			continue;
 
 		std::string name = line.substr(0, pos);
@@ -127,7 +127,7 @@ static inline __u32 ethtool_cmd_speed(struct ethtool_cmd *ep)
 #endif
 
 
-network::network(const string &_name, const string &path): device()
+network::network(const std::string &_name, const std::string &path): device()
 {
 	start_up = 0;
 	end_up = 0;

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -32,36 +32,36 @@
 #include "../parameters/parameters.h"
 
 class network: public device {
-	int start_up, end_up;
-	uint64_t start_pkts, end_pkts;
+	int start_up = 0, end_up = 0;
+	uint64_t start_pkts = 0, end_pkts = 0;
 	struct timeval before, after;
 
-	int start_speed; /* 0 is "no link" */
-	int end_speed; /* 0 is "no link" */
+	int start_speed = 0; /* 0 is "no link" */
+	int end_speed = 0; /* 0 is "no link" */
 
 	std::string sysfs_path;
 	std::string name;
 	std::string humanname;
-	int index_up;
-	int rindex_up;
-	int index_link_100;
-	int rindex_link_100;
-	int index_link_1000;
-	int rindex_link_1000;
-	int index_link_high;
-	int rindex_link_high;
-	int index_pkts;
-	int rindex_pkts;
-	int index_powerunsave;
-	int rindex_powerunsave;
+	int index_up = 0;
+	int rindex_up = 0;
+	int index_link_100 = 0;
+	int rindex_link_100 = 0;
+	int index_link_1000 = 0;
+	int rindex_link_1000 = 0;
+	int index_link_high = 0;
+	int rindex_link_high = 0;
+	int index_pkts = 0;
+	int rindex_pkts = 0;
+	int index_powerunsave = 0;
+	int rindex_powerunsave = 0;
 
-	int valid_100;
-	int valid_1000;
-	int valid_high;
-	int valid_powerunsave;
+	int valid_100 = 0;
+	int valid_1000 = 0;
+	int valid_high = 0;
+	int valid_powerunsave = 0;
 public:
-	uint64_t pkts;
-	double duration;
+	uint64_t pkts = 0;
+	double duration = 0.0;
 
 	network(const std::string &_name, const std::string &path);
 

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -76,7 +76,7 @@ public:
 	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual int power_valid(void) { return utilization_power_valid(rindex_up) + utilization_power_valid(rindex_link_100) + utilization_power_valid(rindex_link_1000)  + utilization_power_valid(rindex_link_high);};
+	virtual bool power_valid(void) { return utilization_power_valid(rindex_up) || utilization_power_valid(rindex_link_100) || utilization_power_valid(rindex_link_1000) || utilization_power_valid(rindex_link_high);};
 	virtual int grouping_prio(void) { return 10; };
 };
 

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_NETWORK_H
-#define _INCLUDE_GUARD_NETWORK_H
+#pragma once
 
 #include <sys/time.h>
 #include <limits.h>
@@ -83,4 +82,3 @@ public:
 
 extern void create_all_nics(callback fn = NULL);
 
-#endif

--- a/src/devices/rfkill.cpp
+++ b/src/devices/rfkill.cpp
@@ -40,7 +40,7 @@
 #include <unistd.h>
 #include <format>
 
-rfkill::rfkill(const string &_name, const string &path): device()
+rfkill::rfkill(const std::string &_name, const std::string &path): device()
 {
 	char buf[4096];
 	ssize_t len;

--- a/src/devices/rfkill.cpp
+++ b/src/devices/rfkill.cpp
@@ -32,8 +32,6 @@
 #include <limits.h>
 
 
-using namespace std;
-
 #include "device.h"
 #include "rfkill.h"
 #include "../parameters/parameters.h"

--- a/src/devices/rfkill.h
+++ b/src/devices/rfkill.h
@@ -31,13 +31,13 @@
 #include "../parameters/parameters.h"
 
 class rfkill: public device {
-	int start_soft, end_soft;
-	int start_hard, end_hard;
+	int start_soft = 0, end_soft = 0;
+	int start_hard = 0, end_hard = 0;
 	std::string sysfs_path;
 	std::string name;
 	std::string humanname;
-	int index;
-	int rindex;
+	int index = 0;
+	int rindex = 0;
 public:
 
 	rfkill(const std::string &_name, const std::string &path);

--- a/src/devices/rfkill.h
+++ b/src/devices/rfkill.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_RFKILL_H
-#define _INCLUDE_GUARD_RFKILL_H
+#pragma once
 
 #include <limits.h>
 #include <string>
@@ -59,5 +58,3 @@ public:
 
 extern void create_all_rfkills(void);
 
-
-#endif

--- a/src/devices/rfkill.h
+++ b/src/devices/rfkill.h
@@ -52,7 +52,7 @@ public:
 	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual int power_valid(void) { return utilization_power_valid(rindex);};
+	virtual bool power_valid(void) { return utilization_power_valid(rindex);};
 	virtual int grouping_prio(void) { return 5; };
 };
 

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -39,7 +39,7 @@
 #include <iostream>
 #include <fstream>
 
-runtime_pmdevice::runtime_pmdevice(const string &_name, const string &path) : device()
+runtime_pmdevice::runtime_pmdevice(const std::string &_name, const std::string &path) : device()
 {
 	sysfs_path = path;
 	register_sysfs_path(sysfs_path);
@@ -99,13 +99,13 @@ double runtime_pmdevice::power_usage(struct result_bundle *result, struct parame
 	return power;
 }
 
-void runtime_pmdevice::set_human_name(const string &_name)
+void runtime_pmdevice::set_human_name(const std::string &_name)
 {
 	humanname = _name;
 }
 
 
-bool device_has_runtime_pm(const string &sysfs_path)
+bool device_has_runtime_pm(const std::string &sysfs_path)
 {
 	if (read_sysfs(std::format("{}/power/runtime_suspended_time", sysfs_path)))
 		return true;

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -31,13 +31,13 @@
 #include "../parameters/parameters.h"
 
 class runtime_pmdevice: public device {
-	uint64_t before_suspended_time, before_active_time;
-	uint64_t after_suspended_time, after_active_time;
+	uint64_t before_suspended_time = 0, before_active_time = 0;
+	uint64_t after_suspended_time = 0, after_active_time = 0;
 	std::string sysfs_path;
 	std::string name;
 	std::string humanname;
-	int index;
-	int r_index;
+	int index = 0;
+	int r_index = 0;
 public:
 
 	runtime_pmdevice(const std::string &_name, const std::string &path);

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -52,7 +52,7 @@ public:
 	virtual std::string device_name(void) { return name; };
 	virtual std::string human_name(void) { return humanname; };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual int power_valid(void) { return utilization_power_valid(r_index);};
+	virtual bool power_valid(void) { return utilization_power_valid(r_index);};
 
 	void set_human_name(const std::string &name);
 	virtual int grouping_prio(void) { return 1; };

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_RUNTIMEPM_H
-#define _INCLUDE_GUARD_RUNTIMEPM_H
+#pragma once
 
 #include <limits.h>
 #include <string>
@@ -63,5 +62,3 @@ extern void create_all_runtime_pm_devices(void);
 
 extern bool device_has_runtime_pm(const std::string &sysfs_path);
 
-
-#endif

--- a/src/devices/thinkpad-fan.h
+++ b/src/devices/thinkpad-fan.h
@@ -47,7 +47,7 @@ public:
 	virtual std::string human_name(void) { return "Laptop fan";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual std::string util_units(void) { return " rpm"; };
-	virtual int power_valid(void) { return utilization_power_valid(r_index);};
+	virtual bool power_valid(void) { return utilization_power_valid(r_index);};
 	virtual int grouping_prio(void) { return 1; };
 };
 

--- a/src/devices/thinkpad-fan.h
+++ b/src/devices/thinkpad-fan.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_THINKPAD_FAN_H
-#define _INCLUDE_GUARD_THINKPAD_FAN_H
+#pragma once
 
 
 #include "device.h"
@@ -54,5 +53,3 @@ public:
 
 extern void create_thinkpad_fan(void);
 
-
-#endif

--- a/src/devices/thinkpad-fan.h
+++ b/src/devices/thinkpad-fan.h
@@ -29,9 +29,9 @@
 #include "../parameters/parameters.h"
 
 class thinkpad_fan: public device {
-	double start_rate, end_rate;
-	int fan_index, fansqr_index, fancub_index;
-	int r_index;
+	double start_rate = 0.0, end_rate = 0.0;
+	int fan_index = 0, fansqr_index = 0, fancub_index = 0;
+	int r_index = 0;
 public:
 
 	thinkpad_fan();

--- a/src/devices/thinkpad-light.h
+++ b/src/devices/thinkpad-light.h
@@ -29,9 +29,9 @@
 #include "../parameters/parameters.h"
 
 class thinkpad_light: public device {
-	double start_rate, end_rate;
-	int light_index;
-	int r_index;
+	double start_rate = 0.0, end_rate = 0.0;
+	int light_index = 0;
+	int r_index = 0;
 public:
 
 	thinkpad_light();

--- a/src/devices/thinkpad-light.h
+++ b/src/devices/thinkpad-light.h
@@ -47,7 +47,7 @@ public:
 	virtual std::string human_name(void) { return "Thinkpad light";};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
 	virtual std::string util_units(void) { return "%"; };
-	virtual int power_valid(void) { return utilization_power_valid(r_index);};
+	virtual bool power_valid(void) { return utilization_power_valid(r_index);};
 	virtual int grouping_prio(void) { return 1; };
 };
 

--- a/src/devices/thinkpad-light.h
+++ b/src/devices/thinkpad-light.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_THINKPAD_LIGHT_H
-#define _INCLUDE_GUARD_THINKPAD_LIGHT_H
+#pragma once
 
 
 #include "device.h"
@@ -54,5 +53,3 @@ public:
 
 extern void create_thinkpad_light(void);
 
-
-#endif

--- a/src/devices/usb.cpp
+++ b/src/devices/usb.cpp
@@ -38,7 +38,7 @@
 #include <iostream>
 #include <fstream>
 
-usbdevice::usbdevice(const string &_name, const string &path, const string &devid): device()
+usbdevice::usbdevice(const std::string &_name, const std::string &path, const std::string &devid): device()
 {
 	std::string vendor;
 	std::string product;

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -57,7 +57,7 @@ public:
 	virtual std::string human_name(void) { return humanname; };
 	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle);
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual int power_valid(void) { return utilization_power_valid(r_index);};
+	virtual bool power_valid(void) { return utilization_power_valid(r_index);};
 	virtual int grouping_prio(void) { return 4; };
 };
 

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -31,17 +31,17 @@
 #include "../parameters/parameters.h"
 
 class usbdevice: public device {
-	int active_before, active_after;
-	int connected_before, connected_after;
+	int active_before = 0, active_after = 0;
+	int connected_before = 0, connected_after = 0;
 	std::string sysfs_path;
 	std::string name;
 	std::string devname;
 	std::string humanname;
-	int index;
-	int r_index;
-	int rootport;
-	int busnum;
-	int devnum;
+	int index = 0;
+	int r_index = 0;
+	int rootport = 0;
+	int busnum = 0;
+	int devnum = 0;
 public:
 
 	usbdevice(const std::string &_name, const std::string &path, const std::string &devid);

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_USB_H
-#define _INCLUDE_GUARD_USB_H
+#pragma once
 
 #include <limits.h>
 #include <string>
@@ -64,5 +63,3 @@ public:
 
 extern void create_all_usb_devices(void);
 
-
-#endif

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -40,8 +40,6 @@
 #include <ctype.h>
 #include <limits.h>
 
-using namespace std;
-
 #include "devlist.h"
 #include "lib.h"
 #include "report/report.h"

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -61,9 +61,9 @@
 
 */
 
-static vector<struct devuser *> one;
-static vector<struct devuser *> two;
-static vector<struct devpower *> devpower;
+static std::vector<struct devuser *> one;
+static std::vector<struct devuser *> two;
+static std::vector<struct devpower *> devpower;
 
 static int phase;
 /*
@@ -95,7 +95,7 @@ void collect_open_devices(void)
 	std::string filename;
 	char link[PATH_MAX];
 	unsigned int i;
-	vector<struct devuser *> *target;
+	std::vector<struct devuser *> *target;
 
 	if (phase == 1)
 		target = &one;
@@ -295,7 +295,7 @@ static bool devlist_sort(struct devuser * i, struct devuser * j)
 
 void report_show_open_devices(void)
 {
-	vector<struct devuser *> *target;
+	std::vector<struct devuser *> *target;
 	unsigned int i;
 	std::string prev, proc;
 	int idx, cols, rows;

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -78,14 +78,17 @@ void clean_open_devices()
 	for (i = 0; i < one.size(); i++) {
 		delete one[i];
 	}
+	one.clear();
 
 	for (i = 0; i < two.size(); i++) {
 		delete two[i];
 	}
+	two.clear();
 
 	for (i = 0; i < devpower.size(); i++){
 		delete devpower[i];
 	}
+	devpower.clear();
 }
 
 void collect_open_devices(void)

--- a/src/devlist.h
+++ b/src/devlist.h
@@ -1,5 +1,4 @@
-#ifndef __INCLUDE_GUARD_DEVLIST_H__
-#define __INCLUDE_GUARD_DEVLIST_H__
+#pragma once
 
 #include <string>
 
@@ -26,4 +25,3 @@ extern void run_devpower_list(void);
 
 extern void report_show_open_devices(void);
 
-#endif

--- a/src/devlist.h
+++ b/src/devlist.h
@@ -3,7 +3,7 @@
 #include <string>
 
 struct devuser {
-	unsigned int pid;
+	unsigned int pid = 0;
 	std::string comm;
 	std::string device;
 };
@@ -12,8 +12,8 @@ class device;
 
 struct devpower {
 	std::string device;
-	double power;
-	class device *dev;
+	double power = 0.0;
+	class device *dev = nullptr;
 };
 
 extern void clean_open_devices();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -100,8 +100,10 @@ void show_tab(unsigned int tab)
 	if (!display)
 		return;
 
+	if (tab >= tab_names.size())
+		return;
+
 	if (tab_bar) {
-		delwin(tab_bar);
 		tab_bar = NULL;
 	}
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -33,8 +33,6 @@
 #include <string>
 #include <string.h>
 
-using namespace std;
-
 static int display = 0;
 
 vector<string> tab_names;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -35,13 +35,13 @@
 
 static int display = 0;
 
-vector<string> tab_names;
-map<string, class tab_window *> tab_windows;
-map<string, string> tab_translations;
+std::vector<std::string> tab_names;
+std::map<std::string, class tab_window *> tab_windows;
+std::map<std::string, std::string> tab_translations;
 
-map<string, string> bottom_lines;
+std::map<std::string, std::string> bottom_lines;
 
-void create_tab(const string &name, const string &translation, class tab_window *w, string bottom_line)
+void create_tab(const std::string &name, const std::string &translation, class tab_window *w, std::string bottom_line)
 {
 	if (!w)
 		w = new(class tab_window);
@@ -151,7 +151,7 @@ void show_tab(unsigned int tab)
 	prefresh(win->win, win->ypad_pos, win->xpad_pos, 1, 0, LINES - 3, COLS - 1);
 }
 
-WINDOW *get_ncurses_win(const string &name)
+WINDOW *get_ncurses_win(const std::string &name)
 {
 	class tab_window *w;
 	WINDOW *win;

--- a/src/display.h
+++ b/src/display.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef __INCLUDE_GUARD_DISPLAY_H_
-#define __INCLUDE_GUARD_DISPLAY_H_
+#pragma once
 
 
 #include <map>
@@ -93,4 +92,3 @@ WINDOW *get_ncurses_win(int nr);
 
 void create_tab(const std::string &name, const std::string &translation, class tab_window *w = NULL, std::string bottom_line = "");
 
-#endif

--- a/src/display.h
+++ b/src/display.h
@@ -86,11 +86,11 @@ public:
 	}
 };
 
-extern map<string, class tab_window *> tab_windows;
+extern std::map<std::string, class tab_window *> tab_windows;
 
-WINDOW *get_ncurses_win(const string &name);
+WINDOW *get_ncurses_win(const std::string &name);
 WINDOW *get_ncurses_win(int nr);
 
-void create_tab(const string &name, const string &translation, class tab_window *w = NULL, string bottom_line = "");
+void create_tab(const std::string &name, const std::string &translation, class tab_window *w = NULL, std::string bottom_line = "");
 
 #endif

--- a/src/display.h
+++ b/src/display.h
@@ -30,8 +30,6 @@
 #include <string>
 #include <ncurses.h>
 
-using namespace std;
-
 extern void init_display(void);
 extern void reset_display(void);
 extern int ncurses_initialized(void);

--- a/src/display.h
+++ b/src/display.h
@@ -45,10 +45,10 @@ extern void window_refresh(void);
 
 class tab_window {
 public:
-	int cursor_pos;
-	int cursor_max;
-	short int xpad_pos, ypad_pos; 
-	WINDOW *win;
+	int cursor_pos = 0;
+	int cursor_max = 0;
+	short int xpad_pos = 0, ypad_pos = 0; 
+	WINDOW *win = nullptr;
 
 	tab_window() {
 		cursor_pos = 0;

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -106,7 +106,7 @@ std::string hz_to_human(unsigned long hz, int digits)
 	return std::format("{:9d}", (int)Hz);
 }
 
-map<unsigned long, string> kallsyms;
+std::map<unsigned long, std::string> kallsyms;
 
 static void read_kallsyms(void)
 {
@@ -121,7 +121,7 @@ static void read_kallsyms(void)
 
 	while (std::getline(stream, line)) {
 		size_t pos = line.find(' ');
-		if (pos == string::npos)
+		if (pos == std::string::npos)
 			continue;
 
 		unsigned long address = 0;
@@ -135,10 +135,10 @@ static void read_kallsyms(void)
 		std::string rest = line.substr(pos + 1);
 		/* skip type character and spaces */
 		size_t pos2 = rest.find_first_not_of(" \t");
-		if (pos2 != string::npos) {
+		if (pos2 != std::string::npos) {
 			/* skip the type char (e.g. 'T') and next spaces */
 			size_t pos3 = rest.find_first_not_of(" \t", pos2 + 1);
-			if (pos3 != string::npos) {
+			if (pos3 != std::string::npos) {
 				kallsyms[address] = rest.substr(pos3);
 			}
 		}
@@ -169,7 +169,7 @@ void set_max_cpu(int cpu)
 }
 
 
-void write_sysfs(const string &filename, const string &value)
+void write_sysfs(const std::string &filename, const std::string &value)
 {
 	if (test_framework_manager::get().is_replaying()) {
 		test_framework_manager::get().replay_write(filename, value);
@@ -178,9 +178,9 @@ void write_sysfs(const string &filename, const string &value)
 	if (test_framework_manager::get().is_recording()) {
 		test_framework_manager::get().record_write(filename, value);
 	}
-	ofstream file;
+	std::ofstream file;
 
-	file.open(filename.c_str(), ios::out);
+	file.open(filename.c_str(), std::ios::out);
 	if (!file)
 		return;
 	try
@@ -192,7 +192,7 @@ void write_sysfs(const string &filename, const string &value)
 	}
 }
 
-int read_sysfs(const string &filename, bool *ok)
+int read_sysfs(const std::string &filename, bool *ok)
 {
 	std::string content = read_file_content(filename);
 	if (content.empty()) {
@@ -213,24 +213,24 @@ int read_sysfs(const string &filename, bool *ok)
 	}
 }
 
-string read_sysfs_string(const string &filename)
+std::string read_sysfs_string(const std::string &filename)
 {
-	string content = read_file_content(filename);
+	std::string content = read_file_content(filename);
 	size_t pos = content.find('\n');
-	if (pos != string::npos)
+	if (pos != std::string::npos)
 		content.erase(pos);
 	return content;
 }
 
-string read_file_content(const string &filename)
+std::string read_file_content(const std::string &filename)
 {
 	if (test_framework_manager::get().is_replaying()) {
 		return test_framework_manager::get().replay_read(filename);
 	}
-	ifstream file;
-	string content;
+	std::ifstream file;
+	std::string content;
 
-	file.open(filename.c_str(), ios::in);
+	file.open(filename.c_str(), std::ios::in);
 	if (!file) {
 		if (test_framework_manager::get().is_recording()) {
 			test_framework_manager::get().record_read_fail(filename);
@@ -344,7 +344,7 @@ int utf_ok = -1;
 
 
 /* pretty print numbers while limiting the precision */
-string fmt_prefix(double n)
+std::string fmt_prefix(double n)
 {
 	static const char prefixes[] = "yzafpnum kMGTPEZY";
 	int omag, npfx;
@@ -369,7 +369,7 @@ string fmt_prefix(double n)
 
 	std::string tmpbuf = std::format("{:.2e}", n);
 	size_t e_pos = tmpbuf.find('e');
-	if (e_pos == string::npos) {
+	if (e_pos == std::string::npos) {
 		return "NaN";
 	}
 	
@@ -411,7 +411,7 @@ string fmt_prefix(double n)
 	return res;
 }
 
-static map<string, string> pretty_prints;
+static std::map<std::string, std::string> pretty_prints;
 static int pretty_print_init = 0;
 
 static void init_pretty_print(void)
@@ -483,7 +483,7 @@ void process_glob(const std::string &d_glob, callback fn)
 	globfree(&g);
 }
 
-string get_user_input(unsigned sz)
+std::string get_user_input(unsigned sz)
 {
 	std::string buf(sz + 1, '\0');
 	fflush(stdout);

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -380,6 +380,7 @@ std::string fmt_prefix(double n)
 	}
 
 	npfx = ((omag + 27) / 3) - (27/3);
+	npfx = std::clamp(npfx, -8, 8);
 	omag = (omag + 27) % 3;
 
 	if (omag == 2)

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -106,8 +106,6 @@ std::string hz_to_human(unsigned long hz, int digits)
 	return std::format("{:9d}", (int)Hz);
 }
 
-using namespace std;
-
 map<unsigned long, string> kallsyms;
 
 static void read_kallsyms(void)

--- a/src/lib.h
+++ b/src/lib.h
@@ -76,10 +76,10 @@ extern std::string kernel_function(uint64_t address);
 #include <ctime>
 #include <sys/time.h>
 
-extern void write_sysfs(const string &filename, const string &value);
-extern int read_sysfs(const string &filename, bool *ok = NULL);
-extern string read_sysfs_string(const string &filename);
-extern string read_file_content(const string &filename);
+extern void write_sysfs(const std::string &filename, const std::string &value);
+extern int read_sysfs(const std::string &filename, bool *ok = NULL);
+extern std::string read_sysfs_string(const std::string &filename);
+extern std::string read_file_content(const std::string &filename);
 extern struct timeval pt_gettime(void);
 
 extern std::string format_watts(double W, unsigned int len);

--- a/src/lib.h
+++ b/src/lib.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef INCLUDE_GUARD_LIB_H
-#define INCLUDE_GUARD_LIB_H
+#pragma once
 
 #define __unused __attribute__((unused))
 
@@ -114,4 +113,3 @@ extern void (*ui_notify_user) (const std::string &msg);
 
 #endif /* __cplusplus */
 
-#endif /* INCLUDE_GUARD_LIB_H */

--- a/src/lib.h
+++ b/src/lib.h
@@ -75,7 +75,6 @@ extern std::string kernel_function(uint64_t address);
 
 #include <ctime>
 #include <sys/time.h>
-using namespace std;
 
 extern void write_sysfs(const string &filename, const string &value);
 extern int read_sysfs(const string &filename, bool *ok = NULL);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -445,7 +445,7 @@ int main(int argc, char **argv)
 		int  iterations = 1, auto_tune = 0, sample_interval = 5;
 		bool auto_tune_dump = false;
 
-		set_new_handler(out_of_memory);
+		std::set_new_handler(out_of_memory);
 
 		setlocale (LC_ALL, "");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -509,7 +509,7 @@ int main(int argc, char **argv)
 				iterations = (optarg ? atoi(optarg) : 1);
 				break;
 			case 'q':
-				if (freopen("/dev/null", "a", stderr))
+				if (!freopen("/dev/null", "a", stderr))
 					fprintf(stderr, _("Quiet mode failed!\n"));
 				break;
 			case 's':

--- a/src/measurement/acpi.cpp
+++ b/src/measurement/acpi.cpp
@@ -33,8 +33,6 @@
 #include <limits.h>
 #include "../lib.h"
 
-using namespace std;
-
 acpi_power_meter::acpi_power_meter(const string &acpi_name) : power_meter(acpi_name)
 {
 	rate = 0.0;

--- a/src/measurement/acpi.cpp
+++ b/src/measurement/acpi.cpp
@@ -24,14 +24,8 @@
  */
 #include "measurement.h"
 #include "acpi.h"
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <limits.h>
 #include "../lib.h"
+#include <format>
 
 acpi_power_meter::acpi_power_meter(const std::string &acpi_name) : power_meter(acpi_name)
 {
@@ -40,130 +34,33 @@ acpi_power_meter::acpi_power_meter(const std::string &acpi_name) : power_meter(a
 	voltage = 0.0;
 }
 
-/*
-present:                 yes
-capacity state:          ok
-charging state:          discharging
-present rate:            8580 mW
-remaining capacity:      34110 mWh
-present voltage:         12001 mV
-*/
-
 void acpi_power_meter::measure(void)
 {
-	std::string filename;
-	std::string content;
-	std::istringstream stream;
-	std::string line;
+	rate = 0.0;
+	voltage = 0.0;
+	capacity = 0.0;
 
-	double _rate = 0;
-	double _capacity = 0;
-	double _voltage = 0;
+	std::string base = std::format("/sys/class/power_supply/{}/", name);
 
-	std::string rate_units = "Unknown";
-	std::string capacity_units = "Unknown";
-	std::string voltage_units = "Unknown";
-
-
-	rate = 0;
-	voltage = 0;
-	capacity = 0;
-
-	filename = std::format("/proc/acpi/battery/{}/state", name);
-	content = read_file_content(filename);
-	if (content.empty())
+	std::string status = read_sysfs_string(base + "status");
+	if (status != "Discharging")
 		return;
 
-	stream.str(content);
-
-	while (std::getline(stream, line)) {
-		if (line.find("present:") != std::string::npos && line.find("yes") == std::string::npos) {
-			return;
-		}
-		if (line.find("charging state:") != std::string::npos && line.find("discharging") == std::string::npos) {
-			return; /* not discharging */
-		}
-		if (line.find("present rate:") != std::string::npos) {
-			size_t pos = line.find(':');
-			if (pos != std::string::npos) {
-				std::istringstream iss(line.substr(pos + 1));
-				iss >> _rate >> rate_units;
-			}
-		}
-		if (line.find("remaining capacity:") != std::string::npos) {
-			size_t pos = line.find(':');
-			if (pos != std::string::npos) {
-				std::istringstream iss(line.substr(pos + 1));
-				iss >> _capacity >> capacity_units;
-			}
-		}
-		if (line.find("present voltage:") != std::string::npos) {
-			size_t pos = line.find(':');
-			if (pos != std::string::npos) {
-				std::istringstream iss(line.substr(pos + 1));
-				iss >> _voltage >> voltage_units;
-			}
-		}
+	/* Try direct power_now (µW → W) */
+	std::string pw = read_sysfs_string(base + "power_now");
+	if (!pw.empty()) {
+		try { rate = std::stod(pw) / 1000000.0; } catch (...) {}
+		return;
 	}
 
-	/* BIOS report random crack-inspired units. Lets try to get to the Si-system units */
-
-	if (voltage_units == "mV") {
-		_voltage = _voltage / 1000.0;
-		voltage_units = "V";
+	/* Fall back to current_now (µA) × voltage_now (µV) → W */
+	std::string cv = read_sysfs_string(base + "current_now");
+	std::string vv = read_sysfs_string(base + "voltage_now");
+	if (!cv.empty() && !vv.empty()) {
+		try {
+			rate = (std::stod(cv) * std::stod(vv)) / 1e12;
+		} catch (...) {}
 	}
-
-	if (rate_units == "mW") {
-		_rate = _rate / 1000.0;
-		rate_units = "W";
-	}
-
-	if (rate_units == "mA") {
-		_rate = _rate / 1000.0;
-		rate_units = "A";
-	}
-
-	if (capacity_units == "mAh") {
-		_capacity = _capacity / 1000.0;
-		capacity_units = "Ah";
-	}
-	if (capacity_units == "mWh") {
-		_capacity = _capacity / 1000.0;
-		capacity_units = "Wh";
-	}
-	if (capacity_units == "Wh") {
-		_capacity = _capacity * 3600.0;
-		capacity_units = "J";
-	}
-
-
-	if (capacity_units == "Ah" && voltage_units == "V") {
-		_capacity = _capacity * 3600.0 * _voltage;
-		capacity_units = "J";
-	}
-
-	if (rate_units == "A" && voltage_units == "V") {
-		_rate = _rate * _voltage;
-		rate_units = "W";
-	}
-
-
-
-
-	if (capacity_units == "J")
-		capacity = _capacity;
-	else
-		capacity = 0.0;
-
-	if (rate_units == "W")
-		rate = _rate;
-	else
-		rate = 0.0;
-
-	if (voltage_units == "V")
-		voltage = _voltage;
-	else
-		voltage = 0.0;
 }
 
 

--- a/src/measurement/acpi.cpp
+++ b/src/measurement/acpi.cpp
@@ -33,7 +33,7 @@
 #include <limits.h>
 #include "../lib.h"
 
-acpi_power_meter::acpi_power_meter(const string &acpi_name) : power_meter(acpi_name)
+acpi_power_meter::acpi_power_meter(const std::string &acpi_name) : power_meter(acpi_name)
 {
 	rate = 0.0;
 	capacity = 0.0;

--- a/src/measurement/acpi.h
+++ b/src/measurement/acpi.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef __INCLUDE_GUARD_ACPI_H
-#define __INCLUDE_GUARD_ACPI_H
+#pragma once
 
 #include "measurement.h"
 
@@ -41,4 +40,3 @@ public:
 	virtual double dev_capacity(void) { return capacity; };
 };
 
-#endif

--- a/src/measurement/acpi.h
+++ b/src/measurement/acpi.h
@@ -27,9 +27,9 @@
 #include "measurement.h"
 
 class acpi_power_meter: public power_meter {
-	double capacity;
-	double rate;
-	double voltage;
+	double capacity = 0.0;
+	double rate = 0.0;
+	double voltage = 0.0;
 	void measure(void);
 public:
 	acpi_power_meter(const std::string &_battery_name);

--- a/src/measurement/extech.cpp
+++ b/src/measurement/extech.cpp
@@ -306,9 +306,12 @@ void extech_power_meter::sample(void)
 		if (ret < 0)
 			continue;
 
-		sum += extech_read(fd);
-		samples++;
-
+		double v = extech_read(fd);
+		if (v >= 0.0) {
+			std::lock_guard<std::mutex> lock(samples_mutex);
+			sum += v;
+			samples++;
+		}
 	}
 }
 
@@ -325,19 +328,25 @@ extern "C"
 
 void extech_power_meter::end_measurement(void)
 {
-	end_thread = 1;
+	end_thread = true;
 	pthread_join( thread, NULL);
-	if (samples){
-		rate = sum / samples;
+	{
+		std::lock_guard<std::mutex> lock(samples_mutex);
+		if (samples)
+			rate = sum / samples;
+		else
+			measure();
 	}
-	else
-		measure();
 }
 
 void extech_power_meter::start_measurement(void)
 {
-	end_thread = 0;
-	sum = samples = 0;
+	end_thread = false;
+	{
+		std::lock_guard<std::mutex> lock(samples_mutex);
+		sum = 0.0;
+		samples = 0;
+	}
 
 	if (pthread_create(&thread, NULL, thread_proc, this))
 		fprintf(stderr, "ERROR: extech measurement thread creation failed\n");

--- a/src/measurement/extech.cpp
+++ b/src/measurement/extech.cpp
@@ -211,7 +211,7 @@ static int parse_packet(struct packet * p)
 	 * Fifth character in 5 character block should be '03'
 	 */
 	for (i = 0; i < 4; i++) {
-		if (p->buf[i * 0] != 2 || p->buf[i * 0 + 4] != 3) {
+		if (p->buf[i * 5] != 2 || p->buf[i * 5 + 4] != 3) {
 			printf("Invalid packet\n");
 			return -1;
 		}

--- a/src/measurement/extech.cpp
+++ b/src/measurement/extech.cpp
@@ -264,7 +264,7 @@ static double extech_read(int fd)
 	return -1000.0;
 }
 
-extech_power_meter::extech_power_meter(const string &extech_name) : power_meter(extech_name)
+extech_power_meter::extech_power_meter(const std::string &extech_name) : power_meter(extech_name)
 {
 	rate = 0.0;
 	int ret;

--- a/src/measurement/extech.cpp
+++ b/src/measurement/extech.cpp
@@ -61,8 +61,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-using namespace std;
-
 struct packet {
 	char	buf[256];
 	char	op[32];

--- a/src/measurement/extech.h
+++ b/src/measurement/extech.h
@@ -28,13 +28,13 @@
 #include "measurement.h"
 
 class extech_power_meter: public power_meter {
-	int fd;
+	int fd = 0;
 
-	double rate;
+	double rate = 0.0;
 	void measure(void);
-	double sum;
-	int samples;
-	int end_thread;
+	double sum = 0.0;
+	int samples = 0;
+	int end_thread = 0;
 	pthread_t thread;
 public:
 	extech_power_meter(const std::string &_dev_name);

--- a/src/measurement/extech.h
+++ b/src/measurement/extech.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include <pthread.h>
+#include <atomic>
+#include <mutex>
 #include "measurement.h"
 
 class extech_power_meter: public power_meter {
@@ -34,7 +36,8 @@ class extech_power_meter: public power_meter {
 	void measure(void);
 	double sum = 0.0;
 	int samples = 0;
-	int end_thread = 0;
+	std::atomic<bool> end_thread{false};
+	std::mutex samples_mutex;
 	pthread_t thread;
 public:
 	extech_power_meter(const std::string &_dev_name);

--- a/src/measurement/extech.h
+++ b/src/measurement/extech.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef __INCLUDE_GUARD_EXTECH_H
-#define __INCLUDE_GUARD_EXTECH_H
+#pragma once
 
 #include <pthread.h>
 #include "measurement.h"
@@ -47,4 +46,3 @@ public:
 	virtual double dev_capacity(void) { return 0.0; };
 };
 
-#endif

--- a/src/measurement/measurement.cpp
+++ b/src/measurement/measurement.cpp
@@ -62,7 +62,7 @@ static struct timespec tlast;
 void start_power_measurement(void)
 {
 	unsigned int i;
-	clock_gettime(CLOCK_REALTIME, &tlast);
+	clock_gettime(CLOCK_MONOTONIC, &tlast);
 	for (i = 0; i < power_meters.size(); i++)
 		power_meters[i]->start_measurement();
 	all_results.joules = 0.0;
@@ -99,7 +99,7 @@ void global_sample_power(void)
 {
 	struct timespec tnow;
 
-	clock_gettime(CLOCK_REALTIME, &tnow);
+	clock_gettime(CLOCK_MONOTONIC, &tnow);
 	/* power * time = joules */
 	all_results.joules += global_power() * \
 			 ( ((double)tnow.tv_sec + 1.0e-9*tnow.tv_nsec) - \

--- a/src/measurement/measurement.cpp
+++ b/src/measurement/measurement.cpp
@@ -55,7 +55,7 @@ double power_meter::power(void)
 	return 0.0;
 }
 
-vector<class power_meter *> power_meters;
+std::vector<class power_meter *> power_meters;
 
 static struct timespec tlast;
 

--- a/src/measurement/measurement.cpp
+++ b/src/measurement/measurement.cpp
@@ -171,9 +171,6 @@ void detect_power_meters(void)
 {
 	process_directory("/sys/class/power_supply", sysfs_power_meters_callback);
 	process_glob("/sys/devices/platform/opal-sensor/hwmon/hwmon*/power*", sysfs_opal_sensors_callback);
-	if (power_meters.size() == 0) {
-		process_directory("/proc/acpi/battery", acpi_power_meters_callback);
-	}
 }
 
 void extech_power_meter(const std::string &devnode)

--- a/src/measurement/measurement.h
+++ b/src/measurement/measurement.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef __INCLUDE_GUARD_MEASUREMENT_H
-#define __INCLUDE_GUARD_MEASUREMENT_H
+#pragma once
 
 #include <vector>
 #include <string>
@@ -70,4 +69,3 @@ extern void extech_power_meter(const std::string &devnode);
 
 extern double min_power;
 
-#endif

--- a/src/measurement/measurement.h
+++ b/src/measurement/measurement.h
@@ -56,7 +56,7 @@ public:
 	}
 };
 
-extern vector<class power_meter *> power_meters;
+extern std::vector<class power_meter *> power_meters;
 
 extern void start_power_measurement(void);
 extern void end_power_measurement(void);

--- a/src/measurement/measurement.h
+++ b/src/measurement/measurement.h
@@ -28,8 +28,6 @@
 #include <vector>
 #include <string>
 
-using namespace std;
-
 class power_meter {
 	bool discharging = false;
 public:

--- a/src/measurement/opal-sensors.cpp
+++ b/src/measurement/opal-sensors.cpp
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <limits.h>
 
-opal_sensors_power_meter::opal_sensors_power_meter(const string &power_supply_name) : power_meter(power_supply_name)
+opal_sensors_power_meter::opal_sensors_power_meter(const std::string &power_supply_name) : power_meter(power_supply_name)
 {
 }
 

--- a/src/measurement/opal-sensors.h
+++ b/src/measurement/opal-sensors.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Stewart Smith <stewart@linux.vnet.ibm.com>
  */
-#ifndef INCLUDE_GUARD_OPAL_SENSORS_H
-#define INCLUDE_GUARD_OPAL_SENSORS_H
+#pragma once
 
 #include "measurement.h"
 #include <limits.h>
@@ -38,4 +37,3 @@ public:
 	virtual double dev_capacity(void) { return 0.0; }
 };
 
-#endif

--- a/src/measurement/sysfs.cpp
+++ b/src/measurement/sysfs.cpp
@@ -29,13 +29,13 @@
 #include <stdio.h>
 #include <limits.h>
 
-sysfs_power_meter::sysfs_power_meter(const string &power_supply_name) : power_meter(power_supply_name)
+sysfs_power_meter::sysfs_power_meter(const std::string &power_supply_name) : power_meter(power_supply_name)
 {
 	rate = 0.0;
 	capacity = 0.0;
 }
 
-bool sysfs_power_meter::get_sysfs_attr(const string &attribute, int *value)
+bool sysfs_power_meter::get_sysfs_attr(const std::string &attribute, int *value)
 {
 	std::string filename;
 	bool ok;

--- a/src/measurement/sysfs.h
+++ b/src/measurement/sysfs.h
@@ -27,8 +27,8 @@
 #include "measurement.h"
 
 class sysfs_power_meter: public power_meter {
-	double capacity;
-	double rate;
+	double capacity = 0.0;
+	double rate = 0.0;
 
 	bool get_sysfs_attr(const std::string &attribute, int *value);
 	bool is_present();

--- a/src/measurement/sysfs.h
+++ b/src/measurement/sysfs.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Anssi Hannula <anssi.hannula@iki.fi>
  */
-#ifndef INCLUDE_GUARD_SYSFS_H
-#define INCLUDE_GUARD_SYSFS_H
+#pragma once
 
 #include "measurement.h"
 
@@ -50,4 +49,3 @@ public:
 	virtual double dev_capacity(void) { return capacity; }
 };
 
-#endif

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -128,6 +128,10 @@ double get_parameter_value(unsigned int index, struct parameter_bundle *the_bund
 
 double get_parameter_weight(int index, struct parameter_bundle *the_bundle)
 {
+	if (index < 0 || (unsigned int)index >= the_bundle->weights.size()) {
+		fprintf(stderr, "BUG: requesting unregistered weight %d\n", index);
+		return 1.0;
+	}
 	return the_bundle->weights[index];
 }
 

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -339,7 +339,7 @@ void store_results(double duration)
 		unsigned int overflow_index;
 		overflow_index = 50 + (rand() % MAX_KEEP);
 		if (past_results.size() >= MAX_PARAM) {
-			/* memory leak, must free old one first */
+			delete past_results[overflow_index];
 			past_results[overflow_index] = clone_results(&all_results);
 		} else {
 			past_results.push_back(clone_results(&all_results));

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -402,6 +402,12 @@ int utilization_power_valid(const std::string &u)
 	if (index <= 0)
 		return 0;
 
+	if (past_results.size() == 0)
+		return 0;
+
+	if (index >= (int)past_results[0]->utilization.size())
+		return 0;
+
 	first_value = past_results[0]->utilization[index];
 	for (i = 1; i < past_results.size(); i++) {
 		if (get_result_value(index, past_results[i]) < first_value - 0.0001)

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -36,16 +36,16 @@
 struct parameter_bundle all_parameters;
 struct result_bundle all_results;
 
-vector <struct result_bundle *> past_results;
+std::vector <struct result_bundle *> past_results;
 
-map <string, int> param_index;
+std::map <std::string, int> param_index;
 static int maxindex = 1;
-map <string, int> result_index;
+std::map <std::string, int> result_index;
 static int maxresindex = 1;
 
 int get_param_index(const std::string &name)
 {
-	std::map<string, int>::iterator it;
+	std::map<std::string, int>::iterator it;
 	int index = 0;
 
 	it = param_index.find(name);
@@ -61,7 +61,7 @@ int get_param_index(const std::string &name)
 
 int get_result_index(const std::string &name)
 {
-	std::map<string, int>::iterator it;
+	std::map<std::string, int>::iterator it;
 	int index = 0;
 
 	it = result_index.find(name);
@@ -246,7 +246,7 @@ double bundle_power(struct parameter_bundle *parameters, struct result_bundle *r
 
 void dump_parameter_bundle(struct parameter_bundle *para)
 {
-	map<string, int>::iterator it;
+	std::map<std::string, int>::iterator it;
 	int index;
 
 	printf("\n\n");
@@ -268,7 +268,7 @@ void dump_parameter_bundle(struct parameter_bundle *para)
 
 void dump_result_bundle(struct result_bundle *res)
 {
-	map<string, int>::iterator it;
+	std::map<std::string, int>::iterator it;
 	unsigned int index;
 
 	printf("\n\n");
@@ -289,7 +289,7 @@ void dump_result_bundle(struct result_bundle *res)
 struct result_bundle * clone_results(struct result_bundle *bundle)
 {
 	struct result_bundle *b2;
-	map<string, double>::iterator it;
+	std::map<std::string, double>::iterator it;
 	unsigned int i;
 
 	b2 = new struct result_bundle;

--- a/src/parameters/parameters.h
+++ b/src/parameters/parameters.h
@@ -34,8 +34,6 @@
 #include "../devices/device.h"
 #include "../lib.h"
 
-using namespace std;
-
 #define MAX_KEEP 700
 #define MAX_PARAM 750
 

--- a/src/parameters/parameters.h
+++ b/src/parameters/parameters.h
@@ -39,9 +39,9 @@
 
 struct parameter_bundle
 {
-	double score;
-	double guessed_power;
-	double actual_power;
+	double score = 0.0;
+	double guessed_power = 0.0;
+	double actual_power = 0.0;
 
 	std::vector<double> parameters;
 	std::vector<double> weights;
@@ -63,8 +63,8 @@ extern void set_parameter_value(const std::string &name, double value, struct pa
 
 struct result_bundle
 {
-	double joules;
-	double power;
+	double joules = 0.0;
+	double power = 0.0;
 	std::vector <double> utilization; /* device name, device utilization %age */
 };
 

--- a/src/parameters/parameters.h
+++ b/src/parameters/parameters.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef __INCLUDE_GUARD_PARAMETERS_H_
-#define __INCLUDE_GUARD_PARAMETERS_H_
+#pragma once
 
 
 #include <map>
@@ -117,5 +116,3 @@ int global_power_valid(void);
 
 extern int global_power_override;
 
-
-#endif

--- a/src/parameters/parameters.h
+++ b/src/parameters/parameters.h
@@ -44,13 +44,13 @@ struct parameter_bundle
 	double guessed_power;
 	double actual_power;
 
-	vector<double> parameters;
-	vector<double> weights;
+	std::vector<double> parameters;
+	std::vector<double> weights;
 };
 
 extern struct parameter_bundle all_parameters;
-extern map <string, int> param_index;
-extern map <string, int> result_index;
+extern std::map <std::string, int> param_index;
+extern std::map <std::string, int> result_index;
 
 extern int get_param_index(const std::string &param);
 extern int get_result_index(const std::string &param);
@@ -66,11 +66,11 @@ struct result_bundle
 {
 	double joules;
 	double power;
-	vector <double> utilization; /* device name, device utilization %age */
+	std::vector <double> utilization; /* device name, device utilization %age */
 };
 
 extern struct result_bundle all_results;
-extern vector <struct result_bundle *> past_results;
+extern std::vector <struct result_bundle *> past_results;
 
 extern double get_result_value(const std::string &name, struct result_bundle *bundle = &all_results);
 extern double get_result_value(int index, struct result_bundle *bundle = &all_results);

--- a/src/parameters/persistent.cpp
+++ b/src/parameters/persistent.cpp
@@ -33,25 +33,25 @@
 
 void save_all_results(const std::string &filename)
 {
-	ofstream file;
+	std::ofstream file;
 	unsigned int i;
 	struct result_bundle *bundle;
 	std::string pathname;
 
 	pathname = get_param_directory(filename);
 
-	file.open(pathname, ios::out);
+	file.open(pathname, std::ios::out);
 	if (!file) {
-		cout << _("Cannot save to file") << " " << pathname << "\n";
+		std::cout << _("Cannot save to file") << " " << pathname << "\n";
 		return;
 	}
 	for (i = 0; i < past_results.size(); i++) {
 		bundle = past_results[i];
-		map<string, int>::iterator it;
-		file << setiosflags(ios::fixed) <<  setprecision(5) << bundle->power << "\n";
+		std::map<std::string, int>::iterator it;
+		file << std::setiosflags(std::ios::fixed) <<  std::setprecision(5) << bundle->power << "\n";
 
 		for (it = result_index.begin(); it != result_index.end(); it++) {
-			file << it->first << "\t" << setprecision(5) << get_result_value(it->second, bundle) << "\n";
+			file << it->first << "\t" << std::setprecision(5) << get_result_value(it->second, bundle) << "\n";
 		}
 		file << ":\n";
 	}
@@ -72,7 +72,7 @@ void close_results()
 
 void load_results(const std::string &filename)
 {
-	string line;
+	std::string line;
 	struct result_bundle *bundle;
 	int first = 1;
 	unsigned int count = 0;
@@ -83,7 +83,7 @@ void load_results(const std::string &filename)
 
 	std::string content = read_file_content(pathname);
 	if (content.empty()) {
-		cout << _("Cannot load from file") << " " << pathname << "\n";
+		std::cout << _("Cannot load from file") << " " << pathname << "\n";
 		return;
 	}
 
@@ -96,7 +96,7 @@ void load_results(const std::string &filename)
 		if (first) {
 			if (line.length() > 0) {
 				try {
-					bundle->power = stod(line);
+					bundle->power = std::stod(line);
 					if (bundle->power < min_power)
 						min_power = bundle->power;
 				} catch (...) {}
@@ -123,13 +123,13 @@ void load_results(const std::string &filename)
 		}
 
 		size_t pos = line.find('\t');
-		if (pos == string::npos)
+		if (pos == std::string::npos)
 			continue;
 
-		string name = line.substr(0, pos);
-		string value_str = line.substr(pos + 1);
+		std::string name = line.substr(0, pos);
+		std::string value_str = line.substr(pos + 1);
 		try {
-			d = stod(value_str);
+			d = std::stod(value_str);
 			set_result_value(name, d, bundle);
 		} catch (...) {}
 	}
@@ -143,7 +143,7 @@ void load_results(const std::string &filename)
 
 void save_parameters(const std::string &filename)
 {
-	ofstream file;
+	std::ofstream file;
 	std::string pathname;
 
 //	printf("result size is %i, #parameters is %i \n", (int)past_results.size(), (int)all_parameters.parameters.size());
@@ -153,33 +153,33 @@ void save_parameters(const std::string &filename)
 
 	pathname = get_param_directory(filename);
 
-	file.open(pathname, ios::out);
+	file.open(pathname, std::ios::out);
 	if (!file) {
-		cout << _("Cannot save to file") << " " << pathname << "\n";
+		std::cout << _("Cannot save to file") << " " << pathname << "\n";
 		return;
 	}
 
-	map<string, int>::iterator it;
+	std::map<std::string, int>::iterator it;
 
 	for (it = param_index.begin(); it != param_index.end(); it++) {
 		int index;
 		index = it->second;
-		file << it->first << "\t" << setprecision(9) << all_parameters.parameters[index] << "\n";
+		file << it->first << "\t" << std::setprecision(9) << all_parameters.parameters[index] << "\n";
 	}
 	file.close();
 }
 
 void load_parameters(const std::string &filename)
 {
-	string line;
+	std::string line;
 	std::string pathname;
 
 	pathname = get_param_directory(filename);
 
 	std::string content = read_file_content(pathname);
 	if (content.empty()) {
-		cout << _("Cannot load from file") << " " << pathname << "\n";
-		cout << _("File will be loaded after taking minimum number of measurement(s) with battery only \n");
+		std::cout << _("Cannot load from file") << " " << pathname << "\n";
+		std::cout << _("File will be loaded after taking minimum number of measurement(s) with battery only \n");
 		return;
 	}
 
@@ -188,13 +188,13 @@ void load_parameters(const std::string &filename)
 	while (getline(stream, line)) {
 		double d;
 		size_t pos = line.find('\t');
-		if (pos == string::npos)
+		if (pos == std::string::npos)
 			continue;
 
-		string name = line.substr(0, pos);
-		string value_str = line.substr(pos + 1);
+		std::string name = line.substr(0, pos);
+		std::string value_str = line.substr(pos + 1);
 		try {
-			d = stod(value_str);
+			d = std::stod(value_str);
 			set_parameter_value(name, d);
 		} catch (...) {}
 	}

--- a/src/parameters/persistent.cpp
+++ b/src/parameters/persistent.cpp
@@ -111,7 +111,7 @@ void load_results(const std::string &filename)
 			bundle_saved = 1;
 			overflow_index = 50 + (rand() % MAX_KEEP);
 			if (past_results.size() >= MAX_PARAM) {
-			/* memory leak, must free old one first */
+				delete past_results[overflow_index];
 				past_results[overflow_index] = bundle;
 			} else {
 				past_results.push_back(bundle);

--- a/src/parameters/persistent.cpp
+++ b/src/parameters/persistent.cpp
@@ -31,8 +31,6 @@
 #include "parameters.h"
 #include "../measurement/measurement.h"
 
-using namespace std;
-
 void save_all_results(const std::string &filename)
 {
 	ofstream file;

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -172,10 +172,10 @@ void perf_event::set_event_name(const std::string &system_name, const std::strin
 
 perf_event::~perf_event(void)
 {
+	clear();
 	if (tep_get_ref(perf_event::tep) == 1) {
 		tep_free(perf_event::tep);
 		perf_event::tep = NULL;
-		clear();
 	} else
 		tep_unref(perf_event::tep);
 }

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -118,6 +118,8 @@ void perf_event::create_perf_event(const std::string &eventname __unused, int _c
 				PROT_READ | PROT_WRITE, MAP_SHARED, perf_fd, 0);
 	if (perf_mmap == MAP_FAILED) {
 		fprintf(stderr, "failed to mmap with %d (%s)\n", errno, strerror(errno));
+		close(perf_fd);
+		perf_fd = -1;
 		return;
 	}
 
@@ -198,6 +200,8 @@ perf_event::perf_event(const std::string &system_name, const std::string &event_
 	bufsize = buffer_size;
 	cpu = _cpu;
 	perf_mmap = NULL;
+	pc = nullptr;
+	data_mmap = nullptr;
 	trace_type = 0;
 	set_event_name(system_name, event_name);
 }
@@ -208,6 +212,8 @@ perf_event::perf_event(void)
 	perf_fd = -1;
 	bufsize = 128;
 	perf_mmap = NULL;
+	pc = nullptr;
+	data_mmap = nullptr;
 	cpu = 0;
 	trace_type = 0;
 }

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -55,7 +55,7 @@ static inline int sys_perf_event_open(struct perf_event_attr *attr,
 			group_fd, flags);
 }
 
-void perf_event::create_perf_event(const string &eventname __unused, int _cpu)
+void perf_event::create_perf_event(const std::string &eventname __unused, int _cpu)
 {
 	struct perf_event_attr attr;
 	int ret;
@@ -133,7 +133,7 @@ void perf_event::create_perf_event(const string &eventname __unused, int _cpu)
 
 }
 
-static int parse_event_format(const string &system_name, const string &event_name)
+static int parse_event_format(const std::string &system_name, const std::string &event_name)
 {
 	char *buf;
 	int size;
@@ -147,7 +147,7 @@ static int parse_event_format(const string &system_name, const string &event_nam
 	return 0;
 }
 
-void perf_event::set_event_name(const string &system_name, const string &event_name)
+void perf_event::set_event_name(const std::string &system_name, const std::string &event_name)
 {
 	struct tep_event *event;
 	int ret;
@@ -187,7 +187,7 @@ static void allocate_tep(void)
 		tep_ref(perf_event::tep);
 }
 
-perf_event::perf_event(const string &system_name, const string &event_name, int _cpu, int buffer_size)
+perf_event::perf_event(const std::string &system_name, const std::string &event_name, int _cpu, int buffer_size)
 {
 	allocate_tep();
 	perf_fd = -1;
@@ -218,7 +218,7 @@ void perf_event::stop(void)
 	int ret;
 	ret = ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0);
 	if (ret)
-		cout << "stop failing\n";
+		std::cout << "stop failing\n";
 }
 
 void perf_event::process(void *cookie)

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -160,6 +160,10 @@ void perf_event::set_event_name(const std::string &system_name, const std::strin
 			return;
 		}
 		event = tep_find_event_by_name(perf_event::tep, system_name.c_str(), event_name.c_str());
+		if (!event) {
+			trace_type = -1;
+			return;
+		}
 	}
 	trace_type = event->id;
 }

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -238,7 +238,10 @@ void perf_event::process(void *cookie)
 	if (perf_fd < 0)
 		return;
 
-	while (pc->data_tail != pc->data_head ) {
+	uint64_t head = pc->data_head;
+	__sync_synchronize(); /* required rmb() before reading ring buffer data */
+
+	while (pc->data_tail != head) {
 		while (pc->data_tail >= (unsigned int)bufsize * getpagesize())
 			pc->data_tail -= bufsize * getpagesize();
 
@@ -255,7 +258,7 @@ void perf_event::process(void *cookie)
 		if (header->type == PERF_RECORD_SAMPLE)
 			handle_event(header, cookie);
 	}
-	pc->data_tail = pc->data_head;
+	pc->data_tail = head;
 }
 
 void perf_event::clear(void)

--- a/src/perf/perf.h
+++ b/src/perf/perf.h
@@ -35,20 +35,20 @@ extern "C" {
 
 class  perf_event {
 protected:
-	int perf_fd;
-	void * perf_mmap;
-	void * data_mmap;
-	struct perf_event_mmap_page *pc;
+	int perf_fd = 0;
+	void * perf_mmap = nullptr;
+	void * data_mmap = nullptr;
+	struct perf_event_mmap_page *pc = nullptr;
 
 
 
-	int bufsize;
+	int bufsize = 0;
 	std::string name;
-	int cpu;
+	int cpu = 0;
 	void create_perf_event(const std::string &eventname, int cpu);
 
 public:
-	unsigned int trace_type;
+	unsigned int trace_type = 0;
 
 	perf_event(void);
 	perf_event(const std::string &system_name, const std::string &event_name, int cpu = 0, int buffer_size = 128);

--- a/src/perf/perf.h
+++ b/src/perf/perf.h
@@ -34,8 +34,6 @@ extern "C" {
 }
 
 
-using namespace std;
-
 class  perf_event {
 protected:
 	int perf_fd;

--- a/src/perf/perf.h
+++ b/src/perf/perf.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_PERF_H_
-#define _INCLUDE_GUARD_PERF_H_
+#pragma once
 
 #include <iostream>
 #include "../lib.h"
@@ -72,4 +71,3 @@ public:
 
 };
 
-#endif

--- a/src/perf/perf_bundle.cpp
+++ b/src/perf/perf_bundle.cpp
@@ -58,7 +58,7 @@ perf_bundle_event::perf_bundle_event(void) : perf_event()
 void perf_bundle_event::handle_event(struct perf_event_header *header, void *cookie)
 {
 	unsigned char *buffer;
-	vector<void *> *vector;
+	std::vector<void *> *vector;
 
 	buffer = (unsigned char *)malloc(header->size);
 	memcpy(buffer, header, header->size);
@@ -92,7 +92,7 @@ void perf_bundle::release(void)
 	records.clear();
 }
 
-bool perf_bundle::add_event(const string &system_name, const string &event_name)
+bool perf_bundle::add_event(const std::string &system_name, const std::string &event_name)
 {
 	unsigned int i;
 	int event_added = false;

--- a/src/perf/perf_bundle.h
+++ b/src/perf/perf_bundle.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_PERF_BUNDLE_H_
-#define _INCLUDE_GUARD_PERF_BUNDLE_H_
+#pragma once
 
 #include <iostream>
 #include <vector>
@@ -52,5 +51,3 @@ public:
 	virtual void handle_trace_point(void *trace, int cpu = 0, uint64_t time = 0);
 };
 
-
-#endif

--- a/src/perf/perf_bundle.h
+++ b/src/perf/perf_bundle.h
@@ -29,8 +29,6 @@
 #include <vector>
 #include <map>
 
-using namespace std;
-
 #include "perf.h"
 class perf_event;
 

--- a/src/perf/perf_bundle.h
+++ b/src/perf/perf_bundle.h
@@ -35,9 +35,9 @@ class perf_event;
 
 class  perf_bundle {
 protected:
-	vector<class perf_event *> events;
+	std::vector<class perf_event *> events;
 public:
-	vector<void *> records;
+	std::vector<void *> records;
 	virtual ~perf_bundle() {};
 
 	virtual void release(void);

--- a/src/perf/perf_event.h
+++ b/src/perf/perf_event.h
@@ -35,8 +35,7 @@
  *
  * For licencing details see kernel-base/COPYING
  */
-#ifndef _LINUX_PERF_EVENT_H
-#define _LINUX_PERF_EVENT_H
+#pragma once
 
 #include <linux/types.h>
 #include <linux/ioctl.h>
@@ -907,4 +906,3 @@ enum trace_flag_type {
 };
 #endif
 
-#endif /* _LINUX_PERF_EVENT_H */

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -143,6 +143,10 @@ static int get_wakeup_pending(unsigned int cpu)
 
 static void change_blame(unsigned int cpu, class power_consumer *consumer, int level)
 {
+	if (cpu_level.size() <= cpu)
+		return;
+	if (cpu_blame.size() <= cpu)
+		return;
 	if (cpu_level[cpu] >= level)
 		return;
 	cpu_blame[cpu] = consumer;

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -459,7 +459,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		ret = tep_get_field_val(NULL, event, "timer", &rec, &val, 0);
 		if (ret < 0) {
-			fprintf(stderr, "softirq_entry event returned no timer ?\n");
+			fprintf(stderr, "timer_expire_entry event returned no timer?\n");
 			return;
 		}
 		tmr = (uint64_t)val;

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -1219,5 +1219,6 @@ void clear_process_data(void)
 	if (perf_events)
 		perf_events->release();
 	delete perf_events;
+	perf_events = nullptr;
 }
 

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -65,6 +65,7 @@ std::vector<class power_consumer *> cpu_blame;
 #define LEVEL_WORK	6
 
 static uint64_t first_stamp, last_stamp;
+static uint64_t prev_disk_time;
 
 double measurement_time;
 
@@ -634,7 +635,6 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		}
 	}
 	else if (event_name == "writeback_inode_dirty") {
-		static uint64_t prev_time;
 		class power_consumer *consumer = NULL;
 		int dev;
 
@@ -651,10 +651,10 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 			consumer->disk_hits++;
 
 			/* if the previous inode dirty was > 1 second ago, it becomes a hard hit */
-			if ((time - prev_time) > 1000000000)
+			if ((time - prev_disk_time) > 1000000000)
 				consumer->hard_disk_hits++;
 
-			prev_time = time;
+			prev_disk_time = time;
 		}
 	}
 }
@@ -686,6 +686,7 @@ void start_process_measurement(void)
 
 	first_stamp = ~0ULL;
 	last_stamp = 0;
+	prev_disk_time = 0;
 	perf_events->start();
 }
 

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -721,72 +721,63 @@ static bool power_cpu_sort(class power_consumer * i, class power_consumer * j)
 
 double total_wakeups(void)
 {
+	if (measurement_time < 0.00001)
+		return 0.0;
 	double total = 0;
 	unsigned int i;
 	for (i = 0; i < all_power.size() ; i++)
 		total += all_power[i]->wake_ups;
 
-	total = total / measurement_time;
-
-
-	return total;
+	return total / measurement_time;
 }
 
 double total_gpu_ops(void)
 {
+	if (measurement_time < 0.00001)
+		return 0.0;
 	double total = 0;
 	unsigned int i;
 	for (i = 0; i < all_power.size() ; i++)
 		total += all_power[i]->gpu_ops;
 
-
-	total = total / measurement_time;
-
-
-	return total;
+	return total / measurement_time;
 }
 
 double total_disk_hits(void)
 {
+	if (measurement_time < 0.00001)
+		return 0.0;
 	double total = 0;
 	unsigned int i;
 	for (i = 0; i < all_power.size() ; i++)
 		total += all_power[i]->disk_hits;
 
-
-	total = total / measurement_time;
-
-
-	return total;
+	return total / measurement_time;
 }
 
 
 double total_hard_disk_hits(void)
 {
+	if (measurement_time < 0.00001)
+		return 0.0;
 	double total = 0;
 	unsigned int i;
 	for (i = 0; i < all_power.size() ; i++)
 		total += all_power[i]->hard_disk_hits;
 
-
-	total = total / measurement_time;
-
-
-	return total;
+	return total / measurement_time;
 }
 
 double total_xwakes(void)
 {
+	if (measurement_time < 0.00001)
+		return 0.0;
 	double total = 0;
 	unsigned int i;
 	for (i = 0; i < all_power.size() ; i++)
 		total += all_power[i]->xwakes;
 
-
-	total = total / measurement_time;
-
-
-	return total;
+	return total / measurement_time;
 }
 
 void process_update_display(void)
@@ -966,17 +957,23 @@ void report_process_update_display(void)
 				usage = std::format("{:5d}{}", (int)all_power[i]->usage(), all_power[i]->usage_units());
 		}
 
-		wakes = std::format("{:5.1f}", all_power[i]->wake_ups / measurement_time);
-		if (all_power[i]->wake_ups / measurement_time <= 0.3)
-			wakes = std::format("{:5.2f}", all_power[i]->wake_ups / measurement_time);
-		
-		gpus = std::format("{:5.1f}", all_power[i]->gpu_ops / measurement_time);
-		
-		disks = std::format("{:5.1f} ({:5.1f})", 
-				all_power[i]->hard_disk_hits / measurement_time,
-				all_power[i]->disk_hits / measurement_time);
-		
-		xwakes = std::format("{:5.1f}", all_power[i]->xwakes / measurement_time);
+		wakes = "  0.0";
+		gpus = "  0.0";
+		disks = "  0.0 (  0.0)";
+		xwakes = "  0.0";
+		if (measurement_time >= 0.00001) {
+			wakes = std::format("{:5.1f}", all_power[i]->wake_ups / measurement_time);
+			if (all_power[i]->wake_ups / measurement_time <= 0.3)
+				wakes = std::format("{:5.2f}", all_power[i]->wake_ups / measurement_time);
+
+			gpus = std::format("{:5.1f}", all_power[i]->gpu_ops / measurement_time);
+
+			disks = std::format("{:5.1f} ({:5.1f})",
+					all_power[i]->hard_disk_hits / measurement_time,
+					all_power[i]->disk_hits / measurement_time);
+
+			xwakes = std::format("{:5.1f}", all_power[i]->xwakes / measurement_time);
+		}
 
 		if (!all_power[i]->show_events()) {
 			wakes = "";

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -585,7 +585,9 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		consumer_child_time(cpu, t);
 	}
 	else if (event_name == "cpu_idle") {
-		tep_get_field_val(NULL, event, "state", &rec, &val, 0);
+		ret = tep_get_field_val(NULL, event, "state", &rec, &val, 0);
+		if (ret < 0)
+			return;
 		if (val == (unsigned int)-1)
 			consume_blame(cpu);
 		else

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -49,13 +49,13 @@
 
 static  class perf_bundle * perf_events;
 
-vector <class power_consumer *> all_power;
+std::vector <class power_consumer *> all_power;
 
-vector< vector<class power_consumer *> > cpu_stack;
+std::vector< std::vector<class power_consumer *> > cpu_stack;
 
-vector<int> cpu_level;
-vector<int> cpu_credit;
-vector<class power_consumer *> cpu_blame;
+std::vector<int> cpu_level;
+std::vector<int> cpu_credit;
+std::vector<class power_consumer *> cpu_blame;
 
 #define LEVEL_HARDIRQ	1
 #define LEVEL_SOFTIRQ	2
@@ -379,7 +379,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		irq->start_interrupt(time);
 
-		if (irq->handler.find("timer") == string::npos)
+		if (irq->handler.find("timer") == std::string::npos)
 			change_blame(cpu, irq, LEVEL_HARDIRQ);
 
 	}

--- a/src/process/interrupt.cpp
+++ b/src/process/interrupt.cpp
@@ -29,7 +29,7 @@
 #include "interrupt.h"
 #include "../lib.h"
 
-const vector<std::string> softirqs = {
+const std::vector<std::string> softirqs = {
 	"HI_SOFTIRQ",
 	"timer(softirq)",
 	"net tx(softirq)",
@@ -43,7 +43,7 @@ const vector<std::string> softirqs = {
 };
 
 
-interrupt::interrupt(const string &_handler, int _number) : power_consumer()
+interrupt::interrupt(const std::string &_handler, int _number) : power_consumer()
 {
 	running_since = 0;
 	number = _number;
@@ -53,7 +53,7 @@ interrupt::interrupt(const string &_handler, int _number) : power_consumer()
 }
 
 
-vector <class interrupt *> all_interrupts;
+std::vector <class interrupt *> all_interrupts;
 
 void interrupt::start_interrupt(uint64_t time)
 {

--- a/src/process/interrupt.h
+++ b/src/process/interrupt.h
@@ -51,8 +51,8 @@ public:
 	virtual std::string usage_units_summary(void);
 };
 
-extern vector <class interrupt *> all_interrupts;
-extern const vector<std::string> softirqs;
+extern std::vector <class interrupt *> all_interrupts;
+extern const std::vector<std::string> softirqs;
 
 
 extern class interrupt * find_create_interrupt(const std::string &_handler, int nr, int cpu);

--- a/src/process/interrupt.h
+++ b/src/process/interrupt.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_INTERRUPT_H
-#define _INCLUDE_GUARD_INTERRUPT_H
+#pragma once
 
 #include <stdint.h>
 
@@ -59,4 +58,3 @@ extern class interrupt * find_create_interrupt(const std::string &_handler, int 
 extern void all_interrupts_to_all_power(void);
 extern void clear_interrupts(void);
 
-#endif

--- a/src/process/interrupt.h
+++ b/src/process/interrupt.h
@@ -29,13 +29,13 @@
 #include "powerconsumer.h"
 
 class interrupt : public power_consumer {
-	uint64_t	running_since;
+	uint64_t	running_since = 0;
 	std::string	desc;
 public:
 	std::string	handler;
-	int		number;
+	int		number = 0;
 
-	int		raw_count;
+	int		raw_count = 0;
 
 	interrupt(const std::string &_handler, int _number);
 

--- a/src/process/powerconsumer.cpp
+++ b/src/process/powerconsumer.cpp
@@ -37,6 +37,9 @@ double power_consumer::Witts(void)
 	double hard_disk_cost;
 	double xwake_cost;
 
+	if (measurement_time < 0.00001)
+		return 0.0;
+
 	if (child_runtime > accumulated_runtime)
 		child_runtime = 0;
 
@@ -80,6 +83,8 @@ power_consumer::power_consumer(void)
 double power_consumer::usage(void)
 {
 	double t;
+	if (measurement_time < 0.00001)
+		return 0.0;
 	t = (accumulated_runtime - child_runtime) / 1000000.0 / measurement_time;
 	if (t < 0.7)
 		t = t * 1000;
@@ -89,6 +94,8 @@ double power_consumer::usage(void)
 std::string power_consumer::usage_units(void)
 {
 	double t;
+	if (measurement_time < 0.00001)
+		return "";
 	t = (accumulated_runtime - child_runtime) / 1000000.0 / measurement_time;
 	if (t < 0.7) {
 		if (utf_ok)

--- a/src/process/powerconsumer.h
+++ b/src/process/powerconsumer.h
@@ -67,7 +67,7 @@ public:
 	virtual int show_events(void) { return 1; };
 };
 
-extern vector <class power_consumer *> all_power;
+extern std::vector <class power_consumer *> all_power;
 
 extern double total_wakeups(void);
 extern double total_cpu_time(void);

--- a/src/process/powerconsumer.h
+++ b/src/process/powerconsumer.h
@@ -62,7 +62,7 @@ public:
 
 	virtual double usage_summary(void) { return usage();};
 	virtual std::string usage_units_summary(void) { return usage_units(); };
-	virtual double events(void) { return  (wake_ups + gpu_ops + hard_disk_hits) / measurement_time;};
+	virtual double events(void) { if (measurement_time < 0.00001) return 0.0; return  (wake_ups + gpu_ops + hard_disk_hits) / measurement_time;};
 	virtual int show_events(void) { return 1; };
 };
 

--- a/src/process/powerconsumer.h
+++ b/src/process/powerconsumer.h
@@ -30,8 +30,6 @@
 #include <algorithm>
 #include <string>
 
-using namespace std;
-
 extern double measurement_time;
 
 class power_consumer;

--- a/src/process/powerconsumer.h
+++ b/src/process/powerconsumer.h
@@ -36,17 +36,17 @@ class power_consumer;
 class power_consumer {
 
 public:
-	uint64_t	accumulated_runtime;
-	uint64_t	child_runtime;
-	int		disk_hits;
-	int		wake_ups;
-	int		gpu_ops;
-	int		hard_disk_hits;  /* those which are likely a wakeup of the disk */
-	int		xwakes;
+	uint64_t	accumulated_runtime = 0;
+	uint64_t	child_runtime = 0;
+	int		disk_hits = 0;
+	int		wake_ups = 0;
+	int		gpu_ops = 0;
+	int		hard_disk_hits = 0;  /* those which are likely a wakeup of the disk */
+	int		xwakes = 0;
 
-	double		power_charge;    /* power consumed by devices opened by this process */
-	class power_consumer *waker;
-	class power_consumer *last_waker;
+	double		power_charge = 0.0;    /* power consumed by devices opened by this process */
+	class power_consumer *waker = nullptr;
+	class power_consumer *last_waker = nullptr;
 
 	power_consumer(void);
 	virtual ~power_consumer() {};

--- a/src/process/powerconsumer.h
+++ b/src/process/powerconsumer.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef __INCLUDE_GUARD_POWER_CONSUMER_
-#define __INCLUDE_GUARD_POWER_CONSUMER_
+#pragma once
 
 #include <stdint.h>
 #include <vector>
@@ -74,5 +73,3 @@ extern double total_cpu_time(void);
 extern double total_gpu_ops(void);
 
 
-
-#endif

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -60,11 +60,14 @@ uint64_t process::deschedule_thread(uint64_t time, int thread_id)
 	if (!running_since)
 		return 0;
 
-	delta = time - running_since;
-
-	if (time < running_since)
+	if (time < running_since) {
 		printf("%llu time    %llu since \n", (unsigned long long)time,
 						     (unsigned long long)running_since);
+		running_since = 0;
+		return 0;
+	}
+
+	delta = time - running_since;
 
 	if (thread_id == 0) /* idle thread */
 		delta = 0;

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -39,7 +39,7 @@
 #include "../lib.h"
 
 
-vector <class process *> all_processes;
+std::vector <class process *> all_processes;
 
 void process::account_disk_dirty(void)
 {
@@ -80,7 +80,7 @@ static void cmdline_to_string(std::string& str)
 }
 
 
-process::process(const string &_comm, int _pid, int _tid) : power_consumer()
+process::process(const std::string &_comm, int _pid, int _tid) : power_consumer()
 {
 	comm = _comm;
 	pid = _pid;

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -119,14 +119,12 @@ process::process(const std::string &_comm, int _pid, int _tid) : power_consumer(
 	desc = std::format("[PID {}] {}", pid, comm);
 
 	std::string cmdline = read_file_content(std::format("/proc/{}/cmdline", _pid));
-	if (!cmdline.empty()) {
-		if (cmdline.size() < 1) {
-			is_kernel = 1;
-			desc = std::format("[PID {}] [{}]", pid, comm);
-		} else {
-			cmdline_to_string(cmdline);
-			desc = std::format("[PID {}] {}", pid, cmdline);
-		}
+	if (cmdline.empty()) {
+		is_kernel = 1;
+		desc = std::format("[PID {}] [{}]", pid, comm);
+	} else {
+		cmdline_to_string(cmdline);
+		desc = std::format("[PID {}] {}", pid, cmdline);
 	}
 }
 

--- a/src/process/process.h
+++ b/src/process/process.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_PROCESS_H
-#define _INCLUDE_GUARD_PROCESS_H
+#pragma once
 
 #include <stdint.h>
 
@@ -92,4 +91,3 @@ extern void report_summary(void);
 
 extern void clear_timers(void);
 
-#endif

--- a/src/process/process.h
+++ b/src/process/process.h
@@ -68,7 +68,7 @@ public:
 
 };
 
-extern vector <class process *> all_processes;
+extern std::vector <class process *> all_processes;
 
 extern double measurement_time;
 

--- a/src/process/process.h
+++ b/src/process/process.h
@@ -39,17 +39,17 @@ Need to collect
  * Number of disk dirties (inode for now)
  */
 class process : public power_consumer {
-	uint64_t	running_since;
+	uint64_t	running_since = 0;
 public:
 	std::string	desc;
-	int		tgid;
+	int		tgid = 0;
 	std::string	comm;
-	int		pid;
+	int		pid = 0;
 
 
-	int		is_idle;   /* count this as if the cpu was idle */
-	int		running;
-	int		is_kernel; /* kernel thread */
+	int		is_idle = 0;   /* count this as if the cpu was idle */
+	int		running = 0;
+	int		is_kernel = 0; /* kernel thread */
 
 	process(const std::string &_comm, int _pid, int _tid = 0);
 

--- a/src/process/processdevice.cpp
+++ b/src/process/processdevice.cpp
@@ -26,7 +26,7 @@
 #include "../parameters/parameters.h"
 #include <stdio.h>
 
-vector<class device_consumer *> all_proc_devices;
+std::vector<class device_consumer *> all_proc_devices;
 
 
 device_consumer::device_consumer(class device *dev) : power_consumer()

--- a/src/process/processdevice.h
+++ b/src/process/processdevice.h
@@ -31,9 +31,9 @@
 
 class device_consumer : public power_consumer {
 public:
-	int prio;
-	double power;
-	class device *device;
+	int prio = 0;
+	double power = 0.0;
+	class device *device = nullptr;
 	device_consumer(class device *dev);
 
 	virtual std::string description(void);

--- a/src/process/processdevice.h
+++ b/src/process/processdevice.h
@@ -47,7 +47,7 @@ public:
 };
 
 extern void all_devices_to_all_power(void);
-extern vector<class device_consumer *> all_proc_devices;
+extern std::vector<class device_consumer *> all_proc_devices;
 
 extern void clear_proc_devices(void);
 

--- a/src/process/processdevice.h
+++ b/src/process/processdevice.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_DEVICE2_H
-#define _INCLUDE_GUARD_DEVICE2_H
+#pragma once
 
 #include <stdint.h>
 
@@ -51,4 +50,3 @@ extern std::vector<class device_consumer *> all_proc_devices;
 
 extern void clear_proc_devices(void);
 
-#endif

--- a/src/process/timer.cpp
+++ b/src/process/timer.cpp
@@ -36,8 +36,6 @@
 
 #include <string_view>
 
-using namespace std;
-
 static bool timer_is_deferred(string_view handler)
 {
 	bool ret = false;

--- a/src/process/timer.cpp
+++ b/src/process/timer.cpp
@@ -36,7 +36,7 @@
 
 #include <string_view>
 
-static bool timer_is_deferred(string_view handler)
+static bool timer_is_deferred(std::string_view handler)
 {
 	bool ret = false;
 	std::string content = read_file_content("/proc/timer_stats");
@@ -66,8 +66,8 @@ timer::timer(unsigned long address) : power_consumer()
 }
 
 
-static map<unsigned long, class timer *> all_timers;
-static map<unsigned long, uint64_t> running_since;
+static std::map<unsigned long, class timer *> all_timers;
+static std::map<unsigned long, uint64_t> running_since;
 
 void timer::fire(uint64_t time, uint64_t timer_struct)
 {
@@ -107,14 +107,14 @@ std::string timer::usage_units_summary(void)
 
 
 
-static void add_timer(const pair<unsigned long, class timer*>& elem)
+static void add_timer(const std::pair<unsigned long, class timer*>& elem)
 {
 	all_power.push_back(elem.second);
 }
 
 void all_timers_to_all_power(void)
 {
-	for_each(all_timers.begin(), all_timers.end(), add_timer);
+	std::for_each(all_timers.begin(), all_timers.end(), add_timer);
 
 }
 

--- a/src/process/timer.cpp
+++ b/src/process/timer.cpp
@@ -107,15 +107,11 @@ std::string timer::usage_units_summary(void)
 
 
 
-static void add_timer(const std::pair<unsigned long, class timer*>& elem)
-{
-	all_power.push_back(elem.second);
-}
-
 void all_timers_to_all_power(void)
 {
-	std::for_each(all_timers.begin(), all_timers.end(), add_timer);
-
+	for (auto &[addr, t] : all_timers)
+		if (t->accumulated_runtime > 0)
+			all_power.push_back(t);
 }
 
 

--- a/src/process/timer.h
+++ b/src/process/timer.h
@@ -32,8 +32,8 @@ class timer : public power_consumer {
 	std::string desc;
 public:
 	std::string	handler;
-	int		raw_count;
-	bool		deferred;
+	int		raw_count = 0;
+	bool		deferred = false;
 
 	timer(unsigned long timer_func);
 
@@ -51,8 +51,8 @@ public:
 
 class timer_list {
 public:
-	uint64_t	timer_address;
-	uint64_t	timer_func;
+	uint64_t	timer_address = 0;
+	uint64_t	timer_func = 0;
 };
 
 

--- a/src/process/timer.h
+++ b/src/process/timer.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_TIMER_H
-#define _INCLUDE_GUARD_TIMER_H
+#pragma once
 
 #include <stdint.h>
 
@@ -61,4 +60,3 @@ extern void all_timers_to_all_power(void);
 extern class timer * find_create_timer(uint64_t func);
 extern void clear_timers(void);
 
-#endif

--- a/src/process/work.cpp
+++ b/src/process/work.cpp
@@ -42,8 +42,8 @@ work::work(unsigned long address) : power_consumer()
 }
 
 
-static map<unsigned long, class work *> all_work;
-static map<unsigned long, uint64_t> running_since;
+static std::map<unsigned long, class work *> all_work;
+static std::map<unsigned long, uint64_t> running_since;
 
 void work::fire(uint64_t time, uint64_t work_struct)
 {
@@ -84,14 +84,14 @@ std::string work::usage_units_summary(void)
 
 
 
-static void add_work(const pair<unsigned long, class work*>& elem)
+static void add_work(const std::pair<unsigned long, class work*>& elem)
 {
 	all_power.push_back(elem.second);
 }
 
 void all_work_to_all_power(void)
 {
-	for_each(all_work.begin(), all_work.end(), add_work);
+	std::for_each(all_work.begin(), all_work.end(), add_work);
 
 }
 

--- a/src/process/work.cpp
+++ b/src/process/work.cpp
@@ -33,8 +33,6 @@
 #include "../lib.h"
 #include "process.h"
 
-using namespace std;
-
 
 work::work(unsigned long address) : power_consumer()
 {

--- a/src/process/work.h
+++ b/src/process/work.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_WORK_H
-#define _INCLUDE_GUARD_WORK_H
+#pragma once
 
 #include <stdint.h>
 
@@ -54,4 +53,3 @@ extern class work * find_create_work(uint64_t func);
 
 extern void clear_work(void);
 
-#endif

--- a/src/process/work.h
+++ b/src/process/work.h
@@ -32,7 +32,7 @@ class work : public power_consumer {
 	std::string desc;
 public:
 	std::string	handler;
-	int		raw_count;
+	int		raw_count = 0;
 
 	work(unsigned long work_func);
 

--- a/src/report/report-data-html.cpp
+++ b/src/report/report-data-html.cpp
@@ -118,10 +118,11 @@ std::string
 double_to_string(double dval)
 {
 	std::ostringstream dtmp;
-	std::string str;
 	dtmp << dval;
-	str= dtmp.str();
-	str = str.substr(0, str.find(".")+2);
+	std::string str = dtmp.str();
+	auto dot = str.find('.');
+	if (dot != std::string::npos)
+		str = str.substr(0, dot + 2);
 	return str;
 }
 

--- a/src/report/report-data-html.cpp
+++ b/src/report/report-data-html.cpp
@@ -114,11 +114,11 @@ void init_wakeup_table_attr(struct table_attributes *table_css, int rows, int co
 }
 
 /* Other Helper Functions */
-string
+std::string
 double_to_string(double dval)
 {
-	ostringstream dtmp;
-	string str;
+	std::ostringstream dtmp;
+	std::string str;
 	dtmp << dval;
 	str= dtmp.str();
 	str = str.substr(0, str.find(".")+2);

--- a/src/report/report-data-html.h
+++ b/src/report/report-data-html.h
@@ -68,7 +68,7 @@ void
 init_wakeup_table_attr(struct table_attributes *table_css, int rows, int cols);
 
 /* Other helper functions */
-string
+std::string
 double_to_string(double dval);
 
 #endif

--- a/src/report/report-data-html.h
+++ b/src/report/report-data-html.h
@@ -15,15 +15,15 @@ struct table_attributes {
 	std::string td_class;
 	std::string tr_class;
 	std::string th_class;
-	position pos_table_title;
-	int title_mod;
-	int rows;
-	int cols;
+	position pos_table_title = T;
+	int title_mod = 0;
+	int rows = 0;
+	int cols = 0;
 };
 
 struct table_size {
-	int rows;
-	int cols;
+	int rows = 0;
+	int cols = 0;
 };
 
 

--- a/src/report/report-data-html.h
+++ b/src/report/report-data-html.h
@@ -1,5 +1,4 @@
-#ifndef PowerTop_REPORT_DATA_HTML_H_C58C116411234A34AC2EFB8D23A69713
-#define PowerTop_REPORT_DATA_HTML_H_C58C116411234A34AC2EFB8D23A69713
+#pragma once
 
 #include <string>
 #include <sstream>
@@ -71,4 +70,3 @@ init_wakeup_table_attr(struct table_attributes *table_css, int rows, int cols);
 std::string
 double_to_string(double dval);
 
-#endif

--- a/src/report/report-data-html.h
+++ b/src/report/report-data-html.h
@@ -4,8 +4,6 @@
 #include <string>
 #include <sstream>
 
-using namespace std;
-
 struct tag_attr {
 	std::string css_class;
 	std::string css_id;

--- a/src/report/report-formatter-base.cpp
+++ b/src/report/report-formatter-base.cpp
@@ -51,7 +51,7 @@ report_formatter_string_base::clear_result()
 /* ************************************************************************ */
 
 void
-report_formatter_string_base::add(const string &str)
+report_formatter_string_base::add(const std::string &str)
 {
 	result += escape_string(str);
 }
@@ -59,7 +59,7 @@ report_formatter_string_base::add(const string &str)
 /* ************************************************************************ */
 
 void
-report_formatter_string_base::add_exact(const string &str)
+report_formatter_string_base::add_exact(const std::string &str)
 {
 	result += str;
 }

--- a/src/report/report-formatter-base.h
+++ b/src/report/report-formatter-base.h
@@ -23,8 +23,7 @@
  * Written by Igor Zhbanov <i.zhbanov@samsung.com>
  * 2012.10 */
 
-#ifndef _REPORT_FORMATTER_BASE_H_
-#define _REPORT_FORMATTER_BASE_H_
+#pragma once
 
 #include "report-formatter.h"
 
@@ -44,4 +43,3 @@ protected:
 	std::string result;
 };
 
-#endif /* _REPORT_FORMATTER_BASE_H_ */

--- a/src/report/report-formatter-csv.cpp
+++ b/src/report/report-formatter-csv.cpp
@@ -49,10 +49,10 @@ report_formatter_csv::finish_report()
 }
 
 
-string
-report_formatter_csv::escape_string(const string &str)
+std::string
+report_formatter_csv::escape_string(const std::string &str)
 {
-	string res;
+	std::string res;
 
 	for (size_t i = 0; i < str.length(); i++) {
 		switch (str[i]) {
@@ -109,7 +109,7 @@ report_formatter_csv::end_div()
 	/*Do nothing*/
 }
 
-void report_formatter_csv::add_title(struct tag_attr *title_att __unused, const string &title)
+void report_formatter_csv::add_title(struct tag_attr *title_att __unused, const std::string &title)
 
 {
 	add_exact("____________________________________________________________________\n");
@@ -140,7 +140,7 @@ report_formatter_csv::add_table(const std::vector<std::string> &system_data, str
 {
 	int i, j;
 	int offset=0;
-	string tmp_str="";
+	std::string tmp_str="";
 	int empty_row=0;
 	add_exact("\n");
 	for (i=0; i < tb_attr->rows; i++){

--- a/src/report/report-formatter-csv.h
+++ b/src/report/report-formatter-csv.h
@@ -43,8 +43,6 @@
 /* Whether to escape with quotes empty cell values with spaces */
 /*#define REPORT_CSV_SPACE_NEED_QUOTES*/
 
-using namespace std;
-
 /* ************************************************************************ */
 
 class report_formatter_csv: public report_formatter_string_base

--- a/src/report/report-formatter-csv.h
+++ b/src/report/report-formatter-csv.h
@@ -62,7 +62,7 @@ public:
 	void add_summary_list(const std::vector<std::string> &list);
 	void add_table(const std::vector<std::string> &system_data, struct table_attributes *tb_attr);private:
 	void add_quotes();
-	string escape_string(const std::string &str);
+	std::string escape_string(const std::string &str);
 	bool csv_need_quotes;
 	size_t text_start;
 };

--- a/src/report/report-formatter-csv.h
+++ b/src/report/report-formatter-csv.h
@@ -62,7 +62,7 @@ public:
 	void add_table(const std::vector<std::string> &system_data, struct table_attributes *tb_attr);private:
 	void add_quotes();
 	std::string escape_string(const std::string &str);
-	bool csv_need_quotes;
-	size_t text_start;
+	bool csv_need_quotes = false;
+	size_t text_start = 0;
 };
 

--- a/src/report/report-formatter-csv.h
+++ b/src/report/report-formatter-csv.h
@@ -23,8 +23,7 @@
  * Written by Igor Zhbanov <i.zhbanov@samsung.com>
  * 2012.10 */
 
-#ifndef _REPORT_FORMATTER_CSV_H_
-#define _REPORT_FORMATTER_CSV_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -67,4 +66,3 @@ public:
 	size_t text_start;
 };
 
-#endif /* _REPORT_FORMATTER_CSV_H_ */

--- a/src/report/report-formatter-html.cpp
+++ b/src/report/report-formatter-html.cpp
@@ -99,10 +99,10 @@ report_formatter_html::add_doc_footer()
 }
 
 /* ************************************************************************ */
-string
-report_formatter_html::escape_string(const string &str)
+std::string
+report_formatter_html::escape_string(const std::string &str)
 {
-	string res;
+	std::string res;
 
 	for (size_t i = 0; i < str.length(); i++) {
 		switch (str[i]) {
@@ -277,7 +277,7 @@ report_formatter_html::end_header()
 void
 report_formatter_html::add_div(struct tag_attr *div_attr)
 {
-	string  empty="";
+	std::string  empty="";
 
 	if (div_attr->css_class == empty && div_attr->css_id == empty)
 		add_exact("<div>\n");
@@ -300,7 +300,7 @@ report_formatter_html::end_div()
 }
 
 void
-report_formatter_html::add_title(struct tag_attr *title_att, const string &title)
+report_formatter_html::add_title(struct tag_attr *title_att, const std::string &title)
 {
 	add_exact(std::format("<h2 class=\"{}\"> {} </h2>\n", title_att->css_class, title));
 }
@@ -328,7 +328,7 @@ report_formatter_html::add_table(const std::vector<std::string> &system_data, st
 {
 	int i, j;
 	int offset=0;
-	string  empty="";
+	std::string  empty="";
 
 	if (tb_attr->table_class == empty)
 		add_exact("<table>\n");

--- a/src/report/report-formatter-html.cpp
+++ b/src/report/report-formatter-html.cpp
@@ -315,7 +315,7 @@ void
 report_formatter_html::add_summary_list(const std::vector<std::string> &list)
 {
 	add_exact("<div><br/> <ul>\n");
-	for (size_t i=0; i < list.size(); i+=2){
+	for (size_t i = 0; i + 1 < list.size(); i += 2) {
 		add_exact(std::format("<li class=\"summary_list\"> <b> {} </b> {} </li>",
 				list[i], list[i+1]));
 	}

--- a/src/report/report-formatter-html.h
+++ b/src/report/report-formatter-html.h
@@ -32,8 +32,6 @@
 #include "report-formatter-base.h"
 #include "report-data-html.h"
 
-using namespace std;
-
 /* Whether to replace " and ' in HTML by &quot; and &apos; respectively */
 /*#define REPORT_HTML_ESCAPE_QUOTES*/
 

--- a/src/report/report-formatter-html.h
+++ b/src/report/report-formatter-html.h
@@ -63,7 +63,7 @@ public:
 	void init_markup();
 	void add_doc_header();
 	void add_doc_footer();
-	string escape_string(const std::string &str);
+	std::string escape_string(const std::string &str);
 
 };
 

--- a/src/report/report-formatter-html.h
+++ b/src/report/report-formatter-html.h
@@ -23,8 +23,7 @@
  * Written by Igor Zhbanov <i.zhbanov@samsung.com>
  * 2012.10 */
 
-#ifndef _REPORT_FORMATTER_HTML_H_
-#define _REPORT_FORMATTER_HTML_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -67,4 +66,3 @@ public:
 
 };
 
-#endif /* _REPORT_FORMATTER_HTML_H_ */

--- a/src/report/report-formatter.h
+++ b/src/report/report-formatter.h
@@ -23,8 +23,7 @@
  * Written by Igor Zhbanov <i.zhbanov@samsung.com>
  * 2012.10 */
 
-#ifndef _REPORT_FORMATTER_H_
-#define _REPORT_FORMATTER_H_
+#pragma once
 
 #include <vector>
 #include "report-maker.h"
@@ -54,4 +53,3 @@ public:
 			struct table_attributes *tb_attr __unused)     {}
 };
 
-#endif /* _REPORT_FORMATTER_H_ */

--- a/src/report/report-formatter.h
+++ b/src/report/report-formatter.h
@@ -29,7 +29,6 @@
 #include <vector>
 #include "report-maker.h"
 #include "../lib.h"
-using namespace std;
 
 class report_formatter
 {

--- a/src/report/report-maker.cpp
+++ b/src/report/report-maker.cpp
@@ -112,7 +112,7 @@ report_maker::setup_report_formatter()
 /* ************************************************************************ */
 
 void
-report_maker::add(const string &str)
+report_maker::add(const std::string &str)
 {
 	formatter->add(str);
 }
@@ -137,7 +137,7 @@ report_maker::end_header()
 }
 
 void
-report_maker::add_title(struct tag_attr *att_title, const string &title)
+report_maker::add_title(struct tag_attr *att_title, const std::string &title)
 {
 	formatter->add_title(att_title, title);
 }

--- a/src/report/report-maker.h
+++ b/src/report/report-maker.h
@@ -129,7 +129,7 @@ public:
 
 private:
 	void setup_report_formatter();
-	report_type type;
-	report_formatter *formatter;
+	report_type type = REPORT_OFF;
+	report_formatter *formatter = nullptr;
 };
 

--- a/src/report/report-maker.h
+++ b/src/report/report-maker.h
@@ -23,8 +23,7 @@
  * Written by Igor Zhbanov <i.zhbanov@samsung.com>
  * 2012.10 */
 
-#ifndef _REPORT_MAKER_H_
-#define _REPORT_MAKER_H_
+#pragma once
 
 /* This report generator implements the following document structure:
  *	body
@@ -133,4 +132,4 @@ private:
 	report_type type;
 	report_formatter *formatter;
 };
-#endif /* _REPORT_MAKER_H_ */
+

--- a/src/report/report-maker.h
+++ b/src/report/report-maker.h
@@ -62,7 +62,6 @@
 
 #include <string>
 #include <vector>
-using namespace std;
 /* Conditional gettext. We need original strings for CSV. */
 #ifdef ENABLE_NLS
 #define __(STRING) \

--- a/src/report/report.cpp
+++ b/src/report/report.cpp
@@ -101,6 +101,8 @@ static std::string get_time_string(const std::string &fmt, time_t t)
 {
 	char buf[128];
 	struct tm *tm_info = localtime(&t);
+	if (!tm_info)
+		return "";
 	if (strftime(buf, sizeof(buf), fmt.c_str(), tm_info))
 		return buf;
 	return "";

--- a/src/report/report.cpp
+++ b/src/report/report.cpp
@@ -126,7 +126,7 @@ static void system_info(void)
 	/* Set array of data in row Major order */
 	std::vector<std::string> system_data(sys_table.rows * sys_table.cols);
 	system_data[0]=__("PowerTOP Version");
-	system_data[1]=std::format("{} ran at {}", PACKAGE_VERSION, get_time_string("%c", now));
+	system_data[1] = pt_format(_("{} ran at {}"), PACKAGE_VERSION, get_time_string("%c", now));
 
 	str = read_sysfs_string("/proc/version");
 	size_t  found = str.find(" ");

--- a/src/report/report.cpp
+++ b/src/report/report.cpp
@@ -40,8 +40,6 @@
 #include <format>
 #include "report-data-html.h"
 
-using namespace std;
-
 struct reportstream reportout;
 report_type reporttype = REPORT_OFF;
 report_maker report(REPORT_OFF);

--- a/src/report/report.cpp
+++ b/src/report/report.cpp
@@ -44,7 +44,7 @@ struct reportstream reportout;
 report_type reporttype = REPORT_OFF;
 report_maker report(REPORT_OFF);
 
-string cpu_model(void)
+std::string cpu_model(void)
 {
 	std::string content = read_file_content("/proc/cpuinfo");
 	if (content.empty())
@@ -68,26 +68,26 @@ string cpu_model(void)
 	return "";
 }
 
-static string read_os_release(const string &filename)
+static std::string read_os_release(const std::string &filename)
 {
-	ifstream file;
-	string line;
-	const string pname = "PRETTY_NAME=";
-	string os("");
+	std::ifstream file;
+	std::string line;
+	const std::string pname = "PRETTY_NAME=";
+	std::string os("");
 
-	file.open(filename, ios::in);
+	file.open(filename, std::ios::in);
 	if (!file)
 		return "";
 	while (getline(file, line)) {
 		if (line.starts_with(pname)) {
 			size_t pos = line.find('=');
-			if (pos == string::npos)
+			if (pos == std::string::npos)
 				break;
 			os = line.substr(pos + 1);
 			if (os.length() >= 2 && (os.front() == '"' || os.front() == '\'')) {
 				os.erase(0, 1);
 				size_t end_pos = os.find_first_of("\"\'");
-				if (end_pos != string::npos)
+				if (end_pos != std::string::npos)
 					os.erase(end_pos);
 			}
 			break;
@@ -97,7 +97,7 @@ static string read_os_release(const string &filename)
 	return os;
 }
 
-static string get_time_string(const std::string &fmt, time_t t)
+static std::string get_time_string(const std::string &fmt, time_t t)
 {
 	char buf[128];
 	struct tm *tm_info = localtime(&t);
@@ -108,7 +108,7 @@ static string get_time_string(const std::string &fmt, time_t t)
 
 static void system_info(void)
 {
-	string str;
+	std::string str;
 	time_t now = time(NULL);
 
 	/* div attr css_class and css_id */
@@ -176,7 +176,7 @@ void init_report_output(const std::string &filename_str, int iterations)
 	else
 	{
 		period = filename_str.find_last_of(".");
-		if (period == string::npos)
+		if (period == std::string::npos)
 			period = filename_str.length();
 
 		stamp = time(NULL);
@@ -186,7 +186,7 @@ void init_report_output(const std::string &filename_str, int iterations)
 			filename_str.substr(period));
 	}
 
-	reportout.report_file.open(reportout.filename, ios::out);
+	reportout.report_file.open(reportout.filename, std::ios::out);
 	if (!reportout.report_file) {
 		fprintf(stderr, _("Cannot open output file %s (%s)\n"),
 			reportout.filename.c_str(), strerror(errno));

--- a/src/report/report.h
+++ b/src/report/report.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef __INCLUDE_GUARD_REPORT_H_
-#define __INCLUDE_GUARD_REPORT_H_
+#pragma once
 
 #include <string>
 #include <stdio.h>
@@ -43,4 +42,3 @@ extern struct reportstream reportout;
 extern void init_report_output(const std::string &filename_str, int iterations);
 extern void finish_report_output(void);
 
-#endif

--- a/src/report/report.h
+++ b/src/report/report.h
@@ -32,8 +32,6 @@
 
 #include "report-maker.h"
 
-using namespace std;
-
 struct reportstream {
 	std::ofstream report_file;
 	std::string filename;

--- a/src/test_framework.cpp
+++ b/src/test_framework.cpp
@@ -89,7 +89,7 @@ void test_framework_manager::record_msr(int cpu, uint64_t offset, uint64_t value
 
 int test_framework_manager::replay_msr(int cpu, uint64_t offset, uint64_t *value) {
 	if (!replaying) return -1;
-	auto key = make_pair(cpu, offset);
+	auto key = std::make_pair(cpu, offset);
 	if (msr_sequences[key].empty()) {
 		throw test_exception(std::format("TEST FAIL: No more recorded content for MSR read: cpu {} offset 0x{:x}", cpu, offset));
 	}
@@ -113,7 +113,7 @@ void test_framework_manager::replay_time(struct timeval *tv) {
 }
 
 void test_framework_manager::save() {
-	ofstream file(record_filename);
+	std::ofstream file(record_filename);
 	if (!file) {
 		std::cerr << "Failed to open record file: " << record_filename << std::endl;
 		return;
@@ -129,7 +129,7 @@ void test_framework_manager::save() {
 		file << "W " << p.first << " " << base64_encode(p.second) << std::endl;
 	}
 	for (const auto& m : recorded_msrs) {
-		file << "M " << std::get<0>(m) << " " << hex << std::get<1>(m) << " " << std::get<2>(m) << dec << std::endl;
+		file << "M " << std::get<0>(m) << " " << std::hex << std::get<1>(m) << " " << std::get<2>(m) << std::dec << std::endl;
 	}
 	for (const auto& t : recorded_times) {
 		file << "T " << t.tv_sec << " " << t.tv_usec << std::endl;
@@ -137,7 +137,7 @@ void test_framework_manager::save() {
 }
 
 void test_framework_manager::load() {
-	ifstream file(replay_filename);
+	std::ifstream file(replay_filename);
 	if (!file) {
 		std::cerr << "Failed to open replay file: " << replay_filename << std::endl;
 		return;
@@ -159,16 +159,16 @@ void test_framework_manager::load() {
 		}
 
 		if (type == 'M') {
-			stringstream msr_ss(rest);
+			std::stringstream msr_ss(rest);
 			int cpu;
 			uint64_t offset, value;
-			msr_ss >> cpu >> hex >> offset >> value;
-			msr_sequences[make_pair(cpu, offset)].push_back(value);
+			msr_ss >> cpu >> std::hex >> offset >> value;
+			msr_sequences[std::make_pair(cpu, offset)].push_back(value);
 			continue;
 		}
 
 		if (type == 'T') {
-			stringstream time_ss(rest);
+			std::stringstream time_ss(rest);
 			struct timeval tv;
 			time_ss >> tv.tv_sec >> tv.tv_usec;
 			time_sequences.push_back(tv);

--- a/src/test_framework.cpp
+++ b/src/test_framework.cpp
@@ -15,8 +15,6 @@
 #include <format>
 #include "test_framework.h"
 
-using namespace std;
-
 test_framework_manager& test_framework_manager::get() {
 	static test_framework_manager instance;
 	return instance;

--- a/src/test_framework.cpp
+++ b/src/test_framework.cpp
@@ -29,56 +29,56 @@ test_framework_manager::~test_framework_manager() {
 	}
 }
 
-void test_framework_manager::set_record(const string& filename) {
+void test_framework_manager::set_record(const std::string& filename) {
 	recording = true;
 	record_filename = filename;
 }
 
-void test_framework_manager::set_replay(const string& filename) {
+void test_framework_manager::set_replay(const std::string& filename) {
 	replaying = true;
 	replay_filename = filename;
 	load();
 }
 
-void test_framework_manager::record_read(const string& path, const string& content) {
+void test_framework_manager::record_read(const std::string& path, const std::string& content) {
 	if (!recording) return;
 	recorded_reads.push_back({path, content});
 }
 
-void test_framework_manager::record_read_fail(const string& path) {
+void test_framework_manager::record_read_fail(const std::string& path) {
 	if (!recording) return;
 	recorded_reads.push_back({path, "__POWERTOP_FILE_NOT_FOUND__"});
 }
 
-string test_framework_manager::replay_read(const string& path) {
+std::string test_framework_manager::replay_read(const std::string& path) {
 	if (!replaying) return "";
 	if (read_sequences[path].empty()) {
 		throw test_exception("TEST FAIL: No more recorded content for read: " + path);
 	}
-	string content = read_sequences[path].front();
+	std::string content = read_sequences[path].front();
 	read_sequences[path].pop_front();
 	if (content == "__POWERTOP_FILE_NOT_FOUND__")
 		return "";
 	return content;
 }
 
-void test_framework_manager::record_write(const string& path, const string& content) {
+void test_framework_manager::record_write(const std::string& path, const std::string& content) {
 	if (!recording) return;
 	recorded_writes.push_back({path, content});
 }
 
-void test_framework_manager::replay_write(const string& path, const string& content) {
+void test_framework_manager::replay_write(const std::string& path, const std::string& content) {
 	if (!replaying) return;
 	if (write_sequences[path].empty()) {
-		cerr << "TEST FAIL: Unexpected write to: " << path << " (nothing recorded)" << endl;
+		std::cerr << "TEST FAIL: Unexpected write to: " << path << " (nothing recorded)" << std::endl;
 		return;
 	}
-	string expected = write_sequences[path].front();
+	std::string expected = write_sequences[path].front();
 	write_sequences[path].pop_front();
 	if (expected != content) {
-		cerr << "TEST FAIL: Write mismatch for " << path << endl;
-		cerr << "  Expected: " << expected << endl;
-		cerr << "  Actual:   " << content << endl;
+		std::cerr << "TEST FAIL: Write mismatch for " << path << std::endl;
+		std::cerr << "  Expected: " << expected << std::endl;
+		std::cerr << "  Actual:   " << content << std::endl;
 	}
 }
 
@@ -115,43 +115,43 @@ void test_framework_manager::replay_time(struct timeval *tv) {
 void test_framework_manager::save() {
 	ofstream file(record_filename);
 	if (!file) {
-		cerr << "Failed to open record file: " << record_filename << endl;
+		std::cerr << "Failed to open record file: " << record_filename << std::endl;
 		return;
 	}
 
 	for (const auto& p : recorded_reads) {
 		if (p.second == "__POWERTOP_FILE_NOT_FOUND__")
-			file << "N " << p.first << endl;
+			file << "N " << p.first << std::endl;
 		else
-			file << "R " << p.first << " " << base64_encode(p.second) << endl;
+			file << "R " << p.first << " " << base64_encode(p.second) << std::endl;
 	}
 	for (const auto& p : recorded_writes) {
-		file << "W " << p.first << " " << base64_encode(p.second) << endl;
+		file << "W " << p.first << " " << base64_encode(p.second) << std::endl;
 	}
 	for (const auto& m : recorded_msrs) {
-		file << "M " << std::get<0>(m) << " " << hex << std::get<1>(m) << " " << std::get<2>(m) << dec << endl;
+		file << "M " << std::get<0>(m) << " " << hex << std::get<1>(m) << " " << std::get<2>(m) << dec << std::endl;
 	}
 	for (const auto& t : recorded_times) {
-		file << "T " << t.tv_sec << " " << t.tv_usec << endl;
+		file << "T " << t.tv_sec << " " << t.tv_usec << std::endl;
 	}
 }
 
 void test_framework_manager::load() {
 	ifstream file(replay_filename);
 	if (!file) {
-		cerr << "Failed to open replay file: " << replay_filename << endl;
+		std::cerr << "Failed to open replay file: " << replay_filename << std::endl;
 		return;
 	}
 
-	string line;
+	std::string line;
 	while (getline(file, line)) {
 		if (line.empty()) continue;
 
 		size_t first_space = line.find(' ');
-		if (first_space == string::npos) continue;
+		if (first_space == std::string::npos) continue;
 
 		char type = line[0];
-		string rest = line.substr(first_space + 1);
+		std::string rest = line.substr(first_space + 1);
 
 		if (type == 'N') {
 			read_sequences[rest].push_back("__POWERTOP_FILE_NOT_FOUND__");
@@ -176,10 +176,10 @@ void test_framework_manager::load() {
 		}
 
 		size_t last_space = rest.rfind(' ');
-		if (last_space == string::npos) continue;
+		if (last_space == std::string::npos) continue;
 
-		string path = rest.substr(0, last_space);
-		string b64_content = rest.substr(last_space + 1);
+		std::string path = rest.substr(0, last_space);
+		std::string b64_content = rest.substr(last_space + 1);
 
 		if (type == 'R') {
 			read_sequences[path].push_back(base64_decode(b64_content));
@@ -189,13 +189,13 @@ void test_framework_manager::load() {
 	}
 }
 
-static const string base64_chars = 
+static const std::string base64_chars = 
              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
              "abcdefghijklmnopqrstuvwxyz"
              "0123456789+/";
 
-string test_framework_manager::base64_encode(const string& in) {
-    string out;
+std::string test_framework_manager::base64_encode(const std::string& in) {
+    std::string out;
     int val = 0, valb = -6;
     for (unsigned char c : in) {
         val = (val << 8) + c;
@@ -210,9 +210,9 @@ string test_framework_manager::base64_encode(const string& in) {
     return out;
 }
 
-string test_framework_manager::base64_decode(const string& in) {
-    string out;
-    vector<int> T(256, -1);
+std::string test_framework_manager::base64_decode(const std::string& in) {
+    std::string out;
+    std::vector<int> T(256, -1);
     for (int i = 0; i < 64; i++) T[base64_chars[i]] = i;
 
     int val = 0, valb = -8;

--- a/src/test_framework.h
+++ b/src/test_framework.h
@@ -78,8 +78,8 @@ private:
 	~test_framework_manager();
 
 #ifdef ENABLE_TEST_FRAMEWORK
-	bool recording;
-	bool replaying;
+	bool recording = false;
+	bool replaying = false;
 	std::string record_filename;
 	std::string replay_filename;
 

--- a/src/test_framework.h
+++ b/src/test_framework.h
@@ -8,8 +8,7 @@
  * Free Software Foundation; version 2 of the License.
  */
 
-#ifndef _INCLUDE_GUARD_TEST_FRAMEWORK_H_
-#define _INCLUDE_GUARD_TEST_FRAMEWORK_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -101,4 +100,3 @@ private:
 #endif
 };
 
-#endif

--- a/src/tuning/bluetooth.h
+++ b/src/tuning/bluetooth.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_BLUETOOTH_TUNE_H
-#define _INCLUDE_GUARD_BLUETOOTH_TUNE_H
+#pragma once
 
 #include <vector>
 
@@ -41,5 +40,3 @@ public:
 
 extern void add_bt_tunable(void);
 
-
-#endif

--- a/src/tuning/bluetooth.h
+++ b/src/tuning/bluetooth.h
@@ -29,8 +29,6 @@
 
 #include "tunable.h"
 
-using namespace std;
-
 class bt_tunable : public tunable {
 public:
 	bt_tunable(void);

--- a/src/tuning/ethernet.cpp
+++ b/src/tuning/ethernet.cpp
@@ -84,7 +84,11 @@ int ethernet_tunable::good_bad(void)
 
 	wol.cmd = ETHTOOL_GWOL;
 	ifr.ifr_data = (caddr_t)&wol;
-        ioctl(sock, SIOCETHTOOL, &ifr);
+	ret = ioctl(sock, SIOCETHTOOL, &ifr);
+	if (ret < 0) {
+		close(sock);
+		return result;
+	}
 
 	if (wol.wolopts)
 		result = TUNE_BAD;
@@ -120,10 +124,14 @@ void ethernet_tunable::toggle(void)
 
 	wol.cmd = ETHTOOL_GWOL;
 	ifr.ifr_data = (caddr_t)&wol;
-        ioctl(sock, SIOCETHTOOL, &ifr);
+	ret = ioctl(sock, SIOCETHTOOL, &ifr);
+	if (ret < 0) {
+		close(sock);
+		return;
+	}
 	wol.cmd = ETHTOOL_SWOL;
 	wol.wolopts = 0;
-        ioctl(sock, SIOCETHTOOL, &ifr);
+	ioctl(sock, SIOCETHTOOL, &ifr);
 
 	close(sock);
 }

--- a/src/tuning/ethernet.cpp
+++ b/src/tuning/ethernet.cpp
@@ -48,7 +48,7 @@
 
 extern void create_all_nics(callback fn);
 
-ethernet_tunable::ethernet_tunable(const string &iface) : tunable("", 0.3, _("Good"), _("Bad"), _("Unknown"))
+ethernet_tunable::ethernet_tunable(const std::string &iface) : tunable("", 0.3, _("Good"), _("Bad"), _("Unknown"))
 {
 	interf = iface;
 	desc = pt_format(_("Wake-on-lan status for device {}"), iface);

--- a/src/tuning/ethernet.h
+++ b/src/tuning/ethernet.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_ETHERNET_TUNE_H
-#define _INCLUDE_GUARD_ETHERNET_TUNE_H
+#pragma once
 
 #include <vector>
 
@@ -42,4 +41,3 @@ public:
 
 extern void add_ethernet_tunable(void);
 
-#endif

--- a/src/tuning/ethernet.h
+++ b/src/tuning/ethernet.h
@@ -29,8 +29,6 @@
 
 #include "tunable.h"
 
-using namespace std;
-
 class ethernet_tunable : public tunable {
 public:
 	std::string interf;

--- a/src/tuning/iw.c
+++ b/src/tuning/iw.c
@@ -260,7 +260,8 @@ static int __handle_cmd(struct nl80211_state *state, const char *iface, int get)
 	return err;
  nla_put_failure:
 	fprintf(stderr, "building message failed\n");
-	return 2;
+	err = 2;
+	goto out;
 }
 
 

--- a/src/tuning/iw.c
+++ b/src/tuning/iw.c
@@ -147,8 +147,9 @@ static int print_power_save_handler(struct nl_msg *msg, void *arg __unused)
 	struct nlattr *attrs[NL80211_ATTR_MAX + 1];
 	struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
 
-	nla_parse(attrs, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
-		  genlmsg_attrlen(gnlh, 0), NULL);
+	if (nla_parse(attrs, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
+		      genlmsg_attrlen(gnlh, 0), NULL) < 0)
+		return -1;
 
 	if (!attrs[NL80211_ATTR_PS_STATE])
 		return 0;

--- a/src/tuning/iw.h
+++ b/src/tuning/iw.h
@@ -1,5 +1,4 @@
-#ifndef __IW_H
-#define __IW_H
+#pragma once
 
 /*
  * This code has been blatently stolen from
@@ -74,4 +73,3 @@ int set_wifi_power_saving(const char *iface, int state);
 }
 #endif
 
-#endif /* __IW_H */

--- a/src/tuning/nl80211.h
+++ b/src/tuning/nl80211.h
@@ -1,5 +1,4 @@
-#ifndef __LINUX_NL80211_H
-#define __LINUX_NL80211_H
+#pragma once
 /*
  * 802.11 netlink interface public header
  *
@@ -1894,4 +1893,3 @@ enum nl80211_tx_power_setting {
 	NL80211_TX_POWER_FIXED,
 };
 
-#endif /* __LINUX_NL80211_H */

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -100,7 +100,7 @@ int runtime_tunable::good_bad(void)
 	if (content == "auto")
 		return TUNE_GOOD;
 	if (content == "on")
-		return TUNE_GOOD;
+		return TUNE_BAD;
 
 	return TUNE_BAD;
 }

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -40,7 +40,7 @@
 #include "../lib.h"
 #include "../devices/runtime_pm.h"
 
-runtime_tunable::runtime_tunable(const string &path, const string &bus, const string &dev, const string &port) : tunable("", 0.4, _("Good"), _("Bad"), _("Unknown"))
+runtime_tunable::runtime_tunable(const std::string &path, const std::string &bus, const std::string &dev, const std::string &port) : tunable("", 0.4, _("Good"), _("Bad"), _("Unknown"))
 {
 	runtime_path = std::format("{}/power/control", path);
 
@@ -78,11 +78,11 @@ runtime_tunable::runtime_tunable(const string &path, const string &bus, const st
 			}
 		}
 
-		if (path.find("ata") != string::npos) {
+		if (path.find("ata") != std::string::npos) {
 			desc = pt_format(_("Runtime PM for port {} of PCI device: {}"), port, pci_id_to_name(vendor, device));
 		}
 
-		if (path.find("block") != string::npos) {
+		if (path.find("block") != std::string::npos) {
 			desc = pt_format(_("Runtime PM for disk {}"), port);
 		}
 

--- a/src/tuning/runtime.h
+++ b/src/tuning/runtime.h
@@ -29,7 +29,6 @@
 #include <limits.h>
 
 #include "tunable.h"
-using namespace std;
 
 class runtime_tunable : public tunable {
 	std::string runtime_path;

--- a/src/tuning/runtime.h
+++ b/src/tuning/runtime.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_RUNTIME_TUNE_H
-#define _INCLUDE_GUARD_RUNTIME_TUNE_H
+#pragma once
 
 #include <vector>
 #include <limits.h>
@@ -43,5 +42,3 @@ public:
 
 extern void add_runtime_tunables(const std::string &bus);
 
-
-#endif

--- a/src/tuning/tunable.cpp
+++ b/src/tuning/tunable.cpp
@@ -32,7 +32,7 @@ std::vector<class tunable *> all_tunables;
 std::vector<class tunable *> all_untunables;
 
 
-tunable::tunable(const string &str, double _score, const string &good, const string &bad, const string &neutral)
+tunable::tunable(const std::string &str, double _score, const std::string &good, const std::string &bad, const std::string &neutral)
 {
 	desc = str;
 	score = _score;

--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_TUNABLE_H
-#define _INCLUDE_GUARD_TUNABLE_H
+#pragma once
 
 #include <vector>
 
@@ -87,4 +86,3 @@ public:
 extern std::vector<class tunable *> all_tunables;
 extern std::vector<class tunable *> all_untunables;
 
-#endif

--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -46,7 +46,7 @@ protected:
 	std::string toggle_bad;
 public:
 	std::string desc;
-	double score;
+	double score = 0.0;
 
 	tunable(void);
 	tunable(const std::string &str, double _score, const std::string &good = "", const std::string &bad = "", const std::string &neutral ="");

--- a/src/tuning/tunable.h
+++ b/src/tuning/tunable.h
@@ -31,8 +31,6 @@
 
 #include <string>
 
-using namespace std;
-
 #define TUNE_GOOD    1
 #define TUNE_BAD     -1
 #define TUNE_UNFIXABLE -2

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -244,7 +244,7 @@ void report_show_tunables(void)
 				continue;
 			tunable_data[idx]=all_tunables[i]->description();
 			idx+=1;
-			tunable_data[idx]=string(all_tunables[i]->toggle_script());
+			tunable_data[idx]=std::string(all_tunables[i]->toggle_script());
 			idx+=1;
 		}
 

--- a/src/tuning/tuning.h
+++ b/src/tuning/tuning.h
@@ -22,12 +22,11 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_TUNING_H
-#define _INCLUDE_GUARD_TUNING_H
+#pragma once
 
 extern void initialize_tuning(void);
 extern void tuning_update_display(void);
 extern void report_show_tunables(void);
 extern void clear_tuning(void);
 extern void auto_toggle_tuning(bool dump_only);
-#endif
+

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -32,7 +32,7 @@
 
 #include "../lib.h"
 #include "../devices/runtime_pm.h"
-i2c_tunable::i2c_tunable(const string &path, const string &name, bool is_adapter) : tunable("", 0.9, _("Good"), _("Bad"), _("Unknown"))
+i2c_tunable::i2c_tunable(const std::string &path, const std::string &name, bool is_adapter) : tunable("", 0.9, _("Good"), _("Bad"), _("Unknown"))
 {
 	std::string filename;
 	std::string devname;

--- a/src/tuning/tuningi2c.h
+++ b/src/tuning/tuningi2c.h
@@ -17,8 +17,7 @@
  *	Daniel Leung <daniel.leung@linux.intel.com>
  */
 
-#ifndef _INCLUDE_GUARD_I2C_TUNE_H
-#define _INCLUDE_GUARD_I2C_TUNE_H
+#pragma once
 
 #include <vector>
 #include <limits.h>
@@ -38,5 +37,3 @@ public:
 
 extern void add_i2c_tunables(void);
 
-
-#endif

--- a/src/tuning/tuningi2c.h
+++ b/src/tuning/tuningi2c.h
@@ -25,8 +25,6 @@
 
 #include "tunable.h"
 
-using namespace std;
-
 class i2c_tunable : public tunable {
 	std::string i2c_path;
 public:

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -36,7 +36,7 @@
 #include <format>
 
 #include "../lib.h"
-sysfs_tunable::sysfs_tunable(const string &str, const string &_sysfs_path, const string &target_content) : tunable(str, 1.0, _("Good"), _("Bad"), _("Unknown"))
+sysfs_tunable::sysfs_tunable(const std::string &str, const std::string &_sysfs_path, const std::string &target_content) : tunable(str, 1.0, _("Good"), _("Bad"), _("Unknown"))
 {
 	sysfs_path = _sysfs_path;
 	target_value = target_content;

--- a/src/tuning/tuningsysfs.h
+++ b/src/tuning/tuningsysfs.h
@@ -30,8 +30,6 @@
 
 #include "tunable.h"
 
-using namespace std;
-
 class sysfs_tunable : public tunable {
 	std::string sysfs_path;
 	std::string target_value;

--- a/src/tuning/tuningsysfs.h
+++ b/src/tuning/tuningsysfs.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_SYSFS_TUNE_H
-#define _INCLUDE_GUARD_SYSFS_TUNE_H
+#pragma once
 
 #include <vector>
 #include <limits.h>
@@ -46,4 +45,3 @@ public:
 extern void add_sysfs_tunable(const std::string &str, const std::string &_sysfs_path, const std::string &_target_content);
 extern void add_sata_tunables(void);
 
-#endif

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -37,7 +37,7 @@
 
 #include "../lib.h"
 
-usb_tunable::usb_tunable(const string &path, const string &name) : tunable("", 0.9, _("Good"), _("Bad"), _("Unknown"))
+usb_tunable::usb_tunable(const std::string &path, const std::string &name) : tunable("", 0.9, _("Good"), _("Bad"), _("Unknown"))
 {
 	std::string vendor;
 	std::string product;
@@ -70,7 +70,7 @@ usb_tunable::usb_tunable(const string &path, const string &name) : tunable("", 0
 
 int usb_tunable::good_bad(void)
 {
-	string content;
+	std::string content;
 
 	content = read_sysfs_string(usb_path);
 

--- a/src/tuning/tuningusb.h
+++ b/src/tuning/tuningusb.h
@@ -30,8 +30,6 @@
 
 #include "tunable.h"
 
-using namespace std;
-
 class usb_tunable : public tunable {
 	std::string usb_path;
 public:

--- a/src/tuning/tuningusb.h
+++ b/src/tuning/tuningusb.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_USB_TUNE_H
-#define _INCLUDE_GUARD_USB_TUNE_H
+#pragma once
 
 #include <vector>
 #include <limits.h>
@@ -43,5 +42,3 @@ public:
 
 extern void add_usb_tunables(void);
 
-
-#endif

--- a/src/tuning/wifi.cpp
+++ b/src/tuning/wifi.cpp
@@ -27,7 +27,6 @@
 #include "tunable.h"
 #include "unistd.h"
 #include "wifi.h"
-#include <string.h>
 #include <utility>
 #include <iostream>
 #include <fstream>
@@ -83,15 +82,16 @@ void add_wifi_tunables(void)
 	dir = opendir("/sys/class/net/");
 	if (!dir)
 		return;
-	while (1) {
+	while (true) {
 		entry = readdir(dir);
 		if (!entry)
 			break;
-		if (strstr(entry->d_name, "wlan")) {
-			wifi = new class wifi_tunable(entry->d_name);
-			all_tunables.push_back(wifi);
+		std::string name(entry->d_name);
+		if (name.starts_with("wlan") || name.starts_with("wlp") || name.starts_with("wlx")) {
+			wifi = new(std::nothrow) class wifi_tunable(name);
+			if (wifi)
+				all_tunables.push_back(wifi);
 		}
-	
 	}
 
 	closedir(dir);

--- a/src/tuning/wifi.cpp
+++ b/src/tuning/wifi.cpp
@@ -43,7 +43,7 @@ extern "C" {
 }
 
 
-wifi_tunable::wifi_tunable(const string &_iface) : tunable("", 1.5, _("Good"), _("Bad"), _("Unknown"))
+wifi_tunable::wifi_tunable(const std::string &_iface) : tunable("", 1.5, _("Good"), _("Bad"), _("Unknown"))
 {
 	iface = _iface;
 	desc = pt_format(_("Wireless Power Saving for interface {}"), iface);

--- a/src/tuning/wifi.h
+++ b/src/tuning/wifi.h
@@ -31,8 +31,6 @@
 
 #include <string>
 
-using namespace std;
-
 class wifi_tunable : public tunable {
 	std::string iface;
 public:

--- a/src/tuning/wifi.h
+++ b/src/tuning/wifi.h
@@ -22,8 +22,7 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#ifndef _INCLUDE_GUARD_WIFI_TUNE_H
-#define _INCLUDE_GUARD_WIFI_TUNE_H
+#pragma once
 
 #include <vector>
 
@@ -44,5 +43,3 @@ public:
 
 extern void add_wifi_tunables(void);
 
-
-#endif

--- a/src/wakeup/waketab.cpp
+++ b/src/wakeup/waketab.cpp
@@ -153,7 +153,7 @@ void report_show_wakeup(void)
 				continue;
 			wakeup_data[idx]=wakeup_all[i]->description();
 			idx+=1;
-			wakeup_data[idx]=string(wakeup_all[i]->wakeup_toggle_script());
+			wakeup_data[idx]=std::string(wakeup_all[i]->wakeup_toggle_script());
 			idx+=1;
 		}
 

--- a/src/wakeup/waketab.cpp
+++ b/src/wakeup/waketab.cpp
@@ -41,7 +41,10 @@ void initialize_wakeup(void)
 
 	init_wakeup();
 
-	win->cursor_max = wakeup_all.size() - 1;
+	if (wakeup_all.empty())
+		win->cursor_max = 0;
+	else
+		win->cursor_max = (int)wakeup_all.size() - 1;
 
 	if (newtab_window)
 		delete newtab_window;
@@ -98,6 +101,8 @@ void wakeup_window::repaint(void)
 
 void wakeup_window::cursor_enter(void)
 {
+	if ((size_t)cursor_pos >= wakeup_all.size())
+		return;
 	class wakeup *wake;
 	std::string wakeup_toggle_script;
 	wake = wakeup_all[cursor_pos];

--- a/src/wakeup/waketab.cpp
+++ b/src/wakeup/waketab.cpp
@@ -13,8 +13,6 @@
 #include "wakeup_ethernet.h"
 #include "wakeup_usb.h"
 
-using namespace std;
-
 static bool should_clear = false;
 
 class wakeup_window *newtab_window;

--- a/src/wakeup/wakeup.cpp
+++ b/src/wakeup/wakeup.cpp
@@ -29,8 +29,6 @@
 #include <vector>
 #include "../lib.h"
 
-using namespace std;
-
 std::vector<class wakeup *> wakeup_all;
 
 wakeup::wakeup(const string &str, double _score, const string &enable, const string &disable)

--- a/src/wakeup/wakeup.cpp
+++ b/src/wakeup/wakeup.cpp
@@ -31,7 +31,7 @@
 
 std::vector<class wakeup *> wakeup_all;
 
-wakeup::wakeup(const string &str, double _score, const string &enable, const string &disable)
+wakeup::wakeup(const std::string &str, double _score, const std::string &enable, const std::string &disable)
 {
 	score = _score;
         desc = str;

--- a/src/wakeup/wakeup.h
+++ b/src/wakeup/wakeup.h
@@ -22,8 +22,7 @@
  * Authors:
  *      Gayatri Kammela <gayatri.kammela@intel.com>
  */
-#ifndef _INCLUDE_GUARD_WAKEUP_H
-#define _INCLUDE_GUARD_WAKEUP_H
+#pragma once
 
 #include<vector>
 #include <limits.h>
@@ -78,4 +77,3 @@ extern void wakeup_update_display(void);
 extern void report_show_wakeup(void);
 extern void clear_wakeup(void);
 
-#endif

--- a/src/wakeup/wakeup.h
+++ b/src/wakeup/wakeup.h
@@ -30,8 +30,6 @@
 
 #include <string>
 
-using namespace std;
-
 #define WAKEUP_ENABLE 1
 #define WAKEUP_DISABLE 0
 

--- a/src/wakeup/wakeup.h
+++ b/src/wakeup/wakeup.h
@@ -41,7 +41,7 @@ protected:
 	std::string toggle_disable;
 public:
 	std::string desc;
-	double score;
+	double score = 0.0;
 
 	wakeup(const std::string &str, double _score, const std::string &enable = "", const std::string &disable = "");
 	wakeup(void);

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -45,7 +45,7 @@
 #include "../lib.h"
 #include "wakeup_ethernet.h"
 
-ethernet_wakeup::ethernet_wakeup(const string &path __unused, const string &iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
+ethernet_wakeup::ethernet_wakeup(const std::string &path __unused, const std::string &iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
 	interf = iface;
 	desc = pt_format(_("Wake-on-lan status for device {}"), iface);
@@ -56,7 +56,7 @@ ethernet_wakeup::ethernet_wakeup(const string &path __unused, const string &ifac
 
 int ethernet_wakeup::wakeup_value(void)
 {
-	string content;
+	std::string content;
 
 	content = read_sysfs_string(eth_path);
 

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -1,4 +1,4 @@
-;/*
+/*
  * Copyright 2018, Intel Corporation
  *
  * This file is part of PowerTOP

--- a/src/wakeup/wakeup_ethernet.h
+++ b/src/wakeup/wakeup_ethernet.h
@@ -22,8 +22,7 @@
  * Authors:
  *      Gayatri Kammela <gayatri.kammela@intel.com>
  */
-#ifndef _INCLUDE_GUARD_ETHERNET_WAKEUP_H
-#define _INCLUDE_GUARD_ETHERNET_WAKEUP_H
+#pragma once
 
 #include <vector>
 
@@ -45,4 +44,3 @@ public:
 
 extern void add_ethernet_wakeup(void);
 
-#endif

--- a/src/wakeup/wakeup_ethernet.h
+++ b/src/wakeup/wakeup_ethernet.h
@@ -29,8 +29,6 @@
 
 #include "wakeup.h"
 
-using namespace std;
-
 class ethernet_wakeup : public wakeup {
 	std::string eth_path;
 public:

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -45,7 +45,7 @@
 #include "../lib.h"
 #include "wakeup_usb.h"
 
-usb_wakeup::usb_wakeup(const string &path __unused, const string &iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
+usb_wakeup::usb_wakeup(const std::string &path __unused, const std::string &iface) : wakeup("", 0.5, _("Enabled"), _("Disabled"))
 {
 	interf = iface;
 	desc = pt_format(_("Wake status for USB device {}"), iface);
@@ -56,7 +56,7 @@ usb_wakeup::usb_wakeup(const string &path __unused, const string &iface) : wakeu
 
 int usb_wakeup::wakeup_value(void)
 {
-	string content;
+	std::string content;
 
 	content = read_sysfs_string(usb_path);
 

--- a/src/wakeup/wakeup_usb.h
+++ b/src/wakeup/wakeup_usb.h
@@ -22,8 +22,7 @@
  * Authors:
  *      Gayatri Kammela <gayatri.kammela@intel.com>
  */
-#ifndef _INCLUDE_GUARD_USB_WAKEUP_H
-#define _INCLUDE_GUARD_USB_WAKEUP_H
+#pragma once
 
 #include <vector>
 
@@ -45,4 +44,3 @@ public:
 
 extern void add_usb_wakeup(void);
 
-#endif

--- a/src/wakeup/wakeup_usb.h
+++ b/src/wakeup/wakeup_usb.h
@@ -29,8 +29,6 @@
 
 #include "wakeup.h"
 
-using namespace std;
-
 class usb_wakeup : public wakeup {
 	std::string usb_path;
 public:


### PR DESCRIPTION
- **Remove 'using namespace std;' from all source files**
- **Add std:: prefixes throughout codebase after removing using namespace std**
- **Update local.md with deep review findings and namespace fix notes**
- **test_framework: add missing std:: qualifiers**
- **test_framework: fix remaining missing std:: qualifiers**
- **Replace #ifndef/#define include guards with #pragma once**
- **headers: replace #ifndef include guards with #pragma once**
- **do_process: add bounds check in change_blame()**
- **do_process: fix dangling perf_events pointer after delete**
- **perf: fix null deref in set_event_name after tep_find_event_by_name**
- **perf: fix null pc deref when mmap fails in create_perf_event**
- **Add in-class default member initializers to all header classes/structs**
- **cpu: add null check for cpu pointer in handle_trace_point**
- **extech: fix i*0 typo in parse_packet — should be i*5**
- **calibrate: fix thread leaks, inverted system() checks, and freopen check**
- **devlist: clear vectors after deleting objects in clean_open_devices**
- **lib: clamp npfx in fmt_prefix to prevent out-of-bounds array access**
- **display: add bounds check in show_tab() before accessing tab_names**
- **runtime: fix good_bad() — runtime PM 'on' is TUNE_BAD not TUNE_GOOD**
- **ethernet: check ioctl(SIOCETHTOOL) return value in good_bad and toggle**
- **wifi: modernise add_wifi_tunables loop**
- **iw: fix resource leak in __handle_cmd on NLA_PUT_U32 failure**
- **iw: check nla_parse() return in print_power_save_handler**
- **powerconsumer: guard against measurement_time < 0.00001 before dividing**
- **process: fix unsigned wraparound in deschedule_thread**
- **process: fix inverted condition in kernel-process detection**
- **do_process: check tep_get_field_val return for cpu_idle state field**
- **do_process: guard measurement_time divisions against near-zero**
- **do_process: fix static prev_time persisting across measurement cycles**
- **do_process: fix copy-paste error in timer_expire_entry error message**
- **timer: filter zero-runtime timers in all_timers_to_all_power()**
- **perf: fix fd and mmap leak in perf_event destructor**
- **perf: add required memory barrier after reading data_head**
- **parameters: fix memory leaks when past_results buffer is full**
- **parameters: add bounds check to get_parameter_weight()**
- **parameters: fix missing guards in utilization_power_valid(string)**
- **report: make 'ran at' string translatable**
- **report: check localtime() return before passing to strftime**
- **report: fix double_to_string truncating integer-valued doubles**
- **report: fix out-of-bounds access in add_summary_list for odd-length lists**
- **cpu: guard against division by zero when num_cores == 0**
- **cpu: guard _core null dereference in report_display_cpu_cstates**
- **rapl: skip '.' and '..' entries in readdir loops**
- **wakeup: remove stray semicolon; fix empty wakeup_all crash**
- **acpi: replace /proc/acpi/battery with /sys/class/power_supply**
- **measurement: use CLOCK_MONOTONIC for elapsed-time measurement**
- **extech: fix data races and discard error sentinel values**
- **backlight: guard against max_level == 0 before division**
- **devices: change power_valid() to return bool throughout**
- **ahci: fix report_device_stats missing link-name column**
- **ahci: close dir before early return in model_name()**
- **devfreq: guard against empty dstates in process_time_stamps()**
- **devfreq: guard against near-zero sample_time in fill_freq_utilization()**
- **i915-gpu: delete gpu_rapl_device when device_present() returns false**
