### PR TITLE
Medium severity fixes: cleanup, bug fixes, and code quality improvements

### DIFF
--- a/local.md
+++ b/local.md
@@ -1,6 +1,9 @@
 This repository is for PowerTOP, a linux tool to find the sources of power
 consumption in a system.
 
+Do **NOT** update this file to record the results of code review or fixes
+for code review comments!
+
 The code review rules for this project are in `review/review.md` and this
 includes a style guide.
 
@@ -16,23 +19,6 @@ The process for working on this codebase always consists for 4 steps
 
 Also read `review/tools.md` when you're asked to use the various
 tooling to create and manipulate test data.
-
-# Code style notes
-
-- All 59 header files now use `#pragma once` instead of `#ifndef`/`#define`/`#endif` include guards (commit 17c3046).
-
-- `using namespace std;` has been removed from all 50 source files (commit 41e0502).
-  All bare STL names (string, vector, map, cout, etc.) have been explicitly qualified
-  with std:: throughout the codebase (commit cb42d45). The build is now clean.
-
-# C++ style notes (additional)
-
-- All virtual method overrides now have the `override` specifier (commit c4ab4f1).
-  271 methods across 44 files were updated. The `-Wsuggest-override` flag is already
-  in meson.build (line 304) to enforce this going forward.
-  A Python script pattern was used: iterate over {filename: [line_numbers]} dict,
-  apply `add_override()` per line — insert `override` before `{` (inline body) or
-  before `;` (declaration), tracking parenthesis depth to find the correct `{`.
 
 # Prefered user style
 

--- a/local.md
+++ b/local.md
@@ -25,6 +25,15 @@ tooling to create and manipulate test data.
   All bare STL names (string, vector, map, cout, etc.) have been explicitly qualified
   with std:: throughout the codebase (commit cb42d45). The build is now clean.
 
+# C++ style notes (additional)
+
+- All virtual method overrides now have the `override` specifier (commit c4ab4f1).
+  271 methods across 44 files were updated. The `-Wsuggest-override` flag is already
+  in meson.build (line 304) to enforce this going forward.
+  A Python script pattern was used: iterate over {filename: [line_numbers]} dict,
+  apply `add_override()` per line — insert `override` before `{` (inline body) or
+  before `;` (declaration), tracking parenthesis depth to find the correct `{`.
+
 # Prefered user style
 
 When asked to make a non-trivial change (multiple files/elements), create a

--- a/meson.build
+++ b/meson.build
@@ -301,6 +301,7 @@ executable('powertop',
     '-fno-omit-frame-pointer',
     '-fstack-protector',
     '-fpermissive',
+    '-Wsuggest-override',
   ],
   install: true
 )

--- a/review/rules.md
+++ b/review/rules.md
@@ -21,8 +21,28 @@
 
 ## General checks
 
-- [ ] All user visible strings must be translatable and use the _() gettext
-    pattern
+- [ ] All user visible strings must be translatable and use the `_()` gettext
+    pattern.
+
+- [ ] When formatting a translated string that contains `{}` placeholders, you
+    **must** use `pt_format` instead of `std::format`. `std::format` requires a
+    compile-time format string; `_()` returns a runtime `const char*` from
+    gettext, so `std::format(_("..."), x)` will not compile. `pt_format` wraps
+    `std::vformat` which accepts runtime strings.
+
+    **Use `std::format` when the string is not translated** (internal/technical
+    strings, data-derived identifiers, log output not shown to the user):
+    ```cpp
+    // OK — not user-visible, no translation needed
+    std::string path = std::format("{}/actual_brightness", sysfs_path);
+    ```
+
+    **Use `pt_format(_(...))` when the string is user-visible and needs
+    translation:**
+    ```cpp
+    // OK — user-visible label with a runtime argument
+    humanname = pt_format(_("USB device: {}"), product);
+    ```
 
 - [ ] malloc() does not fail in practice. Checking for failure is not a coding style
     violation, but the lack of checking is at most of `nit` severity.

--- a/review/rules.md
+++ b/review/rules.md
@@ -8,6 +8,17 @@
     and ".." entries in the directory and not process them as normal
 
 
+## C++ style
+
+- [ ] All virtual method overrides in derived classes must use the `override`
+    specifier. The `virtual` keyword may be kept or omitted on overrides, but
+    `override` is mandatory. Pure virtual declarations in base classes (`= 0`)
+    do not need `override`. The build is configured with `-Wsuggest-override`
+    to enforce this.
+
+- [ ] Use `nullptr` instead of `NULL` in all C++ code (`.cpp` and `.h` files).
+
+
 ## General checks
 
 - [ ] All user visible strings must be translatable and use the _() gettext

--- a/src/calibrate/calibrate.cpp
+++ b/src/calibrate/calibrate.cpp
@@ -205,7 +205,7 @@ static void *burn_cpu_wakeups(void *dummy)
 
 	while (!stop_measurement) {
 		tm.tv_sec = 0;
-		tm.tv_nsec = (unsigned long)dummy;
+		tm.tv_nsec = (unsigned long)(uintptr_t)dummy;
 		nanosleep(&tm, nullptr);
 	}
 	return nullptr;
@@ -245,7 +245,10 @@ static void cpu_calibration(int threads)
 	stop_measurement = 0;
 	for (i = 0; i < threads; i++) {
 		pthread_t thr;
-		pthread_create(&thr, nullptr, burn_cpu, nullptr);
+		if (pthread_create(&thr, nullptr, burn_cpu, nullptr) != 0) {
+			fprintf(stderr, _("Failed to create calibration thread\n"));
+			return;
+		}
 		thr_vec.push_back(thr);
 	}
 
@@ -264,7 +267,10 @@ static void wakeup_calibration(unsigned long interval)
 
 	stop_measurement = 0;
 
-	pthread_create(&thr, nullptr, burn_cpu_wakeups, (void *)interval);
+	if (pthread_create(&thr, nullptr, burn_cpu_wakeups, (void *)(uintptr_t)interval) != 0) {
+		fprintf(stderr, _("Failed to create wakeup calibration thread\n"));
+		return;
+	}
 
 	one_measurement(15, 15, "");
 	stop_measurement = 1;
@@ -370,7 +376,10 @@ static void disk_calibration(void)
 	set_scsi_link("min_power");
 
 	stop_measurement = 0;
-	pthread_create(&thr, nullptr, burn_disk, nullptr);
+	if (pthread_create(&thr, nullptr, burn_disk, nullptr) != 0) {
+		fprintf(stderr, _("Failed to create disk calibration thread\n"));
+		return;
+	}
 
 	one_measurement(15, 15, "");
 	stop_measurement = 1;

--- a/src/calibrate/calibrate.cpp
+++ b/src/calibrate/calibrate.cpp
@@ -227,7 +227,7 @@ static void *burn_disk(void *dummy __unused)
 	while (!stop_measurement) {
 		lseek(fd, 0, SEEK_SET);
 		if(write(fd, buffer, 64*1024) == -1)
-			printf("Error: %s\n", strerror(errno));
+			fprintf(stderr, _("Error: %s\n"), strerror(errno));
 		fdatasync(fd);
 	}
 	unlink(filename);
@@ -344,20 +344,20 @@ static void backlight_calibration(void)
 	}
 	printf(_("Calibrating idle\n"));
 	if (system("DISPLAY=:0 /usr/bin/xset dpms force off") != 0)
-		printf("System is not available\n");
+		fprintf(stderr, _("System is not available\n"));
 	one_measurement(15, 15, "");
 	if (system("DISPLAY=:0 /usr/bin/xset dpms force on") != 0)
-		printf("System is not available\n");
+		fprintf(stderr, _("System is not available\n"));
 }
 
 static void idle_calibration(void)
 {
 	printf(_("Calibrating idle\n"));
 	if (system("DISPLAY=:0 /usr/bin/xset dpms force off") != 0)
-		printf("System is not available\n");
+		fprintf(stderr, _("System is not available\n"));
 	one_measurement(15, 15, "");
 	if (system("DISPLAY=:0 /usr/bin/xset dpms force on") != 0)
-		printf("System is not available\n");
+		fprintf(stderr, _("System is not available\n"));
 }
 
 

--- a/src/calibrate/calibrate.cpp
+++ b/src/calibrate/calibrate.cpp
@@ -196,7 +196,7 @@ static void *burn_cpu(void *dummy __unused)
 	while (!stop_measurement) {
 		d = pow(d, 1.0001);
 	}
-	return NULL;
+	return nullptr;
 }
 
 static void *burn_cpu_wakeups(void *dummy)
@@ -206,9 +206,9 @@ static void *burn_cpu_wakeups(void *dummy)
 	while (!stop_measurement) {
 		tm.tv_sec = 0;
 		tm.tv_nsec = (unsigned long)dummy;
-		nanosleep(&tm, NULL);
+		nanosleep(&tm, nullptr);
 	}
-	return NULL;
+	return nullptr;
 }
 
 static void *burn_disk(void *dummy __unused)
@@ -221,7 +221,7 @@ static void *burn_disk(void *dummy __unused)
 
 	if (fd < 0) {
 		printf(_("Cannot create temp file\n"));
-		return NULL;
+		return nullptr;
 	}
 
 	while (!stop_measurement) {
@@ -231,7 +231,7 @@ static void *burn_disk(void *dummy __unused)
 		fdatasync(fd);
 	}
 	unlink(filename);
-	return NULL;
+	return nullptr;
 }
 
 
@@ -245,7 +245,7 @@ static void cpu_calibration(int threads)
 	stop_measurement = 0;
 	for (i = 0; i < threads; i++) {
 		pthread_t thr;
-		pthread_create(&thr, NULL, burn_cpu, NULL);
+		pthread_create(&thr, nullptr, burn_cpu, nullptr);
 		thr_vec.push_back(thr);
 	}
 
@@ -253,7 +253,7 @@ static void cpu_calibration(int threads)
 	stop_measurement = 1;
 	sleep(1);
 	for (auto &thr : thr_vec)
-		pthread_join(thr, NULL);
+		pthread_join(thr, nullptr);
 }
 
 static void wakeup_calibration(unsigned long interval)
@@ -264,12 +264,12 @@ static void wakeup_calibration(unsigned long interval)
 
 	stop_measurement = 0;
 
-	pthread_create(&thr, NULL, burn_cpu_wakeups, (void *)interval);
+	pthread_create(&thr, nullptr, burn_cpu_wakeups, (void *)interval);
 
 	one_measurement(15, 15, "");
 	stop_measurement = 1;
 	sleep(1);
-	pthread_join(thr, NULL);
+	pthread_join(thr, nullptr);
 }
 
 static void usb_calibration(void)
@@ -370,12 +370,12 @@ static void disk_calibration(void)
 	set_scsi_link("min_power");
 
 	stop_measurement = 0;
-	pthread_create(&thr, NULL, burn_disk, NULL);
+	pthread_create(&thr, nullptr, burn_disk, nullptr);
 
 	one_measurement(15, 15, "");
 	stop_measurement = 1;
 	sleep(1);
-	pthread_join(thr, NULL);
+	pthread_join(thr, nullptr);
 
 
 }

--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -48,7 +48,7 @@ abstract_cpu::~abstract_cpu()
 
 void abstract_cpu::account_freq(uint64_t freq, uint64_t duration)
 {
-	class frequency *state = NULL;
+	class frequency *state = nullptr;
 	unsigned int i;
 
 	for (i = 0; i < pstates.size(); i++) {
@@ -262,7 +262,7 @@ void abstract_cpu::insert_cstate(const std::string &linux_name, const std::strin
 void abstract_cpu::finalize_cstate(const std::string &linux_name, uint64_t usage, uint64_t duration, int count)
 {
 	unsigned int i;
-	struct idle_state *state = NULL;
+	struct idle_state *state = nullptr;
 
 	for (i = 0; i < cstates.size(); i++) {
 		if (cstates[i]->linux_name == linux_name) {
@@ -284,7 +284,7 @@ void abstract_cpu::finalize_cstate(const std::string &linux_name, uint64_t usage
 void abstract_cpu::update_cstate(const std::string &linux_name, const std::string &human_name, uint64_t usage, uint64_t duration, int count, int level)
 {
 	unsigned int i;
-	struct idle_state *state = NULL;
+	struct idle_state *state = nullptr;
 
 	for (i = 0; i < cstates.size(); i++) {
 		if (cstates[i]->linux_name == linux_name) {
@@ -362,7 +362,7 @@ void abstract_cpu::insert_pstate(uint64_t freq, const std::string &human_name, u
 void abstract_cpu::finalize_pstate(uint64_t freq, uint64_t duration, int count)
 {
 	unsigned int i;
-	class frequency *state = NULL;
+	class frequency *state = nullptr;
 
 	for (i = 0; i < pstates.size(); i++) {
 		if (freq == pstates[i]->freq) {
@@ -383,7 +383,7 @@ void abstract_cpu::finalize_pstate(uint64_t freq, uint64_t duration, int count)
 void abstract_cpu::update_pstate(uint64_t freq, const std::string &human_name, uint64_t duration, int count)
 {
 	unsigned int i;
-	class frequency *state = NULL;
+	class frequency *state = nullptr;
 
 	for (i = 0; i < pstates.size(); i++) {
 		if (freq == pstates[i]->freq) {

--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -25,7 +25,6 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>

--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -22,9 +22,8 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#include <iostream>
-#include <fstream>
 #include <sstream>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -271,7 +270,7 @@ void abstract_cpu::finalize_cstate(const std::string &linux_name, uint64_t usage
 	}
 
 	if (!state) {
-		std::cout << "Invalid C state finalize " << linux_name << " \n";
+		fprintf(stderr, _("Invalid C state finalize %s\n"), linux_name.c_str());
 		return;
 	}
 
@@ -371,7 +370,7 @@ void abstract_cpu::finalize_pstate(uint64_t freq, uint64_t duration, int count)
 	}
 
 	if (!state) {
-		std::cout << "Invalid P state finalize " << freq << " \n";
+		fprintf(stderr, _("Invalid P state finalize %" PRIu64 "\n"), freq);
 		return;
 	}
 	state->time_after += duration;

--- a/src/cpu/abstract_cpu.cpp
+++ b/src/cpu/abstract_cpu.cpp
@@ -217,7 +217,7 @@ void abstract_cpu::insert_cstate(const std::string &linux_name, const std::strin
 			char c = human_name[i];
 			if (c >= '0' && c <= '9') {
 				try {
-					state->line_level = std::stoull(human_name.substr(i));
+					state->line_level = std::stoi(human_name.substr(i));
 				} catch (...) {}
 
 				if (i + 1 < human_name.length() && human_name[i+1] != '-') {
@@ -244,7 +244,7 @@ void abstract_cpu::insert_cstate(const std::string &linux_name, const std::strin
 			char c = linux_name[i];
 			if (c >= '0' && c <= '9') {
 				try {
-					state->line_level = std::stoull(linux_name.substr(i));
+					state->line_level = std::stoi(linux_name.substr(i));
 				} catch (...) {}
 				break;
 			}

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -950,7 +950,7 @@ void perf_power_bundle::handle_trace_point(void *trace, int cpunr, uint64_t time
 	if (!event)
 		return;
 
-	if (cpunr >= (int)all_cpus.size()) {
+	if (cpunr < 0 || cpunr >= (int)all_cpus.size()) {
 		fprintf(stderr, _("INVALID cpu nr in handle_trace_point\n"));
 		return;
 	}

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -616,7 +616,7 @@ void report_display_cpu_cstates(void)
 		/* Report Output */
 		if(core_num > 0)
 			title=title/core_num;
-		else if(_core && _core->children.size() > 0)
+		else if(_core && !_core->children.empty())
 			title=title/_core->children.size();
 
 		init_pkg_table_attr(&std_table_css, pkg_tbl_size.rows,  pkg_tbl_size.cols);

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -22,7 +22,6 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#include <iostream>
 #include <fstream>
 #include <vector>
 #include <string.h>
@@ -952,7 +951,7 @@ void perf_power_bundle::handle_trace_point(void *trace, int cpunr, uint64_t time
 		return;
 
 	if (cpunr >= (int)all_cpus.size()) {
-		std::cout << "INVALID cpu nr in handle_trace_point\n";
+		fprintf(stderr, _("INVALID cpu nr in handle_trace_point\n"));
 		return;
 	}
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -24,7 +24,7 @@
  */
 #include <fstream>
 #include <vector>
-#include <string.h>
+#include <cstring>
 #include <stdlib.h>
 #include <sstream>
 #include <ncurses.h>

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -61,7 +61,7 @@ class perf_power_bundle: public perf_bundle
 
 static class abstract_cpu * new_package(int package, int cpu, const std::string &vendor, int family, int model)
 {
-	class abstract_cpu *ret = NULL;
+	class abstract_cpu *ret = nullptr;
 	class cpudevice *cpudev;
 	class cpu_rapl_device *cpu_rapl_dev;
 	class dram_rapl_device *dram_rapl_dev;
@@ -106,7 +106,7 @@ static class abstract_cpu * new_package(int package, int cpu, const std::string 
 
 static class abstract_cpu * new_core(int core, int cpu, const std::string &vendor, int family, int model)
 {
-	class abstract_cpu *ret = NULL;
+	class abstract_cpu *ret = nullptr;
 
 	if (vendor == "GenuineIntel")
 		if (family == 6)
@@ -129,7 +129,7 @@ static class abstract_cpu * new_core(int core, int cpu, const std::string &vendo
 
 static class abstract_cpu * new_i965_gpu(void)
 {
-	class abstract_cpu *ret = NULL;
+	class abstract_cpu *ret = nullptr;
 
 	ret = new class i965_core;
 	ret->childcount = 0;
@@ -140,7 +140,7 @@ static class abstract_cpu * new_i965_gpu(void)
 
 static class abstract_cpu * new_cpu(int number, const std::string &vendor, int family, int model)
 {
-	class abstract_cpu * ret = NULL;
+	class abstract_cpu * ret = nullptr;
 
 	if (vendor == "GenuineIntel")
 		if (family == 6)
@@ -179,7 +179,7 @@ static void handle_one_cpu(unsigned int number, const std::string &vendor, int f
 
 
 	if (system_level.children.size() <= package_number)
-		system_level.children.resize(package_number + 1, NULL);
+		system_level.children.resize(package_number + 1, nullptr);
 
 	if (!system_level.children[package_number]) {
 		system_level.children[package_number] = new_package(package_number, number, vendor, family, model);
@@ -191,7 +191,7 @@ static void handle_one_cpu(unsigned int number, const std::string &vendor, int f
 
 
 	if (package->children.size() <= core_number)
-		package->children.resize(core_number + 1, NULL);
+		package->children.resize(core_number + 1, nullptr);
 
 	if (!package->children[core_number]) {
 		package->children[core_number] = new_core(core_number, number, vendor, family, model);
@@ -202,7 +202,7 @@ static void handle_one_cpu(unsigned int number, const std::string &vendor, int f
 	core->parent = package;
 
 	if (core->children.size() <= number)
-		core->children.resize(number + 1, NULL);
+		core->children.resize(number + 1, nullptr);
 
 	if (!core->children[number]) {
 		core->children[number] = new_cpu(number, vendor, family, model);
@@ -213,7 +213,7 @@ static void handle_one_cpu(unsigned int number, const std::string &vendor, int f
 	cpu->parent = core;
 
 	if (number >= all_cpus.size())
-		all_cpus.resize(number + 1, NULL);
+		all_cpus.resize(number + 1, nullptr);
 	all_cpus[number] = cpu;
 }
 
@@ -228,7 +228,7 @@ static void handle_i965_gpu(void)
 	core_number = package->children.size();
 
 	if (package->children.size() <= core_number)
-		package->children.resize(core_number + 1, NULL);
+		package->children.resize(core_number + 1, nullptr);
 
 	if (!package->children[core_number]) {
 		package->children[core_number] = new_i965_gpu();
@@ -390,7 +390,7 @@ static int get_cstates_num(void)
 	for (package = 0, cstates_num = 0;
 			package < system_level.children.size(); package++) {
 		_package = system_level.children[package];
-		if (_package == NULL)
+		if (_package == nullptr)
 			continue;
 
 		/* walk package cstates and get largest cstates number */
@@ -404,7 +404,7 @@ static int get_cstates_num(void)
 		 */
 		for (core = 0; core < _package->children.size(); core++) {
 			_core = _package->children[core];
-			if (_core == NULL)
+			if (_core == nullptr)
 				continue;
 
 			for (i = 0; i <  _core->cstates.size(); i++)
@@ -417,7 +417,7 @@ static int get_cstates_num(void)
 			 */
 			 for (cpu = 0; cpu < _core->children.size(); cpu++) {
 				_cpu = _core->children[cpu];
-				if (_cpu == NULL)
+				if (_cpu == nullptr)
 					continue;
 
 				for (i = 0; i < _cpu->cstates.size(); i++)
@@ -434,7 +434,7 @@ void report_display_cpu_cstates(void)
 {
 	unsigned int package, core, cpu;
 	int line, cstates_num, title=0, core_num=0;
-	class abstract_cpu *_package, *_core = NULL, * _cpu;
+	class abstract_cpu *_package, *_core = nullptr, * _cpu;
 	std::string core_type;
 
 	cstates_num = get_cstates_num();
@@ -636,7 +636,7 @@ void report_display_cpu_pstates(void)
 {
 	unsigned int package, core, cpu;
 	int line, title=0;
-	class abstract_cpu *_package, *_core = NULL, * _cpu;
+	class abstract_cpu *_package, *_core = nullptr, * _cpu;
 	unsigned int i, pstates_num;
 	std::string core_type;
 
@@ -964,7 +964,7 @@ void perf_power_bundle::handle_trace_point(void *trace, int cpunr, uint64_t time
 	int ret;
 	if (strcmp(event->name, "cpu_idle")==0) {
 
-		ret = tep_get_field_val(NULL, event, "state", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "state", &rec, &val, 0);
                 if (ret < 0) {
                         fprintf(stderr, _("cpu_idle event returned no state?\n"));
                         exit(-1);
@@ -979,7 +979,7 @@ void perf_power_bundle::handle_trace_point(void *trace, int cpunr, uint64_t time
 	if (strcmp(event->name, "power_frequency") == 0
 	|| strcmp(event->name, "cpu_frequency") == 0){
 
-		ret = tep_get_field_val(NULL, event, "state", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "state", &rec, &val, 0);
 		if (ret < 0) {
 			fprintf(stderr, _("power or cpu_frequency event returned no state?\n"));
 			exit(-1);

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -54,7 +54,7 @@ static	class perf_bundle * perf_events;
 
 class perf_power_bundle: public perf_bundle
 {
-	virtual void handle_trace_point(void *trace, int cpu, uint64_t time);
+	virtual void handle_trace_point(void *trace, int cpu, uint64_t time) override;
 
 };
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -512,6 +512,8 @@ void report_display_cpu_cstates(void)
 			if (!_core)
 				continue;
 
+			core_num+=1;
+
 			/* *** PKG STARTS *** */
 			for (line = LEVEL_HEADER; line <= cstates_num; line++) {
 				bool first_cpu = true;

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -170,41 +170,41 @@ class cpu_linux: public abstract_cpu
 	void 	parse_cstates_end(void);
 
 public:
-	virtual void	measurement_start(void);
-	virtual void	measurement_end(void);
+	virtual void	measurement_start(void) override;
+	virtual void	measurement_end(void) override;
 
-	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="");
-	virtual std::string  fill_cstate_name(int line_nr);
-	virtual std::string  fill_cstate_percentage(int line_nr);
-	virtual std::string  fill_cstate_time(int line_nr);
+	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="") override;
+	virtual std::string  fill_cstate_name(int line_nr) override;
+	virtual std::string  fill_cstate_percentage(int line_nr) override;
+	virtual std::string  fill_cstate_time(int line_nr) override;
 
-	virtual std::string  fill_pstate_line(int line_nr);
-	virtual std::string  fill_pstate_name(int line_nr);
+	virtual std::string  fill_pstate_line(int line_nr) override;
+	virtual std::string  fill_pstate_name(int line_nr) override;
 };
 
 class cpu_core: public abstract_cpu
 {
 public:
-	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="");
-	virtual std::string  fill_cstate_name(int line_nr);
+	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="") override;
+	virtual std::string  fill_cstate_name(int line_nr) override;
 
-	virtual std::string  fill_pstate_line(int line_nr);
-	virtual std::string  fill_pstate_name(int line_nr);
+	virtual std::string  fill_pstate_line(int line_nr) override;
+	virtual std::string  fill_pstate_name(int line_nr) override;
 
-	virtual int     can_collapse(void) { return childcount == 1;};
+	virtual int     can_collapse(void) override { return childcount == 1;};
 };
 
 class cpu_package: public abstract_cpu
 {
 protected:
-	virtual void	freq_updated(uint64_t time);
+	virtual void	freq_updated(uint64_t time) override;
 public:
-	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="");
-	virtual std::string  fill_cstate_name(int line_nr);
+	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator="") override;
+	virtual std::string  fill_cstate_name(int line_nr) override;
 
-	virtual std::string  fill_pstate_line(int line_nr);
-	virtual std::string  fill_pstate_name(int line_nr);
-	virtual int     can_collapse(void) { return childcount == 1;};
+	virtual std::string  fill_pstate_line(int line_nr) override;
+	virtual std::string  fill_pstate_name(int line_nr) override;
+	virtual int     can_collapse(void) override { return childcount == 1;};
 };
 
 extern void enumerate_cpus(void);

--- a/src/cpu/cpu_linux.cpp
+++ b/src/cpu/cpu_linux.cpp
@@ -33,7 +33,6 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <string.h>
 #include <sys/types.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/cpu/cpu_linux.cpp
+++ b/src/cpu/cpu_linux.cpp
@@ -61,7 +61,7 @@ void cpu_linux::parse_cstates_start(void)
 		uint64_t duration = 0;
 
 
-		if (strlen(entry->d_name) < 3)
+		if (entry->d_name[0] == '.')
 			continue;
 
 		linux_name = entry->d_name;
@@ -140,7 +140,7 @@ void cpu_linux::parse_cstates_end(void)
 		uint64_t duration = 0;
 
 
-		if (strlen(entry->d_name) < 3)
+		if (entry->d_name[0] == '.')
 			continue;
 
 		linux_name = entry->d_name;

--- a/src/cpu/cpu_rapl_device.cpp
+++ b/src/cpu/cpu_rapl_device.cpp
@@ -24,7 +24,6 @@
  */
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include "../parameters/parameters.h"
 #include "cpu_rapl_device.h"
 

--- a/src/cpu/cpu_rapl_device.cpp
+++ b/src/cpu/cpu_rapl_device.cpp
@@ -36,7 +36,7 @@ cpu_rapl_device::cpu_rapl_device(cpudevice *parent, const std::string &classname
 		rapl = new c_rapl_interface(dev_name, cpu->get_first_cpu());
 	else
 		rapl = new c_rapl_interface();
-	last_time = time(NULL);
+	last_time = time(nullptr);
 	if (rapl->pp0_domain_present()) {
 		device_valid = true;
 		parent->add_child(this);
@@ -46,14 +46,14 @@ cpu_rapl_device::cpu_rapl_device(cpudevice *parent, const std::string &classname
 
 void cpu_rapl_device::start_measurement(void)
 {
-	last_time = time(NULL);
+	last_time = time(nullptr);
 
 	rapl->get_pp0_energy_status(&last_energy);
 }
 
 void cpu_rapl_device::end_measurement(void)
 {
-	time_t		curr_time = time(NULL);
+	time_t		curr_time = time(nullptr);
 	double energy;
 
 	consumed_power = 0.0;

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -40,7 +40,7 @@ class cpu_rapl_device: public cpudevice {
 	bool		device_valid = false;
 
 public:
-	cpu_rapl_device(cpudevice *parent, const std::string &classname = "cpu_core", const std::string &device_name = "cpu_core", class abstract_cpu *_cpu = NULL);
+	cpu_rapl_device(cpudevice *parent, const std::string &classname = "cpu_core", const std::string &device_name = "cpu_core", class abstract_cpu *_cpu = nullptr);
 	~cpu_rapl_device() { delete rapl; }
 	virtual std::string device_name(void) override {return "CPU core";};
 	virtual std::string human_name(void) override {return "CPU core";};

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -42,8 +42,8 @@ class cpu_rapl_device: public cpudevice {
 public:
 	cpu_rapl_device(cpudevice *parent, const std::string &classname = "cpu_core", const std::string &device_name = "cpu_core", class abstract_cpu *_cpu = nullptr);
 	~cpu_rapl_device() { delete rapl; }
-	virtual std::string device_name(void) override {return "CPU core";};
-	virtual std::string human_name(void) override {return "CPU core";};
+	virtual std::string device_name(void) override {return _("CPU core");};
+	virtual std::string human_name(void) override {return _("CPU core");};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
 	virtual void start_measurement(void) override;

--- a/src/cpu/cpu_rapl_device.h
+++ b/src/cpu/cpu_rapl_device.h
@@ -42,12 +42,12 @@ class cpu_rapl_device: public cpudevice {
 public:
 	cpu_rapl_device(cpudevice *parent, const std::string &classname = "cpu_core", const std::string &device_name = "cpu_core", class abstract_cpu *_cpu = NULL);
 	~cpu_rapl_device() { delete rapl; }
-	virtual std::string device_name(void) {return "CPU core";};
-	virtual std::string human_name(void) {return "CPU core";};
+	virtual std::string device_name(void) override {return "CPU core";};
+	virtual std::string human_name(void) override {return "CPU core";};
 	bool device_present() { return device_valid;}
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
 };
 

--- a/src/cpu/cpudevice.cpp
+++ b/src/cpu/cpudevice.cpp
@@ -25,7 +25,6 @@
 #include "cpudevice.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include <format>
 #include "../lib.h"
 #include "../parameters/parameters.h"

--- a/src/cpu/cpudevice.h
+++ b/src/cpu/cpudevice.h
@@ -45,7 +45,7 @@ protected:
 	std::vector<device *>child_devices;
 
 public:
-	cpudevice(const std::string &classname = "cpu", const std::string &device_name = "cpu0", class abstract_cpu *_cpu = NULL);
+	cpudevice(const std::string &classname = "cpu", const std::string &device_name = "cpu0", class abstract_cpu *_cpu = nullptr);
 	virtual std::string class_name(void) override { return _class; };
 
 	virtual std::string device_name(void) override;

--- a/src/cpu/cpudevice.h
+++ b/src/cpu/cpudevice.h
@@ -46,14 +46,14 @@ protected:
 
 public:
 	cpudevice(const std::string &classname = "cpu", const std::string &device_name = "cpu0", class abstract_cpu *_cpu = NULL);
-	virtual std::string class_name(void) { return _class; };
+	virtual std::string class_name(void) override { return _class; };
 
-	virtual std::string device_name(void);
-	virtual std::string human_name(void);
+	virtual std::string device_name(void) override;
+	virtual std::string human_name(void) override;
 
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual bool show_in_list(void) {return false;};
-	virtual double	utilization(void); /* percentage */
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual bool show_in_list(void) override {return false;};
+	virtual double	utilization(void) override; /* percentage */
 	void add_child(device *dev_ptr) { child_devices.push_back(dev_ptr);}
 };
 

--- a/src/cpu/dram_rapl_device.cpp
+++ b/src/cpu/dram_rapl_device.cpp
@@ -37,7 +37,7 @@ dram_rapl_device::dram_rapl_device(cpudevice *parent, const std::string &classna
 		rapl = new c_rapl_interface(dev_name, cpu->get_first_cpu());
 	else
 		rapl = new c_rapl_interface();
-	last_time = time(NULL);
+	last_time = time(nullptr);
 	if (rapl->dram_domain_present()) {
 		device_valid = true;
 		parent->add_child(this);
@@ -47,14 +47,14 @@ dram_rapl_device::dram_rapl_device(cpudevice *parent, const std::string &classna
 
 void dram_rapl_device::start_measurement(void)
 {
-	last_time = time(NULL);
+	last_time = time(nullptr);
 
 	rapl->get_dram_energy_status(&last_energy);
 }
 
 void dram_rapl_device::end_measurement(void)
 {
-	time_t		curr_time = time(NULL);
+	time_t		curr_time = time(nullptr);
 	double energy;
 
 	consumed_power = 0.0;

--- a/src/cpu/dram_rapl_device.cpp
+++ b/src/cpu/dram_rapl_device.cpp
@@ -24,7 +24,6 @@
  */
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include "../parameters/parameters.h"
 #include "dram_rapl_device.h"
 

--- a/src/cpu/dram_rapl_device.h
+++ b/src/cpu/dram_rapl_device.h
@@ -42,12 +42,12 @@ class dram_rapl_device: public cpudevice {
 public:
 	dram_rapl_device(cpudevice *parent, const std::string &classname = "dram_core", const std::string &device_name = "dram_core", class abstract_cpu *_cpu = NULL);
 	~dram_rapl_device() { delete rapl; }
-	virtual std::string device_name(void) {return "DRAM";};
-	virtual std::string human_name(void) {return "DRAM";};
+	virtual std::string device_name(void) override {return "DRAM";};
+	virtual std::string human_name(void) override {return "DRAM";};
 	bool device_present() { return device_valid;}
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	void start_measurement(void);
-	void end_measurement(void);
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	void start_measurement(void) override;
+	void end_measurement(void) override;
 
 };
 

--- a/src/cpu/dram_rapl_device.h
+++ b/src/cpu/dram_rapl_device.h
@@ -40,7 +40,7 @@ class dram_rapl_device: public cpudevice {
 	bool		device_valid = false;
 
 public:
-	dram_rapl_device(cpudevice *parent, const std::string &classname = "dram_core", const std::string &device_name = "dram_core", class abstract_cpu *_cpu = NULL);
+	dram_rapl_device(cpudevice *parent, const std::string &classname = "dram_core", const std::string &device_name = "dram_core", class abstract_cpu *_cpu = nullptr);
 	~dram_rapl_device() { delete rapl; }
 	virtual std::string device_name(void) override {return "DRAM";};
 	virtual std::string human_name(void) override {return "DRAM";};

--- a/src/cpu/intel_cpus.cpp
+++ b/src/cpu/intel_cpus.cpp
@@ -33,7 +33,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/time.h>
-#include <string.h>
+#include <cstring>
 #include <errno.h>
 #include <unistd.h>
 #include <limits.h>

--- a/src/cpu/intel_cpus.cpp
+++ b/src/cpu/intel_cpus.cpp
@@ -279,7 +279,7 @@ void nhm_core::measurement_end(void)
 {
 	unsigned int i;
 	uint64_t time_delta;
-	double ratio;
+	double ratio = 0.0;
 
 	if (this->has_c1_res)
 		c1_after = get_msr(first_cpu, MSR_CORE_C1_RESIDENCY);
@@ -310,7 +310,8 @@ void nhm_core::measurement_end(void)
 
 	time_delta = 1000000 * (stamp_after.tv_sec - stamp_before.tv_sec) + stamp_after.tv_usec - stamp_before.tv_usec;
 
-	ratio = 1.0 * time_delta / (tsc_after - tsc_before);
+	if (tsc_after != tsc_before)
+		ratio = 1.0 * time_delta / (tsc_after - tsc_before);
 
 	for (i = 0; i < cstates.size(); i++) {
 		struct idle_state *state = cstates[i];
@@ -548,7 +549,7 @@ void nhm_package::measurement_start(void)
 void nhm_package::measurement_end(void)
 {
 	uint64_t time_delta;
-	double ratio;
+	double ratio = 0.0;
 	unsigned int i, j;
 
 	for (i = 0; i < children.size(); i++)
@@ -601,7 +602,8 @@ void nhm_package::measurement_end(void)
 
 	time_delta = 1000000 * (stamp_after.tv_sec - stamp_before.tv_sec) + stamp_after.tv_usec - stamp_before.tv_usec;
 
-	ratio = 1.0 * time_delta / (tsc_after - tsc_before);
+	if (tsc_after != tsc_before)
+		ratio = 1.0 * time_delta / (tsc_after - tsc_before);
 
 
 	for (i = 0; i < cstates.size(); i++) {
@@ -665,7 +667,7 @@ void nhm_cpu::measurement_start(void)
 void nhm_cpu::measurement_end(void)
 {
 	uint64_t time_delta;
-	double ratio;
+	double ratio = 0.0;
 	unsigned int i;
 
 	aperf_after = get_msr(number, MSR_APERF);
@@ -681,7 +683,8 @@ void nhm_cpu::measurement_end(void)
 
 	time_delta = 1000000 * (stamp_after.tv_sec - stamp_before.tv_sec) + stamp_after.tv_usec - stamp_before.tv_usec;
 
-	ratio = 1.0 * time_delta / (tsc_after - tsc_before);
+	if (tsc_after != tsc_before)
+		ratio = 1.0 * time_delta / (tsc_after - tsc_before);
 
 
 	for (i = 0; i < cstates.size(); i++) {

--- a/src/cpu/intel_cpus.h
+++ b/src/cpu/intel_cpus.h
@@ -80,11 +80,11 @@ public:
 	int		has_c6c_res = 0;		/* BSW */
 	int		has_c8c9c10_res = 0;
 	nhm_package(int model);
-	virtual void	measurement_start(void);
-	virtual void	measurement_end(void);
-	virtual int     can_collapse(void) { return 0;};
+	virtual void	measurement_start(void) override;
+	virtual void	measurement_end(void) override;
+	virtual int     can_collapse(void) override { return 0;};
 
-	virtual std::string  fill_pstate_line(int line_nr);
+	virtual std::string  fill_pstate_line(int line_nr) override;
 };
 
 class nhm_core: public cpu_core, public intel_util
@@ -103,11 +103,11 @@ public:
 	int		has_c7_res = 0;
 	int		has_c3_res = 0;
 	nhm_core(int model);
-	virtual void	measurement_start(void);
-	virtual void	measurement_end(void);
-	virtual int     can_collapse(void) { return 0;};
+	virtual void	measurement_start(void) override;
+	virtual void	measurement_end(void) override;
+	virtual int     can_collapse(void) override { return 0;};
 
-	virtual std::string  fill_pstate_line(int line_nr);
+	virtual std::string  fill_pstate_line(int line_nr) override;
 };
 
 class nhm_cpu: public cpu_linux, public intel_util
@@ -122,28 +122,28 @@ private:
 	uint64_t	last_stamp = 0;
 	uint64_t	total_stamp = 0;
 public:
-	virtual void	measurement_start(void);
-	virtual void	measurement_end(void);
-	virtual int     can_collapse(void) { return 0;};
+	virtual void	measurement_start(void) override;
+	virtual void	measurement_end(void) override;
+	virtual int     can_collapse(void) override { return 0;};
 
-	virtual std::string  fill_pstate_name(int line_nr);
-	virtual std::string  fill_pstate_line(int line_nr);
-	virtual int	has_pstate_level(int level);
+	virtual std::string  fill_pstate_name(int line_nr) override;
+	virtual std::string  fill_pstate_line(int line_nr) override;
+	virtual int	has_pstate_level(int level) override;
 };
 
 class atom_package: public cpu_package
 {
 public:
-	virtual void	measurement_start(void);
-	virtual void	measurement_end(void);
+	virtual void	measurement_start(void) override;
+	virtual void	measurement_end(void) override;
 
 };
 
 class atom_core: public cpu_core
 {
 public:
-	virtual void	measurement_start(void);
-	virtual void	measurement_end(void);
+	virtual void	measurement_start(void) override;
+	virtual void	measurement_end(void) override;
 
 };
 
@@ -159,16 +159,16 @@ private:
 	struct timeval	after;
 
 public:
-	virtual void	measurement_start(void);
-	virtual void	measurement_end(void);
-	virtual int     can_collapse(void) { return 0;};
+	virtual void	measurement_start(void) override;
+	virtual void	measurement_end(void) override;
+	virtual int     can_collapse(void) override { return 0;};
 
-	virtual std::string  fill_pstate_line(int line_nr);
-	virtual std::string  fill_pstate_name(int line_nr);
-	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator);
-	virtual int	has_pstate_level(int level __unused) { return 0; };
-	virtual int	has_pstates(void) { return 0; };
-	virtual void	wiggle(void) { };
+	virtual std::string  fill_pstate_line(int line_nr) override;
+	virtual std::string  fill_pstate_name(int line_nr) override;
+	virtual std::string  fill_cstate_line(int line_nr, const std::string &separator) override;
+	virtual int	has_pstate_level(int level __unused) override { return 0; };
+	virtual int	has_pstates(void) override { return 0; };
+	virtual void	wiggle(void) override { };
 
 };
 

--- a/src/cpu/intel_gpu.cpp
+++ b/src/cpu/intel_gpu.cpp
@@ -33,7 +33,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/time.h>
-#include <string.h>
 #include <errno.h>
 #include <unistd.h>
 

--- a/src/cpu/intel_gpu.cpp
+++ b/src/cpu/intel_gpu.cpp
@@ -44,9 +44,9 @@
 void i965_core::measurement_start(void)
 {
 	before = pt_gettime();
-	rc6_before = read_sysfs("/sys/class/drm/card0/power/rc6_residency_ms", NULL);
-	rc6p_before = read_sysfs("/sys/class/drm/card0/power/rc6p_residency_ms", NULL);
-	rc6pp_before = read_sysfs("/sys/class/drm/card0/power/rc6pp_residency_ms", NULL);
+	rc6_before = read_sysfs("/sys/class/drm/card0/power/rc6_residency_ms", nullptr);
+	rc6p_before = read_sysfs("/sys/class/drm/card0/power/rc6p_residency_ms", nullptr);
+	rc6pp_before = read_sysfs("/sys/class/drm/card0/power/rc6pp_residency_ms", nullptr);
 
 	update_cstate("gpu c0", "Powered On", 0, 0, 1, 0);
 	update_cstate("gpu rc6", "RC6", 0, rc6_before, 1, 1);
@@ -96,9 +96,9 @@ void i965_core::measurement_end(void)
 {
 	after = pt_gettime();
 
-	rc6_after = read_sysfs("/sys/class/drm/card0/power/rc6_residency_ms", NULL);
-	rc6p_after = read_sysfs("/sys/class/drm/card0/power/rc6p_residency_ms", NULL);
-	rc6pp_after = read_sysfs("/sys/class/drm/card0/power/rc6pp_residency_ms", NULL);
+	rc6_after = read_sysfs("/sys/class/drm/card0/power/rc6_residency_ms", nullptr);
+	rc6p_after = read_sysfs("/sys/class/drm/card0/power/rc6p_residency_ms", nullptr);
+	rc6pp_after = read_sysfs("/sys/class/drm/card0/power/rc6pp_residency_ms", nullptr);
 }
 
 std::string i965_core::fill_pstate_line(int line_nr __unused)

--- a/src/cpu/rapl/rapl_interface.cpp
+++ b/src/cpu/rapl/rapl_interface.cpp
@@ -94,8 +94,8 @@ c_rapl_interface::c_rapl_interface(const std::string &dev_name, int cpu) :
 
 	if (!dev_name.empty()) {
 		std::string base_path = "/sys/class/powercap/intel-rapl/";
-		if ((dir = opendir(base_path.c_str())) != NULL) {
-			while ((entry = readdir(dir)) != NULL) {
+		if ((dir = opendir(base_path.c_str())) != nullptr) {
+			while ((entry = readdir(dir)) != nullptr) {
 				if (std::string_view(entry->d_name).starts_with('.'))
 					continue;
 				std::string path = base_path + entry->d_name + "/name";
@@ -114,8 +114,8 @@ c_rapl_interface::c_rapl_interface(const std::string &dev_name, int cpu) :
 	}
 
 	if (powercap_sysfs_present) {
-		if ((dir = opendir(package_path.c_str())) != NULL) {
-			while ((entry = readdir(dir)) != NULL) {
+		if ((dir = opendir(package_path.c_str())) != nullptr) {
+			while ((entry = readdir(dir)) != nullptr) {
 				if (std::string_view(entry->d_name).starts_with('.'))
 					continue;
 				std::string path = package_path + entry->d_name;

--- a/src/cpu/rapl/rapl_interface.cpp
+++ b/src/cpu/rapl/rapl_interface.cpp
@@ -377,7 +377,7 @@ int c_rapl_interface::get_dram_energy_status(double *status)
 	if (powercap_sysfs_present) {
 		std::string str = read_sysfs_string(powercap_dram_path + "energy_uj");
 		if (str.length() > 0) {
-			*status =  atof(str.c_str()) / 1000000; // uj to Js
+			try { *status = std::stod(str) / 1000000; } catch (...) { return -EINVAL; } // uj to Js
 			return 0;
 		}
 
@@ -468,7 +468,7 @@ int c_rapl_interface::get_pp0_energy_status(double *status)
 	if (powercap_sysfs_present) {
 		std::string str = read_sysfs_string(powercap_core_path + "energy_uj");
 		if (str.length() > 0) {
-			*status = atof(str.c_str()) / 1000000; // uj to Js
+			try { *status = std::stod(str) / 1000000; } catch (...) { return -EINVAL; } // uj to Js
 			return 0;
 		}
 
@@ -556,7 +556,7 @@ int c_rapl_interface::get_pp1_energy_status(double *status)
 	if (powercap_sysfs_present) {
 		std::string str = read_sysfs_string(powercap_uncore_path + "energy_uj");
 		if (str.length() > 0) {
-			*status =  atof(str.c_str()) / 1000000; // uj to Js
+			try { *status = std::stod(str) / 1000000; } catch (...) { return -EINVAL; } // uj to Js
 			return 0;
 		}
 

--- a/src/cpu/rapl/rapl_interface.cpp
+++ b/src/cpu/rapl/rapl_interface.cpp
@@ -301,7 +301,7 @@ int c_rapl_interface::get_pkg_energy_status(double *status)
 		return ret;
 	}
 
-	*status = (double) (value & 0xffffffff) * get_energy_status_unit();
+	*status = (double)(value & 0xffffffff) * energy_status_units;
 
 	return ret;
 }
@@ -391,7 +391,7 @@ int c_rapl_interface::get_dram_energy_status(double *status)
 		return ret;
 	}
 
-	*status = (double) (value & 0xffffffff) * get_energy_status_unit();
+	*status = (double)(value & 0xffffffff) * energy_status_units;
 
 	return ret;
 }
@@ -482,7 +482,7 @@ int c_rapl_interface::get_pp0_energy_status(double *status)
 		return ret;
 	}
 
-	*status = (double) (value & 0xffffffff) * get_energy_status_unit();
+	*status = (double)(value & 0xffffffff) * energy_status_units;
 
 	return ret;
 }
@@ -570,7 +570,7 @@ int c_rapl_interface::get_pp1_energy_status(double *status)
 		return ret;
 	}
 
-	*status = (double) (value & 0xffffffff) * get_energy_status_unit();
+	*status = (double)(value & 0xffffffff) * energy_status_units;
 
 	return ret;
 }

--- a/src/cpu/rapl/rapl_interface.cpp
+++ b/src/cpu/rapl/rapl_interface.cpp
@@ -100,7 +100,7 @@ c_rapl_interface::c_rapl_interface(const std::string &dev_name, int cpu) :
 					continue;
 				std::string path = base_path + entry->d_name + "/name";
 				std::string str = read_sysfs_string(path);
-				if (str.length() > 0) {
+				if (!str.empty()) {
 					if (str == dev_name) {
 						package_path = base_path + entry->d_name + "/";
 						powercap_sysfs_present = true;
@@ -120,7 +120,7 @@ c_rapl_interface::c_rapl_interface(const std::string &dev_name, int cpu) :
 					continue;
 				std::string path = package_path + entry->d_name;
 				std::string str = read_sysfs_string(path + "/name");
-				if (str.length() > 0) {
+				if (!str.empty()) {
 					if (str == "core") {
 						rapl_domains |= PP0_DOMAIN_PRESENT;
 						powercap_core_path = path + "/";
@@ -376,7 +376,7 @@ int c_rapl_interface::get_dram_energy_status(double *status)
 
 	if (powercap_sysfs_present) {
 		std::string str = read_sysfs_string(powercap_dram_path + "energy_uj");
-		if (str.length() > 0) {
+		if (!str.empty()) {
 			try { *status = std::stod(str) / 1000000; } catch (...) { return -EINVAL; } // uj to Js
 			return 0;
 		}
@@ -467,7 +467,7 @@ int c_rapl_interface::get_pp0_energy_status(double *status)
 
 	if (powercap_sysfs_present) {
 		std::string str = read_sysfs_string(powercap_core_path + "energy_uj");
-		if (str.length() > 0) {
+		if (!str.empty()) {
 			try { *status = std::stod(str) / 1000000; } catch (...) { return -EINVAL; } // uj to Js
 			return 0;
 		}
@@ -555,7 +555,7 @@ int c_rapl_interface::get_pp1_energy_status(double *status)
 
 	if (powercap_sysfs_present) {
 		std::string str = read_sysfs_string(powercap_uncore_path + "energy_uj");
-		if (str.length() > 0) {
+		if (!str.empty()) {
 			try { *status = std::stod(str) / 1000000; } catch (...) { return -EINVAL; } // uj to Js
 			return 0;
 		}

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -37,7 +37,6 @@
 #include "ahci.h"
 #include "../parameters/parameters.h"
 #include "report/report-data-html.h"
-#include <string.h>
 #include <format>
 
 std::vector <class ahci *> links;

--- a/src/devices/ahci.cpp
+++ b/src/devices/ahci.cpp
@@ -259,8 +259,6 @@ double ahci::power_usage(struct result_bundle *result, struct parameter_bundle *
 void ahci_create_device_stats_table(void)
 {
 	unsigned int i;
-	int cols=0;
-	int rows=0;
 
 	/* div attr css_class and css_id */
 	tag_attr div_attr;
@@ -281,8 +279,8 @@ void ahci_create_device_stats_table(void)
 
 	/* Set Table attributes, rows, and cols */
 	table_attributes std_table_css;
-	cols=5;
-	rows=links.size()+1;
+	int cols = 5;
+	int rows = static_cast<int>(links.size()) + 1;
 	init_std_side_table_attr(&std_table_css, rows, cols);
 
 

--- a/src/devices/ahci.h
+++ b/src/devices/ahci.h
@@ -49,18 +49,18 @@ public:
 
 	ahci(const std::string &_name, const std::string &path);
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void); /* percentage */
+	virtual double	utilization(void) override; /* percentage */
 
-	virtual std::string class_name(void) { return "ahci";};
+	virtual std::string class_name(void) override { return "ahci";};
 
-	virtual std::string device_name(void) { return name; };
-	virtual std::string human_name(void) { return humanname; };
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual bool power_valid(void) { return utilization_power_valid(partial_rindex) || utilization_power_valid(active_rindex);};
-	virtual int grouping_prio(void) { return 1; };
+	virtual std::string device_name(void) override { return name; };
+	virtual std::string human_name(void) override { return humanname; };
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual bool power_valid(void) override { return utilization_power_valid(partial_rindex) || utilization_power_valid(active_rindex);};
+	virtual int grouping_prio(void) override { return 1; };
 	virtual void report_device_stats(std::vector<std::string> &ahci_data, int idx);
 };
 

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -35,7 +35,6 @@
 
 #include "../devlist.h"
 
-#include <string.h>
 #include <unistd.h>
 #include <format>
 

--- a/src/devices/alsa.cpp
+++ b/src/devices/alsa.cpp
@@ -102,7 +102,10 @@ void alsa::end_measurement(void)
 		} catch (...) {}
 	}
 
-	p = (end_active - start_active) / (0.001 + end_active + end_inactive - start_active - start_inactive) * 100.0;
+	double active_delta = (end_active >= start_active) ? (double)(end_active - start_active) : 0.0;
+	double total_delta = (end_active + end_inactive >= start_active + start_inactive) ?
+		(double)(end_active + end_inactive - start_active - start_inactive) : 0.0;
+	p = active_delta / (0.001 + total_delta) * 100.0;
 	report_utilization(name, p);
 }
 
@@ -111,7 +114,10 @@ double alsa::utilization(void)
 {
 	double p;
 
-	p = (end_active - start_active) / (0.001 + end_active - start_active + end_inactive - start_inactive) * 100.0;
+	double active_delta = (end_active >= start_active) ? (double)(end_active - start_active) : 0.0;
+	double total_delta = (end_active + end_inactive >= start_active + start_inactive) ?
+		(double)(end_active + end_inactive - start_active - start_inactive) : 0.0;
+	p = active_delta / (0.001 + total_delta) * 100.0;
 
 	return p;
 }
@@ -141,10 +147,10 @@ double alsa::power_usage(struct result_bundle *result, struct parameter_bundle *
 	double power;
 	double factor;
 	double util;
-	static int index = 0;
+	static int index = -1;
 
 	power = 0;
-	if (!index)
+	if (index < 0)
 		index = get_param_index("alsa-codec-power");
 
 	factor = get_parameter_value(index, bundle);

--- a/src/devices/alsa.h
+++ b/src/devices/alsa.h
@@ -43,20 +43,20 @@ public:
 
 	alsa(const std::string &_name, const std::string &path);
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void); /* percentage */
+	virtual double	utilization(void) override; /* percentage */
 
-	virtual std::string class_name(void) { return "alsa";};
+	virtual std::string class_name(void) override { return "alsa";};
 
-	virtual std::string device_name(void) { return name; };
-	virtual std::string human_name(void);
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual bool power_valid(void) { return utilization_power_valid(rindex);};
+	virtual std::string device_name(void) override { return name; };
+	virtual std::string human_name(void) override;
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual bool power_valid(void) override { return utilization_power_valid(rindex);};
 
-	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle);
-	virtual int grouping_prio(void) { return 0; };
+	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle) override;
+	virtual int grouping_prio(void) override { return 0; };
 
 };
 

--- a/src/devices/backlight.cpp
+++ b/src/devices/backlight.cpp
@@ -35,7 +35,6 @@
 #include "backlight.h"
 #include "../parameters/parameters.h"
 
-#include <string.h>
 #include <format>
 
 

--- a/src/devices/backlight.h
+++ b/src/devices/backlight.h
@@ -48,7 +48,7 @@ public:
 	virtual std::string class_name(void) override { return "backlight";};
 
 	virtual std::string device_name(void) override { return name; };
-	virtual std::string human_name(void) override { return "Display backlight";};
+	virtual std::string human_name(void) override { return _("Display backlight");};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
 	virtual int grouping_prio(void) override { return 10; };
 };

--- a/src/devices/backlight.h
+++ b/src/devices/backlight.h
@@ -40,17 +40,17 @@ public:
 
 	backlight(const std::string &_name, const std::string &path);
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void); /* percentage */
+	virtual double	utilization(void) override; /* percentage */
 
-	virtual std::string class_name(void) { return "backlight";};
+	virtual std::string class_name(void) override { return "backlight";};
 
-	virtual std::string device_name(void) { return name; };
-	virtual std::string human_name(void) { return "Display backlight";};
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual int grouping_prio(void) { return 10; };
+	virtual std::string device_name(void) override { return name; };
+	virtual std::string human_name(void) override { return "Display backlight";};
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual int grouping_prio(void) override { return 10; };
 };
 
 extern void create_all_backlights(void);

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -97,7 +97,7 @@ void devfreq::add_devfreq_freq_state(uint64_t freq, uint64_t time)
 
 	state->freq = freq;
 	if (freq == 0)
-		state->human_name = "Idle";
+		state->human_name = _("Idle");
 	else
 		state->human_name = hz_to_human(freq);
 	state->time_before = time;

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -82,7 +82,8 @@ void devfreq::process_time_stamps()
 		active_time += state->time_after;
 	}
 	/* Compute idle time for the device */
-	dstates[i]->time_after = sample_time - active_time;
+	double idle = sample_time - (double)active_time;
+	dstates[i]->time_after = (idle > 0.0) ? (uint64_t)idle : 0;
 }
 
 void devfreq::add_devfreq_freq_state(uint64_t freq, uint64_t time)

--- a/src/devices/devfreq.cpp
+++ b/src/devices/devfreq.cpp
@@ -41,7 +41,7 @@
 #include "../report/report-maker.h"
 
 static bool is_enabled = true;
-static DIR *dir = NULL;
+static DIR *dir = nullptr;
 
 static std::vector<class devfreq *> all_devfreq;
 
@@ -106,14 +106,14 @@ void devfreq::add_devfreq_freq_state(uint64_t freq, uint64_t time)
 void devfreq::update_devfreq_freq_state(uint64_t freq, uint64_t time)
 {
 	unsigned int i;
-	class frequency *state = NULL;
+	class frequency *state = nullptr;
 
 	for(i=0; i < dstates.size(); i++) {
 		if (freq == dstates[i]->freq)
 			state = dstates[i];
 	}
 
-	if (state == NULL) {
+	if (state == nullptr) {
 		add_devfreq_freq_state(freq, time);
 		return;
 	}
@@ -240,20 +240,20 @@ void create_all_devfreq_devices(void)
 
 	std::string p = "/sys/class/devfreq/";
 	dir = opendir(p.c_str());
-	if (dir == NULL) {
+	if (dir == nullptr) {
 		fprintf(stderr, "Devfreq not enabled\n");
 		is_enabled = false;
 		return;
 	}
 
-	while(readdir(dir) != NULL)
+	while(readdir(dir) != nullptr)
 		num++;
 
 	if (num == 2) {
 		fprintf(stderr, "Devfreq not enabled\n");
 		is_enabled = false;
 		closedir(dir);
-		dir = NULL;
+		dir = nullptr;
 		return;
 	}
 
@@ -327,8 +327,8 @@ void clear_all_devfreq()
 	}
 	all_devfreq.clear();
 	/* close /sys/class/devfreq */
-	if (dir != NULL) {
+	if (dir != nullptr) {
 		closedir(dir);
-		dir = NULL;
+		dir = nullptr;
 	}
 }

--- a/src/devices/devfreq.h
+++ b/src/devices/devfreq.h
@@ -50,19 +50,19 @@ public:
 	std::string fill_freq_utilization(unsigned int idx);
 	std::string fill_freq_name(unsigned int idx);
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void); /* percentage */
+	virtual double	utilization(void) override; /* percentage */
 
-	virtual std::string class_name(void) { return "devfreq";};
+	virtual std::string class_name(void) override { return "devfreq";};
 
-	virtual std::string device_name(void) { return dir_name; };
-	virtual std::string human_name(void) { return "devfreq";};
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual std::string util_units(void) { return " rpm"; };
-	virtual bool power_valid(void) { return false; /*utilization_power_valid(r_index);*/};
-	virtual int grouping_prio(void) { return 1; };
+	virtual std::string device_name(void) override { return dir_name; };
+	virtual std::string human_name(void) override { return "devfreq";};
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual std::string util_units(void) override { return " rpm"; };
+	virtual bool power_valid(void) override { return false; /*utilization_power_valid(r_index);*/};
+	virtual int grouping_prio(void) override { return 1; };
 };
 
 extern void create_all_devfreq_devices(void);

--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -51,7 +51,6 @@
 #include "../report/report-data-html.h"
 #include "../measurement/measurement.h"
 #include "../devlist.h"
-#include <unistd.h>
 
 device::device(void)
 {

--- a/src/devices/gpu_rapl_device.cpp
+++ b/src/devices/gpu_rapl_device.cpp
@@ -24,7 +24,6 @@
  */
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include "../parameters/parameters.h"
 #include "gpu_rapl_device.h"
 

--- a/src/devices/gpu_rapl_device.cpp
+++ b/src/devices/gpu_rapl_device.cpp
@@ -42,13 +42,16 @@ gpu_rapl_device::gpu_rapl_device(i915gpu *parent)
 
 void gpu_rapl_device::start_measurement(void)
 {
+	if (!device_valid)
+		return;
 	last_time = time(nullptr);
-
 	rapl.get_pp1_energy_status(&last_energy);
 }
 
 void gpu_rapl_device::end_measurement(void)
 {
+	if (!device_valid)
+		return;
 	time_t		curr_time = time(nullptr);
 	double energy;
 

--- a/src/devices/gpu_rapl_device.cpp
+++ b/src/devices/gpu_rapl_device.cpp
@@ -32,7 +32,7 @@ gpu_rapl_device::gpu_rapl_device(i915gpu *parent)
 	: i915gpu(),
 	  device_valid(false)
 {
-	last_time = time(NULL);
+	last_time = time(nullptr);
 	if (rapl.pp1_domain_present()) {
 		device_valid = true;
 		parent->add_child(this);
@@ -42,14 +42,14 @@ gpu_rapl_device::gpu_rapl_device(i915gpu *parent)
 
 void gpu_rapl_device::start_measurement(void)
 {
-	last_time = time(NULL);
+	last_time = time(nullptr);
 
 	rapl.get_pp1_energy_status(&last_energy);
 }
 
 void gpu_rapl_device::end_measurement(void)
 {
-	time_t		curr_time = time(NULL);
+	time_t		curr_time = time(nullptr);
 	double energy;
 
 	consumed_power = 0.0;

--- a/src/devices/gpu_rapl_device.h
+++ b/src/devices/gpu_rapl_device.h
@@ -41,13 +41,13 @@ class gpu_rapl_device: public i915gpu {
 
 public:
 	gpu_rapl_device(i915gpu *parent);
-	virtual std::string class_name(void) { return "GPU core";};
-	virtual std::string device_name(void) { return "GPU core";};
-	virtual std::string human_name(void) { return "GPU core";};
+	virtual std::string class_name(void) override { return "GPU core";};
+	virtual std::string device_name(void) override { return "GPU core";};
+	virtual std::string human_name(void) override { return "GPU core";};
 	bool device_present() { return device_valid;}
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
 };
 

--- a/src/devices/gpu_rapl_device.h
+++ b/src/devices/gpu_rapl_device.h
@@ -41,9 +41,9 @@ class gpu_rapl_device: public i915gpu {
 
 public:
 	gpu_rapl_device(i915gpu *parent);
-	virtual std::string class_name(void) override { return "GPU core";};
-	virtual std::string device_name(void) override { return "GPU core";};
-	virtual std::string human_name(void) override { return "GPU core";};
+	virtual std::string class_name(void) override { return _("GPU core");};
+	virtual std::string device_name(void) override { return _("GPU core");};
+	virtual std::string human_name(void) override { return _("GPU core");};
 	bool device_present() { return device_valid;}
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
 	virtual void start_measurement(void) override;

--- a/src/devices/i915-gpu.cpp
+++ b/src/devices/i915-gpu.cpp
@@ -70,9 +70,9 @@ void create_i915_gpu(void)
 	class i915gpu *gpu;
 	gpu_rapl_device *rapl_dev;
 
-	if (!tracefs_event_file_exists(NULL, "i915", "i915_gem_ring_dispatch", "format")) {
+	if (!tracefs_event_file_exists(nullptr, "i915", "i915_gem_ring_dispatch", "format")) {
 		/* try an older tracepoint */
-		if (!tracefs_event_file_exists(NULL, "i915", "i915_gem_request_submit", "format"))
+		if (!tracefs_event_file_exists(nullptr, "i915", "i915_gem_request_submit", "format"))
 			return;
 	}
 

--- a/src/devices/i915-gpu.cpp
+++ b/src/devices/i915-gpu.cpp
@@ -39,7 +39,6 @@
 #include "gpu_rapl_device.h"
 
 extern "C" {
-#include <string.h>
 #include <unistd.h>
 #include <tracefs.h>
 }

--- a/src/devices/i915-gpu.h
+++ b/src/devices/i915-gpu.h
@@ -36,22 +36,22 @@ public:
 
 	i915gpu();
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void); /* percentage */
+	virtual double	utilization(void) override; /* percentage */
 
-	virtual std::string class_name(void) { return "GPU";};
+	virtual std::string class_name(void) override { return "GPU";};
 
-	virtual std::string device_name(void) {
+	virtual std::string device_name(void) override {
 		if (child_devices.size())
 			return "GPU misc";
 		return "GPU";
 	};
-	virtual std::string human_name(void) { return "Intel GPU"; };
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual bool show_in_list(void) {return false;};
-	virtual std::string util_units(void) { return " ops/s"; };
+	virtual std::string human_name(void) override { return "Intel GPU"; };
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual bool show_in_list(void) override {return false;};
+	virtual std::string util_units(void) override { return " ops/s"; };
 
 	virtual void add_child(device *dev_ptr) { child_devices.push_back(dev_ptr);}
 };

--- a/src/devices/i915-gpu.h
+++ b/src/devices/i915-gpu.h
@@ -48,10 +48,10 @@ public:
 			return "GPU misc";
 		return "GPU";
 	};
-	virtual std::string human_name(void) override { return "Intel GPU"; };
+	virtual std::string human_name(void) override { return _("Intel GPU"); };
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
 	virtual bool show_in_list(void) override {return false;};
-	virtual std::string util_units(void) override { return " ops/s"; };
+	virtual std::string util_units(void) override { return _(" ops/s"); };
 
 	virtual void add_child(device *dev_ptr) { child_devices.push_back(dev_ptr);}
 };

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -61,10 +61,10 @@ static void do_proc_net_dev(void)
 	static time_t last_time;
 	class network *dev;
 
-	if (time(NULL) == last_time)
+	if (time(nullptr) == last_time)
 		return;
 
-	last_time = time(NULL);
+	last_time = time(nullptr);
 
 	std::string content = read_file_content("/proc/net/dev");
 	if (content.empty())

--- a/src/devices/network.cpp
+++ b/src/devices/network.cpp
@@ -46,7 +46,7 @@ extern "C" {
 #include "../tuning/iw.h"
 }
 
-#include <string.h>
+#include <cstring>
 #include <format>
 #include <net/if.h>
 #include <linux/sockios.h>

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -65,19 +65,19 @@ public:
 
 	network(const std::string &_name, const std::string &path);
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void);
-	virtual std::string util_units(void) { return " pkts/s"; };
+	virtual double	utilization(void) override;
+	virtual std::string util_units(void) override { return " pkts/s"; };
 
-	virtual std::string class_name(void) { return "ethernet";};
+	virtual std::string class_name(void) override { return "ethernet";};
 
-	virtual std::string device_name(void) { return name; };
-	virtual std::string human_name(void) { return humanname; };
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual bool power_valid(void) { return utilization_power_valid(rindex_up) || utilization_power_valid(rindex_link_100) || utilization_power_valid(rindex_link_1000) || utilization_power_valid(rindex_link_high);};
-	virtual int grouping_prio(void) { return 10; };
+	virtual std::string device_name(void) override { return name; };
+	virtual std::string human_name(void) override { return humanname; };
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual bool power_valid(void) override { return utilization_power_valid(rindex_up) || utilization_power_valid(rindex_link_100) || utilization_power_valid(rindex_link_1000) || utilization_power_valid(rindex_link_high);};
+	virtual int grouping_prio(void) override { return 10; };
 };
 
 extern void create_all_nics(callback fn = NULL);

--- a/src/devices/network.h
+++ b/src/devices/network.h
@@ -80,5 +80,5 @@ public:
 	virtual int grouping_prio(void) override { return 10; };
 };
 
-extern void create_all_nics(callback fn = NULL);
+extern void create_all_nics(callback fn = nullptr);
 

--- a/src/devices/rfkill.cpp
+++ b/src/devices/rfkill.cpp
@@ -36,7 +36,6 @@
 #include "rfkill.h"
 #include "../parameters/parameters.h"
 
-#include <string.h>
 #include <unistd.h>
 #include <format>
 

--- a/src/devices/rfkill.h
+++ b/src/devices/rfkill.h
@@ -42,18 +42,18 @@ public:
 
 	rfkill(const std::string &_name, const std::string &path);
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void); /* percentage */
+	virtual double	utilization(void) override; /* percentage */
 
-	virtual std::string class_name(void) { return "radio";};
+	virtual std::string class_name(void) override { return "radio";};
 
-	virtual std::string device_name(void) { return name; };
-	virtual std::string human_name(void) { return humanname; };
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual bool power_valid(void) { return utilization_power_valid(rindex);};
-	virtual int grouping_prio(void) { return 5; };
+	virtual std::string device_name(void) override { return name; };
+	virtual std::string human_name(void) override { return humanname; };
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual bool power_valid(void) override { return utilization_power_valid(rindex);};
+	virtual int grouping_prio(void) override { return 5; };
 };
 
 extern void create_all_rfkills(void);

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -135,7 +135,8 @@ static void do_bus(const std::string &bus)
 		if (entry->d_name[0] == '.')
 			continue;
 
-		dev = new class runtime_pmdevice(entry->d_name, std::format("/sys/bus/{}/devices/{}", bus, entry->d_name));
+		std::string path = std::format("/sys/bus/{}/devices/{}", bus, entry->d_name);
+		dev = new class runtime_pmdevice(entry->d_name, path);
 		if (bus == "i2c") {
 			std::string devname;
 			bool is_adapter = false;
@@ -170,6 +171,10 @@ static void do_bus(const std::string &bus)
 				dev->set_human_name(pt_format(_("PCI Device: {}"),
 					pci_id_to_name(vendor, device)));
 			}
+		}
+		if (!device_has_runtime_pm(path)) {
+			delete dev;
+			continue;
 		}
 		all_devices.push_back(dev);
 	}

--- a/src/devices/runtime_pm.cpp
+++ b/src/devices/runtime_pm.cpp
@@ -24,7 +24,6 @@
  */
 #include "runtime_pm.h"
 
-#include <string.h>
 
 #include <stdio.h>
 #include <unistd.h>

--- a/src/devices/runtime_pm.h
+++ b/src/devices/runtime_pm.h
@@ -42,20 +42,20 @@ public:
 
 	runtime_pmdevice(const std::string &_name, const std::string &path);
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void); /* percentage */
+	virtual double	utilization(void) override; /* percentage */
 
-	virtual std::string class_name(void) { return "runtime_pm";};
+	virtual std::string class_name(void) override { return "runtime_pm";};
 
-	virtual std::string device_name(void) { return name; };
-	virtual std::string human_name(void) { return humanname; };
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual bool power_valid(void) { return utilization_power_valid(r_index);};
+	virtual std::string device_name(void) override { return name; };
+	virtual std::string human_name(void) override { return humanname; };
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual bool power_valid(void) override { return utilization_power_valid(r_index);};
 
 	void set_human_name(const std::string &name);
-	virtual int grouping_prio(void) { return 1; };
+	virtual int grouping_prio(void) override { return 1; };
 };
 
 extern void create_all_runtime_pm_devices(void);

--- a/src/devices/thinkpad-fan.cpp
+++ b/src/devices/thinkpad-fan.cpp
@@ -22,8 +22,6 @@
  * Authors:
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
-#include <iostream>
-#include <fstream>
 
 #include <stdio.h>
 #include <sys/types.h>
@@ -41,7 +39,6 @@
 #include "../process/powerconsumer.h"
 
 #include <string.h>
-#include <unistd.h>
 
 thinkpad_fan::thinkpad_fan(): device()
 {

--- a/src/devices/thinkpad-fan.cpp
+++ b/src/devices/thinkpad-fan.cpp
@@ -38,7 +38,6 @@
 #include "../parameters/parameters.h"
 #include "../process/powerconsumer.h"
 
-#include <string.h>
 
 thinkpad_fan::thinkpad_fan(): device()
 {

--- a/src/devices/thinkpad-fan.h
+++ b/src/devices/thinkpad-fan.h
@@ -44,7 +44,7 @@ public:
 	virtual std::string class_name(void) override { return "fan";};
 
 	virtual std::string device_name(void) override { return "Fan-1";};
-	virtual std::string human_name(void) override { return "Laptop fan";};
+	virtual std::string human_name(void) override { return _("Laptop fan");};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
 	virtual std::string util_units(void) override { return " rpm"; };
 	virtual bool power_valid(void) override { return utilization_power_valid(r_index);};

--- a/src/devices/thinkpad-fan.h
+++ b/src/devices/thinkpad-fan.h
@@ -36,19 +36,19 @@ public:
 
 	thinkpad_fan();
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void); /* percentage */
+	virtual double	utilization(void) override; /* percentage */
 
-	virtual std::string class_name(void) { return "fan";};
+	virtual std::string class_name(void) override { return "fan";};
 
-	virtual std::string device_name(void) { return "Fan-1";};
-	virtual std::string human_name(void) { return "Laptop fan";};
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual std::string util_units(void) { return " rpm"; };
-	virtual bool power_valid(void) { return utilization_power_valid(r_index);};
-	virtual int grouping_prio(void) { return 1; };
+	virtual std::string device_name(void) override { return "Fan-1";};
+	virtual std::string human_name(void) override { return "Laptop fan";};
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual std::string util_units(void) override { return " rpm"; };
+	virtual bool power_valid(void) override { return utilization_power_valid(r_index);};
+	virtual int grouping_prio(void) override { return 1; };
 };
 
 extern void create_thinkpad_fan(void);

--- a/src/devices/thinkpad-light.cpp
+++ b/src/devices/thinkpad-light.cpp
@@ -40,7 +40,6 @@
 #include "../parameters/parameters.h"
 #include "../process/powerconsumer.h"
 
-#include <string.h>
 #include <unistd.h>
 
 thinkpad_light::thinkpad_light(): device()

--- a/src/devices/thinkpad-light.h
+++ b/src/devices/thinkpad-light.h
@@ -36,19 +36,19 @@ public:
 
 	thinkpad_light();
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void); /* percentage */
+	virtual double	utilization(void) override; /* percentage */
 
-	virtual std::string class_name(void) { return "light";};
+	virtual std::string class_name(void) override { return "light";};
 
-	virtual std::string device_name(void) { return "Light-1";};
-	virtual std::string human_name(void) { return "Thinkpad light";};
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual std::string util_units(void) { return "%"; };
-	virtual bool power_valid(void) { return utilization_power_valid(r_index);};
-	virtual int grouping_prio(void) { return 1; };
+	virtual std::string device_name(void) override { return "Light-1";};
+	virtual std::string human_name(void) override { return "Thinkpad light";};
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual std::string util_units(void) override { return "%"; };
+	virtual bool power_valid(void) override { return utilization_power_valid(r_index);};
+	virtual int grouping_prio(void) override { return 1; };
 };
 
 extern void create_thinkpad_light(void);

--- a/src/devices/thinkpad-light.h
+++ b/src/devices/thinkpad-light.h
@@ -44,7 +44,7 @@ public:
 	virtual std::string class_name(void) override { return "light";};
 
 	virtual std::string device_name(void) override { return "Light-1";};
-	virtual std::string human_name(void) override { return "Thinkpad light";};
+	virtual std::string human_name(void) override { return _("Thinkpad light");};
 	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
 	virtual std::string util_units(void) override { return "%"; };
 	virtual bool power_valid(void) override { return utilization_power_valid(r_index);};

--- a/src/devices/usb.cpp
+++ b/src/devices/usb.cpp
@@ -112,12 +112,8 @@ double usbdevice::utilization(void) /* percentage */
 
 void usbdevice::register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle)
 {
-	char devfs_name[1024];
-
-	snprintf(devfs_name, sizeof(devfs_name), "usb/%03d/%03d", busnum,
-		 devnum);
-
-        register_devpower(devfs_name, power_usage(results, bundle), this);
+	std::string devfs_name = std::format("usb/{:03}/{:03}", busnum, devnum);
+	register_devpower(devfs_name.c_str(), power_usage(results, bundle), this);
 }
 
 double usbdevice::power_usage(struct result_bundle *result, struct parameter_bundle *bundle)

--- a/src/devices/usb.cpp
+++ b/src/devices/usb.cpp
@@ -24,7 +24,6 @@
  */
 #include "usb.h"
 
-#include <string.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>

--- a/src/devices/usb.h
+++ b/src/devices/usb.h
@@ -46,19 +46,19 @@ public:
 
 	usbdevice(const std::string &_name, const std::string &path, const std::string &devid);
 
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double	utilization(void); /* percentage */
+	virtual double	utilization(void) override; /* percentage */
 
-	virtual std::string class_name(void) { return "usb";};
+	virtual std::string class_name(void) override { return "usb";};
 
-	virtual std::string device_name(void) { return devname; };
-	virtual std::string human_name(void) { return humanname; };
-	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle);
-	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle);
-	virtual bool power_valid(void) { return utilization_power_valid(r_index);};
-	virtual int grouping_prio(void) { return 4; };
+	virtual std::string device_name(void) override { return devname; };
+	virtual std::string human_name(void) override { return humanname; };
+	virtual void register_power_with_devlist(struct result_bundle *results, struct parameter_bundle *bundle) override;
+	virtual double power_usage(struct result_bundle *result, struct parameter_bundle *bundle) override;
+	virtual bool power_valid(void) override { return utilization_power_valid(r_index);};
+	virtual int grouping_prio(void) override { return 4; };
 };
 
 extern void create_all_usb_devices(void);

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -166,7 +166,7 @@ void collect_open_devices(void)
 				dev = new(std::nothrow) struct devuser;
 				if (!dev)
 					continue;
-				dev->pid = strtoull(entry->d_name, NULL, 10);
+				dev->pid = strtoull(entry->d_name, nullptr, 10);
 				dev->device = link;
 				dev->comm = read_sysfs_string(std::format("/proc/{}/comm", entry->d_name));
 				target->push_back(dev);
@@ -253,7 +253,7 @@ void clear_devpower(void)
 void register_devpower(const std::string &devstring, double power, class device *_dev)
 {
 	unsigned int i;
-	struct devpower *dev =  NULL;
+	struct devpower *dev =  nullptr;
 
 	for (i = 0; i < devpower.size(); i++)
 		if (devstring == devpower[i]->device) {

--- a/src/devlist.cpp
+++ b/src/devlist.cpp
@@ -36,7 +36,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <dirent.h>
-#include <string.h>
+#include <cstring>
 #include <ctype.h>
 #include <limits.h>
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -31,7 +31,6 @@
 #include <vector>
 #include <map>
 #include <string>
-#include <string.h>
 
 static int display = 0;
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -86,8 +86,8 @@ void reset_display(void)
 }
 
 
-WINDOW *tab_bar = NULL;
-WINDOW *bottom_line = NULL;
+WINDOW *tab_bar = nullptr;
+WINDOW *bottom_line = nullptr;
 
 static int current_tab;
 
@@ -104,12 +104,12 @@ void show_tab(unsigned int tab)
 		return;
 
 	if (tab_bar) {
-		tab_bar = NULL;
+		tab_bar = nullptr;
 	}
 
 	if (bottom_line) {
 		delwin(bottom_line);
-		bottom_line = NULL;
+		bottom_line = nullptr;
 	}
 
 	tab_bar = newwin(1, 0, 0, 0);
@@ -159,11 +159,11 @@ WINDOW *get_ncurses_win(const std::string &name)
 	WINDOW *win;
 
 	if (tab_windows.count(name) == 0)
-		return NULL;
+		return nullptr;
 
 	w = tab_windows[name];
 	if (!w)
-		return NULL;
+		return nullptr;
 
 	win = w->win;
 
@@ -176,11 +176,11 @@ WINDOW *get_ncurses_win(int nr)
 	WINDOW *win;
 
 	if (nr < 0 || nr >= (int)tab_names.size())
-		return NULL;
+		return nullptr;
 
 	w = tab_windows[tab_names[nr]];
 	if (!w)
-		return NULL;
+		return nullptr;
 
 	win = w->win;
 

--- a/src/display.h
+++ b/src/display.h
@@ -55,7 +55,7 @@ public:
 		cursor_max = 0;
 		xpad_pos =0;
 		ypad_pos = 0;
-		win = NULL;
+		win = nullptr;
 	}
 
 	virtual void cursor_down(void) { 
@@ -81,7 +81,7 @@ public:
 	virtual ~tab_window()
 	{
 		delwin(win);
-		win = NULL;
+		win = nullptr;
 	}
 };
 
@@ -90,5 +90,5 @@ extern std::map<std::string, class tab_window *> tab_windows;
 WINDOW *get_ncurses_win(const std::string &name);
 WINDOW *get_ncurses_win(int nr);
 
-void create_tab(const std::string &name, const std::string &translation, class tab_window *w = NULL, std::string bottom_line = "");
+void create_tab(const std::string &name, const std::string &translation, class tab_window *w = nullptr, std::string bottom_line = "");
 

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -261,7 +261,7 @@ struct timeval pt_gettime(void)
 		test_framework_manager::get().replay_time(&tv);
 		return tv;
 	}
-	gettimeofday(&tv, NULL);
+	gettimeofday(&tv, nullptr);
 	if (test_framework_manager::get().is_recording()) {
 		test_framework_manager::get().record_time(tv);
 	}
@@ -273,13 +273,13 @@ void align_string(std::string &str, size_t min_sz, size_t max_sz)
 	size_t sz;
 	const char *buffer = str.c_str();
 
-	/** mbsrtowcs() allows NULL dst and zero sz,
+	/** mbsrtowcs() allows nullptr dst and zero sz,
 	 * comparing to mbstowcs(), which causes undefined
 	 * behaviour under given circumstances*/
 
 	/* start with mbsrtowcs() local mbstate_t * and
-	 * NULL dst pointer*/
-	sz = mbsrtowcs(NULL, &buffer, max_sz, NULL);
+	 * nullptr dst pointer*/
+	sz = mbsrtowcs(nullptr, &buffer, max_sz, nullptr);
 	if (sz == (size_t)-1) {
 		return;
 	}
@@ -463,7 +463,7 @@ void process_glob(const std::string &d_glob, callback fn)
 	glob_t g;
 	size_t c;
 
-	switch (glob(d_glob.c_str(), GLOB_ERR | GLOB_MARK | GLOB_NOSORT, NULL, &g)) {
+	switch (glob(d_glob.c_str(), GLOB_ERR | GLOB_MARK | GLOB_NOSORT, nullptr, &g)) {
 	case GLOB_NOSPACE:
 		fprintf(stderr,_("glob returned GLOB_NOSPACE\n"));
 		globfree(&g);

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -25,7 +25,7 @@
  */
 #include <map>
 #include <vector>
-#include <string.h>
+#include <cstring>
 #include <iostream>
 #include <utility>
 #include <fstream>

--- a/src/lib.h
+++ b/src/lib.h
@@ -76,7 +76,7 @@ extern std::string kernel_function(uint64_t address);
 #include <sys/time.h>
 
 extern void write_sysfs(const std::string &filename, const std::string &value);
-extern int read_sysfs(const std::string &filename, bool *ok = NULL);
+extern int read_sysfs(const std::string &filename, bool *ok = nullptr);
 extern std::string read_sysfs_string(const std::string &filename);
 extern std::string read_file_content(const std::string &filename);
 extern struct timeval pt_gettime(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -419,8 +419,6 @@ static void powertop_init(int auto_tune)
 	register_parameter("disk-operations", 0.0);
 	register_parameter("xwakes", 0.1);
 
-        load_parameters("saved_parameters.powertop");
-
 	initialized = 1;
 }
 
@@ -471,7 +469,7 @@ int main(int argc, char **argv)
 			case 'c':
 				powertop_init(0);
 				calibrate();
-				break;
+				exit(0);
 			case 'C':		/* csv report */
 				reporttype = REPORT_CSV;
 				filename = optarg ? optarg : "powertop.csv";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -236,7 +236,7 @@ void one_measurement(int seconds, int sample_interval, const std::string &worklo
 		pthread_t thread = 0UL;
 		end_thread = false;
 		if (pthread_create(&thread, nullptr, measure_background_thread, &sample_interval))
-			fprintf(stderr, "ERROR: workload measurement thread creation failed\n");
+			fprintf(stderr, _("ERROR: workload measurement thread creation failed\n"));
 
 		if (system(workload.c_str()))
 			fprintf(stderr, _("Unknown issue running workload!\n"));
@@ -542,7 +542,7 @@ int main(int argc, char **argv)
 			make_report(time_out, workload, iterations, sample_interval, filename);
 
 		if (debug_learning)
-			printf("Learning debugging enabled\n");
+			fprintf(stderr, _("Learning debugging enabled\n"));
 
 		learn_parameters(250, 0);
 		save_parameters("saved_parameters.powertop");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,25 +87,25 @@ enum {
 static const struct option long_options[] =
 {
 	/* These options set a flag. */
-	{"auto-tune",	no_argument,		NULL,		 OPT_AUTO_TUNE},
-	{"auto-tune-dump",	no_argument,	NULL,		 OPT_AUTO_TUNE_DUMP},
-	{"calibrate",	no_argument,		NULL,		 'c'},
-	{"csv",		optional_argument,	NULL,		 'C'},
+	{"auto-tune",	no_argument,		nullptr,		 OPT_AUTO_TUNE},
+	{"auto-tune-dump",	no_argument,	nullptr,		 OPT_AUTO_TUNE_DUMP},
+	{"calibrate",	no_argument,		nullptr,		 'c'},
+	{"csv",		optional_argument,	nullptr,		 'C'},
 	{"debug",	no_argument,		&debug_learning, OPT_DEBUG},
-	{"extech",	optional_argument,	NULL,		 OPT_EXTECH},
-	{"html",	optional_argument,	NULL,		 'r'},
-	{"iteration",	optional_argument,	NULL,		 'i'},
-	{"quiet",	no_argument,		NULL,		 'q'},
-	{"sample",	optional_argument,	NULL,		 's'},
-	{"time",	optional_argument,	NULL,		 't'},
-	{"workload",	optional_argument,	NULL,		 'w'},
-	{"version",	no_argument,		NULL,		 'V'},
-	{"help",	no_argument,		NULL,		 'h'},
+	{"extech",	optional_argument,	nullptr,		 OPT_EXTECH},
+	{"html",	optional_argument,	nullptr,		 'r'},
+	{"iteration",	optional_argument,	nullptr,		 'i'},
+	{"quiet",	no_argument,		nullptr,		 'q'},
+	{"sample",	optional_argument,	nullptr,		 's'},
+	{"time",	optional_argument,	nullptr,		 't'},
+	{"workload",	optional_argument,	nullptr,		 'w'},
+	{"version",	no_argument,		nullptr,		 'V'},
+	{"help",	no_argument,		nullptr,		 'h'},
 #ifdef ENABLE_TEST_FRAMEWORK
-	{"record",	required_argument,	NULL,		 OPT_RECORD},
-	{"replay",	required_argument,	NULL,		 OPT_REPLAY},
+	{"record",	required_argument,	nullptr,		 OPT_RECORD},
+	{"replay",	required_argument,	nullptr,		 OPT_REPLAY},
 #endif
-	{NULL,		0,			NULL,		 0}
+	{nullptr,		0,			nullptr,		 0}
 };
 
 static void print_version()
@@ -119,7 +119,7 @@ static bool set_refresh_timeout()
 	mvprintw(1, 0, "%s (currently %u): ", _("Set refresh time out"), time_out);
 	buf = get_user_input(3);
 	show_tab(0);
-	unsigned time = strtoul(buf.c_str(), NULL, 0);
+	unsigned time = strtoul(buf.c_str(), nullptr, 0);
 	if (!time) return 0;
 	if (time > 32) time = 32;
 	time_out = time;
@@ -156,7 +156,7 @@ static void do_sleep(int seconds)
 		sleep(seconds);
 		return;
 	}
-	target = time(NULL) + seconds;
+	target = time(nullptr) + seconds;
 	delta = seconds;
 	do {
 		int c;
@@ -203,7 +203,7 @@ static void do_sleep(int seconds)
 			return;
 		}
 
-		delta = target - time(NULL);
+		delta = target - time(nullptr);
 		if (delta <= 0)
 			break;
 
@@ -235,7 +235,7 @@ void one_measurement(int seconds, int sample_interval, const std::string &worklo
 	if (!workload.empty()) {
 		pthread_t thread = 0UL;
 		end_thread = false;
-		if (pthread_create(&thread, NULL, measure_background_thread, &sample_interval))
+		if (pthread_create(&thread, nullptr, measure_background_thread, &sample_interval))
 			fprintf(stderr, "ERROR: workload measurement thread creation failed\n");
 
 		if (system(workload.c_str()))
@@ -244,7 +244,7 @@ void one_measurement(int seconds, int sample_interval, const std::string &worklo
 		if (thread)
 		{
 			end_thread = true;
-			pthread_join( thread, NULL);
+			pthread_join( thread, nullptr);
 		}
 		global_sample_power();
 	} else {
@@ -396,7 +396,7 @@ static void powertop_init(int auto_tune)
 		}
 	}
 
-	srand(time(NULL));
+	srand(time(nullptr));
 
 	if (access("/var/cache/", W_OK) == 0)
 		mkdir("/var/cache/powertop", 0600);

--- a/src/measurement/acpi.h
+++ b/src/measurement/acpi.h
@@ -33,10 +33,10 @@ class acpi_power_meter: public power_meter {
 	void measure(void);
 public:
 	acpi_power_meter(const std::string &_battery_name);
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double power(void);
-	virtual double dev_capacity(void) { return capacity; };
+	virtual double power(void) override;
+	virtual double dev_capacity(void) override { return capacity; };
 };
 

--- a/src/measurement/extech.cpp
+++ b/src/measurement/extech.cpp
@@ -225,7 +225,7 @@ static int parse_packet(struct packet * p)
 			printf("Invalid packet, conversion failed\n");
 			return -1;
 		}
-		p->watts = strtod( &(p->op[8 * i]), NULL);
+		p->watts = strtod( &(p->op[8 * i]), nullptr);
 	}
 	return 0;
 }
@@ -249,7 +249,7 @@ static double extech_read(int fd)
 
 	memset(&p, 0, sizeof(p));
 
-	ret = select(fd + 1, &read_fd, NULL, NULL, &tv);
+	ret = select(fd + 1, &read_fd, nullptr, nullptr, &tv);
 	if (ret <= 0)
 		return -1;
 
@@ -300,7 +300,7 @@ void extech_power_meter::sample(void)
 	tv.tv_sec = 0;
 	tv.tv_nsec = 200000000;
 	while (!end_thread) {
-		nanosleep(&tv, NULL);
+		nanosleep(&tv, nullptr);
 		/* trigger the extech to send data */
 		ret = write(fd, " ", 1);
 		if (ret < 0)
@@ -329,7 +329,7 @@ extern "C"
 void extech_power_meter::end_measurement(void)
 {
 	end_thread = true;
-	pthread_join( thread, NULL);
+	pthread_join( thread, nullptr);
 	{
 		std::lock_guard<std::mutex> lock(samples_mutex);
 		if (samples)
@@ -348,7 +348,7 @@ void extech_power_meter::start_measurement(void)
 		samples = 0;
 	}
 
-	if (pthread_create(&thread, NULL, thread_proc, this))
+	if (pthread_create(&thread, nullptr, thread_proc, this))
 		fprintf(stderr, "ERROR: extech measurement thread creation failed\n");
 
 }

--- a/src/measurement/extech.cpp
+++ b/src/measurement/extech.cpp
@@ -140,7 +140,7 @@ static int setup_serial_device(int dev_fd)
 }
 
 
-static unsigned int decode_extech_value(unsigned char byt3, unsigned char byt4, char *a)
+static int decode_extech_value(unsigned char byt3, unsigned char byt4, char *a)
 {
 	unsigned int input = ((unsigned int)byt4 << 8) + byt3;
 	unsigned int i;
@@ -217,7 +217,7 @@ static int parse_packet(struct packet * p)
 		}
 	}
 
-	for (i = 0; i < 1; i++) {
+	for (i = 0; i < 4; i++) {
 		ret = decode_extech_value(p->buf[5 * i + 2],
 					  p->buf[5 * i + 3],
 					  &(p->op[8 * i]));

--- a/src/measurement/extech.cpp
+++ b/src/measurement/extech.cpp
@@ -212,7 +212,7 @@ static int parse_packet(struct packet * p)
 	 */
 	for (i = 0; i < 4; i++) {
 		if (p->buf[i * 5] != 2 || p->buf[i * 5 + 4] != 3) {
-			printf("Invalid packet\n");
+			fprintf(stderr, _("Invalid packet\n"));
 			return -1;
 		}
 	}
@@ -222,7 +222,7 @@ static int parse_packet(struct packet * p)
 					  p->buf[5 * i + 3],
 					  &(p->op[8 * i]));
 		if (ret) {
-			printf("Invalid packet, conversion failed\n");
+			fprintf(stderr, _("Invalid packet, conversion failed\n"));
 			return -1;
 		}
 		p->watts = strtod( &(p->op[8 * i]), nullptr);
@@ -286,7 +286,7 @@ void extech_power_meter::measure(void)
 {
 	/* trigger the extech to send data */
 	if(write(fd, " ", 1) == -1)
-		 printf("Error: %s\n", strerror(errno));
+		 fprintf(stderr, _("Error: %s\n"), strerror(errno));
 
 	rate = extech_read(fd);
 
@@ -349,7 +349,7 @@ void extech_power_meter::start_measurement(void)
 	}
 
 	if (pthread_create(&thread, nullptr, thread_proc, this))
-		fprintf(stderr, "ERROR: extech measurement thread creation failed\n");
+		fprintf(stderr, _("ERROR: extech measurement thread creation failed\n"));
 
 }
 

--- a/src/measurement/extech.cpp
+++ b/src/measurement/extech.cpp
@@ -37,7 +37,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
-#include <string.h>
+#include <cstring>
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -57,7 +57,7 @@
 #include "../lib.h"
 #include <iostream>
 #include <fstream>
-#include <string.h>
+#include <cstring>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/measurement/extech.h
+++ b/src/measurement/extech.h
@@ -41,11 +41,11 @@ class extech_power_meter: public power_meter {
 	pthread_t thread;
 public:
 	extech_power_meter(const std::string &_dev_name);
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 	virtual void sample(void);
 	
-	virtual double power(void);
-	virtual double dev_capacity(void) { return 0.0; };
+	virtual double power(void) override;
+	virtual double dev_capacity(void) override { return 0.0; };
 };
 

--- a/src/measurement/opal-sensors.cpp
+++ b/src/measurement/opal-sensors.cpp
@@ -25,7 +25,6 @@
 #include "measurement.h"
 #include "opal-sensors.h"
 #include "../lib.h"
-#include <string.h>
 #include <stdio.h>
 #include <limits.h>
 

--- a/src/measurement/opal-sensors.h
+++ b/src/measurement/opal-sensors.h
@@ -30,10 +30,10 @@
 class opal_sensors_power_meter: public power_meter {
 public:
 	opal_sensors_power_meter(const std::string &power_supply_name);
-	virtual void start_measurement(void) {};
-	virtual void end_measurement(void) {};
+	virtual void start_measurement(void) override {};
+	virtual void end_measurement(void) override {};
 
-	virtual double power(void);
-	virtual double dev_capacity(void) { return 0.0; }
+	virtual double power(void) override;
+	virtual double dev_capacity(void) override { return 0.0; }
 };
 

--- a/src/measurement/sysfs.cpp
+++ b/src/measurement/sysfs.cpp
@@ -25,7 +25,6 @@
 #include "measurement.h"
 #include "sysfs.h"
 #include "../lib.h"
-#include <string.h>
 #include <stdio.h>
 #include <limits.h>
 

--- a/src/measurement/sysfs.h
+++ b/src/measurement/sysfs.h
@@ -42,10 +42,10 @@ class sysfs_power_meter: public power_meter {
 	void measure();
 public:
 	sysfs_power_meter(const std::string &power_supply_name);
-	virtual void start_measurement(void);
-	virtual void end_measurement(void);
+	virtual void start_measurement(void) override;
+	virtual void end_measurement(void) override;
 
-	virtual double power(void) { return rate; }
-	virtual double dev_capacity(void) { return capacity; }
+	virtual double power(void) override { return rate; }
+	virtual double dev_capacity(void) override { return capacity; }
 };
 

--- a/src/parameters/learn.cpp
+++ b/src/parameters/learn.cpp
@@ -158,7 +158,7 @@ void learn_parameters(int iterations, int do_base_power)
 	if (do_base_power && !debug_learning)
 		best_so_far->parameters[bpi] = best_so_far->parameters[bpi] * 0.9998;
 
-	start = time(NULL);
+	start = time(nullptr);
 
 	while (retry--) {
 		int changed  = 0;
@@ -169,7 +169,7 @@ void learn_parameters(int iterations, int do_base_power)
 
 		bestparam = -1;
 
-		if (time(NULL) - start > 1 && !debug_learning)
+		if (time(nullptr) - start > 1 && !debug_learning)
 			retry = 0;
 
 		calculate_params(best_so_far);

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -25,7 +25,6 @@
 #include "parameters.h"
 #include "../measurement/measurement.h"
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
 #include <math.h>
 #include <vector>

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -299,7 +299,7 @@ struct result_bundle * clone_results(struct result_bundle *bundle)
 	b2 = new struct result_bundle;
 
 	if (!b2)
-		return NULL;
+		return nullptr;
 
 	b2->power = bundle->power;
 	b2->utilization.resize(bundle->utilization.size());
@@ -320,7 +320,7 @@ struct parameter_bundle * clone_parameters(struct parameter_bundle *bundle)
 	b2 = new struct parameter_bundle;
 
 	if (!b2)
-		return NULL;
+		return nullptr;
 
 	b2->score = 0;
 	b2->guessed_power = 0;

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -455,7 +455,7 @@ int global_power_valid(void)
 	if (past_results.size() > 3 * all_parameters.parameters.size())
 		return 1;
 
-	if (past_results.size() > 0 && global_run_times < 1){
+	if (!past_results.empty() && global_run_times < 1){
 		fprintf(stderr, _("To show power estimates do %ld measurement(s) connected to battery only\n"),
 			(3 * all_parameters.parameters.size()) - past_results.size());
 		global_run_times += 1; 

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -254,9 +254,9 @@ void dump_parameter_bundle(struct parameter_bundle *para)
 	int index;
 
 	printf("\n\n");
-	printf("Parameter state \n");
+	printf(_("Parameter state \n"));
 	printf("----------------------------------\n");
-	printf("Value\t\tName\n");
+	printf(_("Value\t\tName\n"));
 	for (it = param_index.begin(); it != param_index.end(); it++) {
 		index = it->second;
 		printf("%5.2f\t\t%s (%i)\n", para->parameters[index], it->first.c_str(), index);
@@ -276,9 +276,9 @@ void dump_result_bundle(struct result_bundle *res)
 	unsigned int index;
 
 	printf("\n\n");
-	printf("Utilisation state \n");
+	printf(_("Utilisation state \n"));
 	printf("----------------------------------\n");
-	printf("Value\t\tName\n");
+	printf(_("Value\t\tName\n"));
 	for (it = result_index.begin(); it != result_index.end(); it++) {
 		index = get_result_index(it->first);
 		printf("%5.2f%%\t\t%s(%i)\n", res->utilization[index], it->first.c_str(), index);
@@ -457,7 +457,7 @@ int global_power_valid(void)
 		return 1;
 
 	if (past_results.size() > 0 && global_run_times < 1){
-		printf("To show power estimates do %ld measurement(s) connected to battery only\n",
+		fprintf(stderr, _("To show power estimates do %ld measurement(s) connected to battery only\n"),
 			(3 * all_parameters.parameters.size()) - past_results.size());
 		global_run_times += 1; 
 	}

--- a/src/parameters/parameters.h
+++ b/src/parameters/parameters.h
@@ -29,7 +29,6 @@
 #include <vector>
 #include <string>
 
-#include "string.h"
 #include "../devices/device.h"
 #include "../lib.h"
 

--- a/src/parameters/persistent.cpp
+++ b/src/parameters/persistent.cpp
@@ -134,8 +134,10 @@ void load_results(const std::string &filename)
 		} catch (...) {}
 	}
 
+	delete bundle;   /* always discard last-allocated but unsaved bundle */
+
 	if (bundle_saved == 0)
-		delete bundle;
+		return;
 
 	// '%i" is for count, do not translate
 	fprintf(stderr, _("Loaded %i prior measurements\n"), (int)count);

--- a/src/parameters/persistent.cpp
+++ b/src/parameters/persistent.cpp
@@ -42,7 +42,7 @@ void save_all_results(const std::string &filename)
 
 	file.open(pathname, std::ios::out);
 	if (!file) {
-		std::cout << _("Cannot save to file") << " " << pathname << "\n";
+		fprintf(stderr, "%s %s\n", _("Cannot save to file"), pathname.c_str());
 		return;
 	}
 	for (i = 0; i < past_results.size(); i++) {
@@ -83,7 +83,7 @@ void load_results(const std::string &filename)
 
 	std::string content = read_file_content(pathname);
 	if (content.empty()) {
-		std::cout << _("Cannot load from file") << " " << pathname << "\n";
+		fprintf(stderr, "%s %s\n", _("Cannot load from file"), pathname.c_str());
 		return;
 	}
 
@@ -157,7 +157,7 @@ void save_parameters(const std::string &filename)
 
 	file.open(pathname, std::ios::out);
 	if (!file) {
-		std::cout << _("Cannot save to file") << " " << pathname << "\n";
+		fprintf(stderr, "%s %s\n", _("Cannot save to file"), pathname.c_str());
 		return;
 	}
 
@@ -180,8 +180,8 @@ void load_parameters(const std::string &filename)
 
 	std::string content = read_file_content(pathname);
 	if (content.empty()) {
-		std::cout << _("Cannot load from file") << " " << pathname << "\n";
-		std::cout << _("File will be loaded after taking minimum number of measurement(s) with battery only \n");
+		fprintf(stderr, "%s %s\n", _("Cannot load from file"), pathname.c_str());
+		fprintf(stderr, _("File will be loaded after taking minimum number of measurement(s) with battery only\n"));
 		return;
 	}
 

--- a/src/parameters/persistent.cpp
+++ b/src/parameters/persistent.cpp
@@ -94,7 +94,7 @@ void load_results(const std::string &filename)
 	while (getline(stream, line)) {
 		double d;
 		if (first) {
-			if (line.length() > 0) {
+			if (!line.empty()) {
 				try {
 					bundle->power = std::stod(line);
 					if (bundle->power < min_power)

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -114,7 +114,7 @@ void perf_event::create_perf_event(const std::string &eventname __unused, int _c
 
 	fcntl(perf_fd, F_SETFL, O_NONBLOCK);
 
-	perf_mmap = mmap(NULL, (bufsize+1)*getpagesize(),
+	perf_mmap = mmap(nullptr, (bufsize+1)*getpagesize(),
 				PROT_READ | PROT_WRITE, MAP_SHARED, perf_fd, 0);
 	if (perf_mmap == MAP_FAILED) {
 		fprintf(stderr, "failed to mmap with %d (%s)\n", errno, strerror(errno));
@@ -140,7 +140,7 @@ static int parse_event_format(const std::string &system_name, const std::string 
 	char *buf;
 	int size;
 
-	buf = tracefs_event_file_read(NULL, system_name.c_str(), event_name.c_str(), "format", &size);
+	buf = tracefs_event_file_read(nullptr, system_name.c_str(), event_name.c_str(), "format", &size);
 	if (!buf)
 		return -1;
 
@@ -175,7 +175,7 @@ perf_event::~perf_event(void)
 	clear();
 	if (tep_get_ref(perf_event::tep) == 1) {
 		tep_free(perf_event::tep);
-		perf_event::tep = NULL;
+		perf_event::tep = nullptr;
 	} else
 		tep_unref(perf_event::tep);
 }
@@ -199,7 +199,7 @@ perf_event::perf_event(const std::string &system_name, const std::string &event_
 	perf_fd = -1;
 	bufsize = buffer_size;
 	cpu = _cpu;
-	perf_mmap = NULL;
+	perf_mmap = nullptr;
 	pc = nullptr;
 	data_mmap = nullptr;
 	trace_type = 0;
@@ -211,7 +211,7 @@ perf_event::perf_event(void)
 	allocate_tep();
 	perf_fd = -1;
 	bufsize = 128;
-	perf_mmap = NULL;
+	perf_mmap = nullptr;
 	pc = nullptr;
 	data_mmap = nullptr;
 	cpu = 0;
@@ -266,7 +266,7 @@ void perf_event::clear(void)
 	if (perf_mmap) {
 //		memset(perf_mmap, 0, (bufsize)*getpagesize());
 		munmap(perf_mmap, (bufsize+1)*getpagesize());
-		perf_mmap = NULL;
+		perf_mmap = nullptr;
 	}
 	if (perf_fd != -1)
 		close(perf_fd);

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -30,7 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <string.h>
+#include <cstring>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -23,7 +23,6 @@
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
 
-#include <iostream>
 #include <fstream>
 
 #include <errno.h>
@@ -117,7 +116,7 @@ void perf_event::create_perf_event(const std::string &eventname __unused, int _c
 	perf_mmap = mmap(nullptr, (bufsize+1)*getpagesize(),
 				PROT_READ | PROT_WRITE, MAP_SHARED, perf_fd, 0);
 	if (perf_mmap == MAP_FAILED) {
-		fprintf(stderr, "failed to mmap with %d (%s)\n", errno, strerror(errno));
+		fprintf(stderr, _("failed to mmap with %d (%s)\n"), errno, strerror(errno));
 		close(perf_fd);
 		perf_fd = -1;
 		return;
@@ -126,7 +125,7 @@ void perf_event::create_perf_event(const std::string &eventname __unused, int _c
 	ret = ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
 
 	if (ret < 0) {
-		fprintf(stderr, "failed to enable perf \n");
+		fprintf(stderr, _("failed to enable perf\n"));
 	}
 
 	pc = (perf_event_mmap_page *)perf_mmap;
@@ -228,7 +227,7 @@ void perf_event::stop(void)
 	int ret;
 	ret = ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0);
 	if (ret)
-		std::cout << "stop failing\n";
+		fprintf(stderr, _("stop failing\n"));
 }
 
 void perf_event::process(void *cookie)

--- a/src/perf/perf.cpp
+++ b/src/perf/perf.cpp
@@ -225,6 +225,8 @@ void perf_event::start(void)
 void perf_event::stop(void)
 {
 	int ret;
+	if (perf_fd < 0)
+		return;
 	ret = ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0);
 	if (ret)
 		fprintf(stderr, _("stop failing\n"));

--- a/src/perf/perf.h
+++ b/src/perf/perf.h
@@ -48,7 +48,7 @@ protected:
 	void create_perf_event(const std::string &eventname, int cpu);
 
 public:
-	unsigned int trace_type = 0;
+	int trace_type = 0;
 
 	perf_event(void);
 	perf_event(const std::string &system_name, const std::string &event_name, int cpu = 0, int buffer_size = 128);

--- a/src/perf/perf_bundle.cpp
+++ b/src/perf/perf_bundle.cpp
@@ -279,5 +279,5 @@ void perf_bundle::process(void)
 
 void perf_bundle::handle_trace_point(void *trace __unused, int cpu __unused, uint64_t time __unused)
 {
-	printf("UH OH... abstract handle_trace_point called\n");
+	fprintf(stderr, _("abstract handle_trace_point called\n"));
 }

--- a/src/perf/perf_bundle.cpp
+++ b/src/perf/perf_bundle.cpp
@@ -242,7 +242,7 @@ static void fixup_sample_trace_cpu(struct perf_sample *sample)
 	if (!event)
 		return;
 	/** don't touch trace if event does not contain cpu_id field*/
-	ret = tep_get_field_val(NULL, event, "cpu_id", &rec, &cpu_nr, 0);
+	ret = tep_get_field_val(nullptr, event, "cpu_id", &rec, &cpu_nr, 0);
 	if (ret < 0)
 		return;
 	sample->trace.cpu = cpu_nr;

--- a/src/perf/perf_bundle.cpp
+++ b/src/perf/perf_bundle.cpp
@@ -47,7 +47,7 @@ class perf_bundle_event: public perf_event
 {
 public:
 	perf_bundle_event(void);
-	virtual void handle_event(struct perf_event_header *header, void *cookie);
+	virtual void handle_event(struct perf_event_header *header, void *cookie) override;
 };
 
 perf_bundle_event::perf_bundle_event(void) : perf_event()

--- a/src/perf/perf_bundle.cpp
+++ b/src/perf/perf_bundle.cpp
@@ -25,7 +25,7 @@
 #include <iostream>
 #include <malloc.h>
 #include <algorithm>
-#include <string.h>
+#include <cstring>
 #include <stdint.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -174,7 +174,7 @@ static void consume_blame(unsigned int cpu)
 
 class perf_process_bundle: public perf_bundle
 {
-	virtual void handle_trace_point(void *trace, int cpu, uint64_t time);
+	virtual void handle_trace_point(void *trace, int cpu, uint64_t time) override;
 };
 
 static bool comm_is_xorg(const std::string &comm)

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -100,7 +100,7 @@ static class power_consumer *current_consumer(unsigned int cpu)
 
 		return cpu_stack[cpu][cpu_stack[cpu].size()-1];
 
-	return NULL;
+	return nullptr;
 }
 
 static void clear_consumers(void)
@@ -166,7 +166,7 @@ static void consume_blame(unsigned int cpu)
 		return;
 
 	cpu_blame[cpu]->wake_ups++;
-	cpu_blame[cpu] = NULL;
+	cpu_blame[cpu] = nullptr;
 	cpu_level[cpu] = 0;
 	clear_wakeup_pending(cpu);
 }
@@ -234,8 +234,8 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 	}
 
 	if (event_name == "sched_switch") {
-		class process *old_proc = NULL;
-		class process *new_proc  = NULL;
+		class process *old_proc = nullptr;
+		class process *new_proc  = nullptr;
 		std::string next_comm;
 		int next_pid;
 		int prev_pid;
@@ -246,12 +246,12 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		next_comm = get_tep_field_str(trace, event, field);
 
-		ret = tep_get_field_val(NULL, event, "next_pid", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "next_pid", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		next_pid = (int)val;
 
-		ret = tep_get_field_val(NULL, event, "prev_pid", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "prev_pid", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		prev_pid = (int)val;
@@ -269,13 +269,13 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 			old_proc = (class process *)current_consumer(cpu);
 
 		if (old_proc && old_proc->name() != "process")
-			old_proc = NULL;
+			old_proc = nullptr;
 
 		/* retire the old process */
 
 		if (old_proc) {
 			old_proc->deschedule_thread(time, prev_pid);
-			old_proc->waker = NULL;
+			old_proc->waker = nullptr;
 		}
 
 		if (consumer_depth(cpu))
@@ -298,17 +298,17 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 			consume_blame(cpu);
 		}
-		new_proc->waker = NULL;
+		new_proc->waker = nullptr;
 	}
 	else if (event_name == "sched_wakeup") {
-		class power_consumer *from = NULL;
-		class process *dest_proc = NULL;
-		class process *from_proc = NULL;
+		class power_consumer *from = nullptr;
+		class process *dest_proc = nullptr;
+		class process *from_proc = nullptr;
 		std::string comm;
 		int flags;
 		int pid;
 
-		ret = tep_get_common_field_val(NULL, event, "common_flags", &rec, &val, 0);
+		ret = tep_get_common_field_val(nullptr, event, "common_flags", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		flags = (int)val;
@@ -336,7 +336,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		comm = get_tep_field_str(trace, event, field);
 
-		ret = tep_get_field_val(NULL, event, "pid", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "pid", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		pid = (int)val;
@@ -345,13 +345,13 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		if (from && from->name() != "process"){
 			/* not a process doing the wakeup */
-			from = NULL;
-			from_proc = NULL;
+			from = nullptr;
+			from_proc = nullptr;
 		} else {
 			from_proc = (class process *) from;
 		}
 
-		if (from_proc && (dest_proc->running == 0) && (dest_proc->waker == NULL) && (pid != 0) && !dont_blame_me(from_proc->comm))
+		if (from_proc && (dest_proc->running == 0) && (dest_proc->waker == nullptr) && (pid != 0) && !dont_blame_me(from_proc->comm))
 			dest_proc->waker = from;
 		if (from)
 			dest_proc->last_waker = from;
@@ -362,7 +362,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 	}
 	else if (event_name == "irq_handler_entry") {
-		class interrupt *irq = NULL;
+		class interrupt *irq = nullptr;
 		std::string handler;
 		int nr;
 
@@ -372,7 +372,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		handler = get_tep_field_str(trace, event, field);
 
-		ret = tep_get_field_val(NULL, event, "irq", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "irq", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		nr = (int)val;
@@ -390,7 +390,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 	}
 
 	else if (event_name == "irq_handler_exit") {
-		class interrupt *irq = NULL;
+		class interrupt *irq = nullptr;
 		uint64_t t;
 
 		/* find interrupt (top of stack) */
@@ -404,11 +404,11 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 	}
 
 	else if (event_name == "softirq_entry") {
-		class interrupt *irq = NULL;
+		class interrupt *irq = nullptr;
 		std::string handler;
 		int vec;
 
-		ret = tep_get_field_val(NULL, event, "vec", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "vec", &rec, &val, 0);
                 if (ret < 0) {
                         fprintf(stderr, "softirq_entry event returned no vector number?\n");
                         return;
@@ -429,7 +429,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		change_blame(cpu, irq, LEVEL_SOFTIRQ);
 	}
 	else if (event_name == "softirq_exit") {
-		class interrupt *irq = NULL;
+		class interrupt *irq = nullptr;
 		uint64_t t;
 
 		irq = (class interrupt *) current_consumer(cpu);
@@ -441,11 +441,11 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		consumer_child_time(cpu, t);
 	}
 	else if (event_name == "timer_expire_entry") {
-		class timer *timer = NULL;
+		class timer *timer = nullptr;
 		uint64_t function;
 		uint64_t tmr;
 
-		ret = tep_get_field_val(NULL, event, "function", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "function", &rec, &val, 0);
 		if (ret < 0) {
 			fprintf(stderr, "timer_expire_entry event returned no function value?\n");
 			return;
@@ -457,7 +457,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		if (timer->is_deferred())
 			return;
 
-		ret = tep_get_field_val(NULL, event, "timer", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "timer", &rec, &val, 0);
 		if (ret < 0) {
 			fprintf(stderr, "timer_expire_entry event returned no timer?\n");
 			return;
@@ -471,11 +471,11 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 			change_blame(cpu, timer, LEVEL_TIMER);
 	}
 	else if (event_name == "timer_expire_exit") {
-		class timer *timer = NULL;
+		class timer *timer = nullptr;
 		uint64_t tmr;
 		uint64_t t;
 
-		ret = tep_get_field_val(NULL, event, "timer", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "timer", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		tmr = (uint64_t)val;
@@ -493,18 +493,18 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		consumer_child_time(cpu, t);
 	}
 	else if (event_name == "hrtimer_expire_entry") {
-		class timer *timer = NULL;
+		class timer *timer = nullptr;
 		uint64_t function;
 		uint64_t tmr;
 
-		ret = tep_get_field_val(NULL, event, "function", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "function", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		function = (uint64_t)val;
 
 		timer = find_create_timer(function);
 
-		ret = tep_get_field_val(NULL, event, "hrtimer", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "hrtimer", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		tmr = (uint64_t)val;
@@ -516,7 +516,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 			change_blame(cpu, timer, LEVEL_TIMER);
 	}
 	else if (event_name == "hrtimer_expire_exit") {
-		class timer *timer = NULL;
+		class timer *timer = nullptr;
 		uint64_t tmr;
 		uint64_t t;
 
@@ -525,7 +525,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 			return;
 		}
 
-		ret = tep_get_field_val(NULL, event, "hrtimer", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "hrtimer", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		tmr = (uint64_t)val;
@@ -539,16 +539,16 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		consumer_child_time(cpu, t);
 	}
 	else if (event_name == "workqueue_execute_start") {
-		class work *work = NULL;
+		class work *work = nullptr;
 		uint64_t function;
 		uint64_t wk;
 
-		ret = tep_get_field_val(NULL, event, "function", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "function", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		function = (uint64_t)val;
 
-		ret = tep_get_field_val(NULL, event, "work", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "work", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		wk = (uint64_t)val;
@@ -564,11 +564,11 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 			change_blame(cpu, work, LEVEL_WORK);
 	}
 	else if (event_name == "workqueue_execute_end") {
-		class work *work = NULL;
+		class work *work = nullptr;
 		uint64_t t;
 		uint64_t wk;
 
-		ret = tep_get_field_val(NULL, event, "work", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "work", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		wk = (uint64_t)val;
@@ -586,7 +586,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		consumer_child_time(cpu, t);
 	}
 	else if (event_name == "cpu_idle") {
-		ret = tep_get_field_val(NULL, event, "state", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "state", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		if (val == (unsigned int)-1)
@@ -604,10 +604,10 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 	 || event_name == "i915_gem_request_submit") {
 		/* any kernel contains only one of the these tracepoints,
 		 * the latter one got replaced by the former one */
-		class power_consumer *consumer = NULL;
+		class power_consumer *consumer = nullptr;
 		int flags;
 
-		ret = tep_get_common_field_val(NULL, event, "common_flags", &rec, &val, 0);
+		ret = tep_get_common_field_val(nullptr, event, "common_flags", &rec, &val, 0);
 		if (ret < 0)
 			return;
 		flags = (int)val;
@@ -615,13 +615,13 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		consumer = current_consumer(cpu);
 		/* currently we don't count graphic requests submitted from irq contect */
 		if ( (flags & TRACE_FLAG_HARDIRQ) || (flags & TRACE_FLAG_SOFTIRQ)) {
-			consumer = NULL;
+			consumer = nullptr;
 		}
 
 
 		/* if we are X, and someone just woke us, account the GPU op to the guy waking us */
 		if (consumer && consumer->name() == "process") {
-			class process *proc = NULL;
+			class process *proc = nullptr;
 			proc = (class process *) consumer;
 			if (comm_is_xorg(proc->comm) && proc->last_waker) {
 				consumer = proc->last_waker;
@@ -635,12 +635,12 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 		}
 	}
 	else if (event_name == "writeback_inode_dirty") {
-		class power_consumer *consumer = NULL;
+		class power_consumer *consumer = nullptr;
 		int dev;
 
 		consumer = current_consumer(cpu);
 
-		ret = tep_get_field_val(NULL, event, "dev", &rec, &val, 0);
+		ret = tep_get_field_val(nullptr, event, "dev", &rec, &val, 0);
 		if (ret < 0)
 
 			return;
@@ -1153,8 +1153,8 @@ void process_process_data(void)
 	cpu_credit.resize(get_max_cpu()+1, 0);
 	cpu_level.resize(0, 0);
 	cpu_level.resize(get_max_cpu()+1, 0);
-	cpu_blame.resize(0, NULL);
-	cpu_blame.resize(get_max_cpu()+1, NULL);
+	cpu_blame.resize(0, nullptr);
+	cpu_blame.resize(get_max_cpu()+1, nullptr);
 
 
 

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -38,7 +38,6 @@
 #include <stack>
 
 #include <stdio.h>
-#include <string.h>
 #include <ncurses.h>
 
 #include "../perf/perf_bundle.h"

--- a/src/process/do_process.cpp
+++ b/src/process/do_process.cpp
@@ -410,7 +410,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		ret = tep_get_field_val(nullptr, event, "vec", &rec, &val, 0);
                 if (ret < 0) {
-                        fprintf(stderr, "softirq_entry event returned no vector number?\n");
+                        fprintf(stderr, _("softirq_entry event returned no vector number?\n"));
                         return;
                 }
 		vec = (int)val;
@@ -447,7 +447,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		ret = tep_get_field_val(nullptr, event, "function", &rec, &val, 0);
 		if (ret < 0) {
-			fprintf(stderr, "timer_expire_entry event returned no function value?\n");
+			fprintf(stderr, _("timer_expire_entry event returned no function value?\n"));
 			return;
 		}
 		function = (uint64_t)val;
@@ -459,7 +459,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
 
 		ret = tep_get_field_val(nullptr, event, "timer", &rec, &val, 0);
 		if (ret < 0) {
-			fprintf(stderr, "timer_expire_entry event returned no timer?\n");
+			fprintf(stderr, _("timer_expire_entry event returned no timer?\n"));
 			return;
 		}
 		tmr = (uint64_t)val;

--- a/src/process/interrupt.cpp
+++ b/src/process/interrupt.cpp
@@ -23,7 +23,6 @@
  *	Arjan van de Ven <arjan@linux.intel.com>
  */
 #include <stdint.h>
-#include <string.h>
 #include <stdio.h>
 #include "process.h"
 #include "interrupt.h"

--- a/src/process/interrupt.h
+++ b/src/process/interrupt.h
@@ -42,12 +42,12 @@ public:
 	virtual void start_interrupt(uint64_t time);
 	virtual uint64_t end_interrupt(uint64_t time);
 
-	virtual std::string description(void);
+	virtual std::string description(void) override;
 
-	virtual std::string name(void) { return "interrupt"; };
-	virtual std::string type(void) { return "Interrupt"; };
-	virtual double usage_summary(void);
-	virtual std::string usage_units_summary(void);
+	virtual std::string name(void) override { return "interrupt"; };
+	virtual std::string type(void) override { return "Interrupt"; };
+	virtual double usage_summary(void) override;
+	virtual std::string usage_units_summary(void) override;
 };
 
 extern std::vector <class interrupt *> all_interrupts;

--- a/src/process/powerconsumer.cpp
+++ b/src/process/powerconsumer.cpp
@@ -75,8 +75,8 @@ power_consumer::power_consumer(void)
 	gpu_ops = 0;
 	hard_disk_hits = 0;
 	xwakes = 0;
-	waker = NULL;
-	last_waker = NULL;
+	waker = nullptr;
+	last_waker = nullptr;
 	power_charge = 0.0;
 }
 

--- a/src/process/powerconsumer.cpp
+++ b/src/process/powerconsumer.cpp
@@ -99,9 +99,9 @@ std::string power_consumer::usage_units(void)
 	t = (accumulated_runtime - child_runtime) / 1000000.0 / measurement_time;
 	if (t < 0.7) {
 		if (utf_ok)
-			return " µs/s";
+			return _(" µs/s");
 		else
-			return " us/s";
+			return _(" us/s");
 	}
-	return " ms/s";
+	return _(" ms/s");
 }

--- a/src/process/powerconsumer.h
+++ b/src/process/powerconsumer.h
@@ -29,6 +29,8 @@
 #include <algorithm>
 #include <string>
 
+#include "../lib.h"
+
 extern double measurement_time;
 
 class power_consumer;
@@ -54,8 +56,8 @@ public:
 	virtual double Witts(void);
 	virtual std::string description(void) { return ""; };
 
-	virtual std::string name(void) { return "abstract"; };
-	virtual std::string type(void) { return "abstract"; };
+	virtual std::string name(void) { return _("abstract"); };
+	virtual std::string type(void) { return _("abstract"); };
 
 	virtual double usage(void);
 	virtual std::string usage_units(void);

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -26,7 +26,6 @@
 
 
 #include "process.h"
-#include <string.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -89,8 +89,8 @@ process::process(const std::string &_comm, int _pid, int _tid) : power_consumer(
 	pid = _pid;
 	is_idle = 0;
 	running = 0;
-	last_waker = NULL;
-	waker = NULL;
+	last_waker = nullptr;
+	waker = nullptr;
 	is_kernel = 0;
 	tgid = _tid;
 

--- a/src/process/process.cpp
+++ b/src/process/process.cpp
@@ -104,7 +104,7 @@ process::process(const std::string &_comm, int _pid, int _tid) : power_consumer(
 					size_t pos = line.find(':');
 					if (pos != std::string::npos) {
 						try {
-							tgid = std::stoull(line.substr(pos + 1));
+							tgid = std::stoi(line.substr(pos + 1));
 						} catch (...) {}
 						break;
 					}

--- a/src/process/process.h
+++ b/src/process/process.h
@@ -58,12 +58,12 @@ public:
 
 	virtual void account_disk_dirty(void);
 
-	virtual std::string description(void);
-	virtual std::string name(void) { return "process"; };
-	virtual std::string type(void) { return "Process"; };
+	virtual std::string description(void) override;
+	virtual std::string name(void) override { return "process"; };
+	virtual std::string type(void) override { return "Process"; };
 
-	virtual double usage_summary(void);
-	virtual std::string usage_units_summary(void);
+	virtual double usage_summary(void) override;
+	virtual std::string usage_units_summary(void) override;
 
 };
 

--- a/src/process/processdevice.h
+++ b/src/process/processdevice.h
@@ -36,13 +36,13 @@ public:
 	class device *device = nullptr;
 	device_consumer(class device *dev);
 
-	virtual std::string description(void);
-	virtual std::string name(void) { return "device"; };
-	virtual std::string type(void) { return "Device"; };
-	virtual double Witts(void);
-	virtual double usage(void) { return device->utilization();};
-	virtual std::string usage_units(void) {return device->util_units();};
-	virtual int show_events(void) { return 0; };
+	virtual std::string description(void) override;
+	virtual std::string name(void) override { return "device"; };
+	virtual std::string type(void) override { return "Device"; };
+	virtual double Witts(void) override;
+	virtual double usage(void) override { return device->utilization();};
+	virtual std::string usage_units(void) override {return device->util_units();};
+	virtual int show_events(void) override { return 0; };
 };
 
 extern void all_devices_to_all_power(void);

--- a/src/process/processdevice.h
+++ b/src/process/processdevice.h
@@ -37,8 +37,8 @@ public:
 	device_consumer(class device *dev);
 
 	virtual std::string description(void) override;
-	virtual std::string name(void) override { return "device"; };
-	virtual std::string type(void) override { return "Device"; };
+	virtual std::string name(void) override { return _("device"); };
+	virtual std::string type(void) override { return _("Device"); };
 	virtual double Witts(void) override;
 	virtual double usage(void) override { return device->utilization();};
 	virtual std::string usage_units(void) override {return device->util_units();};

--- a/src/process/timer.cpp
+++ b/src/process/timer.cpp
@@ -26,7 +26,6 @@
 #include <utility>
 
 #include <stdint.h>
-#include <string.h>
 #include <stdio.h>
 #include <sstream>
 

--- a/src/process/timer.cpp
+++ b/src/process/timer.cpp
@@ -102,7 +102,7 @@ double timer::usage_summary(void)
 
 std::string timer::usage_units_summary(void)
 {
-	return "%";
+	return _("%");
 }
 
 

--- a/src/process/timer.cpp
+++ b/src/process/timer.cpp
@@ -66,7 +66,7 @@ timer::timer(unsigned long address) : power_consumer()
 }
 
 
-static std::map<unsigned long, class timer *> all_timers;
+static std::map<uint64_t, class timer *> all_timers;
 static std::map<unsigned long, uint64_t> running_since;
 
 void timer::fire(uint64_t time, uint64_t timer_struct)
@@ -139,7 +139,7 @@ class timer * find_create_timer(uint64_t func)
 
 void clear_timers(void)
 {
-	std::map<unsigned long, class timer *>::iterator it = all_timers.begin();
+	std::map<uint64_t, class timer *>::iterator it = all_timers.begin();
 	while (it != all_timers.end()) {
 		delete it->second;
 		all_timers.erase(it);

--- a/src/process/timer.h
+++ b/src/process/timer.h
@@ -41,11 +41,11 @@ public:
 	uint64_t done(uint64_t time, uint64_t timer_struct);
 	bool is_deferred(void);
 
-	virtual std::string description(void);
-	virtual std::string name(void) { return "timer"; };
-	virtual std::string type(void) { return "Timer"; };
-	virtual double usage_summary(void);
-	virtual std::string usage_units_summary(void);
+	virtual std::string description(void) override;
+	virtual std::string name(void) override { return "timer"; };
+	virtual std::string type(void) override { return "Timer"; };
+	virtual double usage_summary(void) override;
+	virtual std::string usage_units_summary(void) override;
 
 };
 

--- a/src/process/timer.h
+++ b/src/process/timer.h
@@ -49,13 +49,6 @@ public:
 
 };
 
-class timer_list {
-public:
-	uint64_t	timer_address = 0;
-	uint64_t	timer_func = 0;
-};
-
-
 extern void all_timers_to_all_power(void);
 extern class timer * find_create_timer(uint64_t func);
 extern void clear_timers(void);

--- a/src/process/work.cpp
+++ b/src/process/work.cpp
@@ -26,7 +26,6 @@
 #include <utility>
 
 #include <stdint.h>
-#include <string.h>
 #include <stdio.h>
 
 #include "work.h"

--- a/src/process/work.h
+++ b/src/process/work.h
@@ -39,11 +39,11 @@ public:
 	void fire(uint64_t time, uint64_t work_struct);
 	uint64_t done(uint64_t time, uint64_t work_struct);
 
-	virtual std::string description(void);
-	virtual std::string name(void) { return "work"; };
-	virtual std::string type(void) { return "kWork"; };
-	virtual double usage_summary(void);
-	virtual std::string usage_units_summary(void);
+	virtual std::string description(void) override;
+	virtual std::string name(void) override { return "work"; };
+	virtual std::string type(void) override { return "kWork"; };
+	virtual double usage_summary(void) override;
+	virtual std::string usage_units_summary(void) override;
 
 };
 

--- a/src/report/report-data-html.cpp
+++ b/src/report/report-data-html.cpp
@@ -99,6 +99,7 @@ void init_tune_table_attr(struct table_attributes *table_css, int rows, int cols
 	table_css->th_class="emph_title";
 	table_css->td_class="";
 	table_css->pos_table_title=T;
+	table_css->title_mod=0;
 	table_css->rows=rows;
 	table_css->cols=cols;
 }
@@ -109,6 +110,7 @@ void init_wakeup_table_attr(struct table_attributes *table_css, int rows, int co
 	table_css->th_class="emph_title";
 	table_css->td_class="";
 	table_css->pos_table_title=T;
+	table_css->title_mod=0;
 	table_css->rows=rows;
 	table_css->cols=cols;
 }

--- a/src/report/report-formatter-base.h
+++ b/src/report/report-formatter-base.h
@@ -30,10 +30,10 @@
 class report_formatter_string_base: public report_formatter
 {
 public:
-	virtual std::string get_result();
-	virtual void clear_result();
+	virtual std::string get_result() override;
+	virtual void clear_result() override;
 
-	virtual void add(const std::string &str);
+	virtual void add(const std::string &str) override;
 
 protected:
 	void add_exact(const std::string &str);

--- a/src/report/report-formatter-csv.h
+++ b/src/report/report-formatter-csv.h
@@ -48,20 +48,20 @@ class report_formatter_csv: public report_formatter_string_base
 {
 public:
 	report_formatter_csv();
-	void finish_report();
+	void finish_report() override;
 
 	/* Report Style */
-	void add_logo();
-	void add_header();
-	void end_header();
-	void add_div(struct tag_attr *div_attr);
-	void end_div();
-	void add_title(struct tag_attr *title_att, const std::string &title);
-	void add_navigation();
-	void add_summary_list(const std::vector<std::string> &list);
-	void add_table(const std::vector<std::string> &system_data, struct table_attributes *tb_attr);private:
+	void add_logo() override;
+	void add_header() override;
+	void end_header() override;
+	void add_div(struct tag_attr *div_attr) override;
+	void end_div() override;
+	void add_title(struct tag_attr *title_att, const std::string &title) override;
+	void add_navigation() override;
+	void add_summary_list(const std::vector<std::string> &list) override;
+	void add_table(const std::vector<std::string> &system_data, struct table_attributes *tb_attr) override;private:
 	void add_quotes();
-	std::string escape_string(const std::string &str);
+	std::string escape_string(const std::string &str) override;
 	bool csv_need_quotes = false;
 	size_t text_start = 0;
 };

--- a/src/report/report-formatter-csv.h
+++ b/src/report/report-formatter-csv.h
@@ -60,9 +60,7 @@ public:
 	void add_navigation() override;
 	void add_summary_list(const std::vector<std::string> &list) override;
 	void add_table(const std::vector<std::string> &system_data, struct table_attributes *tb_attr) override;private:
-	void add_quotes();
 	std::string escape_string(const std::string &str) override;
 	bool csv_need_quotes = false;
-	size_t text_start = 0;
 };
 

--- a/src/report/report-formatter-html.h
+++ b/src/report/report-formatter-html.h
@@ -46,23 +46,23 @@ class report_formatter_html: public report_formatter_string_base
 {
 public:
 	report_formatter_html();
-	void finish_report();
+	void finish_report() override;
 
 	/* Report Style */
-	void add_logo();
-	void add_header();
-	void end_header();
-	void add_div(struct tag_attr *div_attr);
-	void end_div();
-	void add_title(struct tag_attr *title_att, const std::string &title);
-	void add_navigation();
-	void add_summary_list(const std::vector<std::string> &list);
-	void add_table(const std::vector<std::string> &system_data, struct table_attributes *tb_attr);private:
+	void add_logo() override;
+	void add_header() override;
+	void end_header() override;
+	void add_div(struct tag_attr *div_attr) override;
+	void end_div() override;
+	void add_title(struct tag_attr *title_att, const std::string &title) override;
+	void add_navigation() override;
+	void add_summary_list(const std::vector<std::string> &list) override;
+	void add_table(const std::vector<std::string> &system_data, struct table_attributes *tb_attr) override;private:
 	/* Document structure related functions */
 	void init_markup();
 	void add_doc_header();
 	void add_doc_footer();
-	std::string escape_string(const std::string &str);
+	std::string escape_string(const std::string &str) override;
 
 };
 

--- a/src/report/report-maker.cpp
+++ b/src/report/report-maker.cpp
@@ -38,7 +38,7 @@
 report_maker::report_maker(report_type t)
 {
 	type = t;
-	formatter = NULL;
+	formatter = nullptr;
 	setup_report_formatter();
 	clear_result(); /* To reset state and add document header */
 }

--- a/src/report/report.cpp
+++ b/src/report/report.cpp
@@ -28,12 +28,12 @@
 #include "report.h"
 #include "report-maker.h"
 #include <errno.h>
-#include <string.h>
+#include <cstring>
 #include <utility>
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <string.h>
+#include <cstring>
 #include <malloc.h>
 #include <unistd.h>
 #include <limits.h>

--- a/src/report/report.cpp
+++ b/src/report/report.cpp
@@ -111,7 +111,7 @@ static std::string get_time_string(const std::string &fmt, time_t t)
 static void system_info(void)
 {
 	std::string str;
-	time_t now = time(NULL);
+	time_t now = time(nullptr);
 
 	/* div attr css_class and css_id */
 	tag_attr div_attr;
@@ -181,7 +181,7 @@ void init_report_output(const std::string &filename_str, int iterations)
 		if (period == std::string::npos)
 			period = filename_str.length();
 
-		stamp = time(NULL);
+		stamp = time(nullptr);
 		reportout.filename = std::format("{}-{}{}",
 			filename_str.substr(0, period),
 			get_time_string("%Y%m%d-%H%M%S", stamp),

--- a/src/tuning/bluetooth.cpp
+++ b/src/tuning/bluetooth.cpp
@@ -138,17 +138,17 @@ int bt_tunable::good_bad(void)
 
 
 	/* this check is expensive.. only do it once per minute */
-	if (time(NULL) - last_check_time > 60) {
+	if (time(nullptr) - last_check_time > 60) {
 		last_check_result = TUNE_BAD;
 		/* now, also check for active connections */
 		file = popen("/usr/bin/hcitool con 2> /dev/null", "r");
 		if (file) {
 			char line[2048];
 			/* first line is standard header */
-			if (fgets(line, 2047, file) == NULL)
+			if (fgets(line, 2047, file) == nullptr)
 				goto out;
 			memset(line, 0, 2048);
-			if (fgets(line, 2047, file) == NULL) {
+			if (fgets(line, 2047, file) == nullptr) {
 				result = last_check_result = TUNE_GOOD;
 				goto out;
 			}
@@ -158,7 +158,7 @@ int bt_tunable::good_bad(void)
 				goto out;
 			}
 		}
-		last_check_time = time(NULL);
+		last_check_time = time(nullptr);
 	};
 
 	result = last_check_result;

--- a/src/tuning/bluetooth.cpp
+++ b/src/tuning/bluetooth.cpp
@@ -28,7 +28,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <cstring>
 #include <utility>
 #include <iostream>
 #include <fstream>

--- a/src/tuning/bluetooth.cpp
+++ b/src/tuning/bluetooth.cpp
@@ -139,16 +139,17 @@ int bt_tunable::good_bad(void)
 
 	/* this check is expensive.. only do it once per minute */
 	if (time(nullptr) - last_check_time > 60) {
+		last_check_time = time(nullptr);
 		last_check_result = TUNE_BAD;
 		/* now, also check for active connections */
 		file = popen("/usr/bin/hcitool con 2> /dev/null", "r");
 		if (file) {
 			char line[2048];
 			/* first line is standard header */
-			if (fgets(line, 2047, file) == nullptr)
+			if (fgets(line, sizeof(line), file) == nullptr)
 				goto out;
-			memset(line, 0, 2048);
-			if (fgets(line, 2047, file) == nullptr) {
+			memset(line, 0, sizeof(line));
+			if (fgets(line, sizeof(line), file) == nullptr) {
 				result = last_check_result = TUNE_GOOD;
 				goto out;
 			}
@@ -158,7 +159,6 @@ int bt_tunable::good_bad(void)
 				goto out;
 			}
 		}
-		last_check_time = time(nullptr);
 	};
 
 	result = last_check_result;

--- a/src/tuning/bluetooth.h
+++ b/src/tuning/bluetooth.h
@@ -32,9 +32,9 @@ class bt_tunable : public tunable {
 public:
 	bt_tunable(void);
 
-	virtual int good_bad(void);
+	virtual int good_bad(void) override;
 
-	virtual void toggle(void);
+	virtual void toggle(void) override;
 
 };
 

--- a/src/tuning/ethernet.cpp
+++ b/src/tuning/ethernet.cpp
@@ -29,7 +29,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <cstring>
 #include <utility>
 #include <iostream>
 #include <fstream>

--- a/src/tuning/ethernet.h
+++ b/src/tuning/ethernet.h
@@ -33,9 +33,9 @@ public:
 	std::string interf;
 	ethernet_tunable(const std::string &iface);
 
-	virtual int good_bad(void);
+	virtual int good_bad(void) override;
 
-	virtual void toggle(void);
+	virtual void toggle(void) override;
 
 };
 

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -25,15 +25,11 @@
 
 #include "tuning.h"
 #include "tunable.h"
-#include "unistd.h"
 #include "runtime.h"
 #include <utility>
-#include <iostream>
-#include <fstream>
 #include <unistd.h>
 #include <sys/types.h>
 #include <dirent.h>
-#include <limits.h>
 #include <format>
 
 #include "../lib.h"

--- a/src/tuning/runtime.cpp
+++ b/src/tuning/runtime.cpp
@@ -27,7 +27,6 @@
 #include "tunable.h"
 #include "unistd.h"
 #include "runtime.h"
-#include <string.h>
 #include <utility>
 #include <iostream>
 #include <fstream>

--- a/src/tuning/runtime.h
+++ b/src/tuning/runtime.h
@@ -34,9 +34,9 @@ class runtime_tunable : public tunable {
 public:
 	runtime_tunable(const std::string &runtime_path, const std::string &bus, const std::string &dev, const std::string &port);
 
-	virtual int good_bad(void);
+	virtual int good_bad(void) override;
 
-	virtual void toggle(void);
+	virtual void toggle(void) override;
 
 };
 

--- a/src/tuning/tunable.cpp
+++ b/src/tuning/tunable.cpp
@@ -25,7 +25,6 @@
 
 #include "tuning.h"
 #include "tunable.h"
-#include <string.h>
 #include "../lib.h"
 
 std::vector<class tunable *> all_tunables;

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -82,7 +82,7 @@ void initialize_tuning(void)
 
 	init_tuning();
 
-	w->cursor_max = all_tunables.size() - 1;
+	w->cursor_max = all_tunables.empty() ? 0 : static_cast<int>(all_tunables.size()) - 1;
 
 	if (tune_window)
 		delete tune_window;

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -26,7 +26,6 @@
 #include <algorithm>
 
 #include <stdio.h>
-#include <string.h>
 #include <ncurses.h>
 
 

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -51,10 +51,10 @@ class tuning_window *tune_window;
 
 class tuning_window: public tab_window {
 public:
-	virtual void repaint(void);
-	virtual void cursor_enter(void);
-	virtual void expose(void);
-	virtual void window_refresh(void);
+	virtual void repaint(void) override;
+	virtual void cursor_enter(void) override;
+	virtual void expose(void) override;
+	virtual void window_refresh(void) override;
 };
 
 static void init_tuning(void)

--- a/src/tuning/tuningi2c.cpp
+++ b/src/tuning/tuningi2c.cpp
@@ -21,7 +21,6 @@
 #include "tunable.h"
 #include "unistd.h"
 #include "tuningi2c.h"
-#include <string.h>
 #include <dirent.h>
 #include <utility>
 #include <iostream>

--- a/src/tuning/tuningi2c.h
+++ b/src/tuning/tuningi2c.h
@@ -29,9 +29,9 @@ class i2c_tunable : public tunable {
 public:
 	i2c_tunable(const std::string &path, const std::string &name, bool is_adapter);
 
-	virtual int good_bad(void);
+	virtual int good_bad(void) override;
 
-	virtual void toggle(void);
+	virtual void toggle(void) override;
 
 };
 

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -27,7 +27,6 @@
 #include "tunable.h"
 #include <unistd.h>
 #include "tuningsysfs.h"
-#include <string.h>
 #include <dirent.h>
 #include <utility>
 #include <iostream>

--- a/src/tuning/tuningsysfs.cpp
+++ b/src/tuning/tuningsysfs.cpp
@@ -63,7 +63,7 @@ void sysfs_tunable::toggle(void)
 	good = good_bad();
 
 	if (good == TUNE_GOOD) {
-		if (bad_value.length() > 0)
+		if (!bad_value.empty())
 			write_sysfs(sysfs_path, bad_value);
 		return;
 	}

--- a/src/tuning/tuningsysfs.h
+++ b/src/tuning/tuningsysfs.h
@@ -36,9 +36,9 @@ class sysfs_tunable : public tunable {
 public:
 	sysfs_tunable(const std::string &str, const std::string &sysfs_path, const std::string &target_content);
 
-	virtual int good_bad(void);
+	virtual int good_bad(void) override;
 
-	virtual void toggle(void);
+	virtual void toggle(void) override;
 
 };
 

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -27,7 +27,6 @@
 #include "tunable.h"
 #include "unistd.h"
 #include "tuningusb.h"
-#include <string.h>
 #include <dirent.h>
 #include <utility>
 #include <iostream>

--- a/src/tuning/tuningusb.cpp
+++ b/src/tuning/tuningusb.cpp
@@ -111,16 +111,19 @@ static void add_usb_callback(const std::string &d_name)
 	filename = std::format("/sys/bus/usb/devices/{}", d_name);
 	if ((dir = opendir(filename.c_str()))) {
 		struct dirent *entry;
+		bool has_non_autosuspend = false;
 		while ((entry = readdir(dir))) {
 			/* dirname: <busnum>-<devnum>...:<config num>-<interface num> */
 			if (!isdigit(entry->d_name[0]))
 				continue;
 			filename = std::format("/sys/bus/usb/devices/{}/{}/supports_autosuspend", d_name, entry->d_name);
-			if (access(filename.c_str(), R_OK) == 0 && read_sysfs(filename) == 0)
+			if (access(filename.c_str(), R_OK) == 0 && read_sysfs(filename) == 0) {
+				has_non_autosuspend = true;
 				break;
+			}
 		}
 		closedir(dir);
-		if (entry)
+		if (has_non_autosuspend)
 			return;
 	}
 

--- a/src/tuning/tuningusb.h
+++ b/src/tuning/tuningusb.h
@@ -34,9 +34,9 @@ class usb_tunable : public tunable {
 public:
 	usb_tunable(const std::string &usb_path, const std::string &path);
 
-	virtual int good_bad(void);
+	virtual int good_bad(void) override;
 
-	virtual void toggle(void);
+	virtual void toggle(void) override;
 
 };
 

--- a/src/tuning/wifi.cpp
+++ b/src/tuning/wifi.cpp
@@ -25,7 +25,6 @@
 
 #include "tuning.h"
 #include "tunable.h"
-#include "unistd.h"
 #include "wifi.h"
 #include <utility>
 #include <iostream>

--- a/src/tuning/wifi.h
+++ b/src/tuning/wifi.h
@@ -35,9 +35,9 @@ class wifi_tunable : public tunable {
 public:
 	wifi_tunable(const std::string &_iface);
 
-	virtual int good_bad(void);
+	virtual int good_bad(void) override;
 
-	virtual void toggle(void);
+	virtual void toggle(void) override;
 
 };
 

--- a/src/wakeup/waketab.cpp
+++ b/src/wakeup/waketab.cpp
@@ -1,6 +1,5 @@
 #include <algorithm>
 #include <stdio.h>
-#include <string.h>
 #include <ncurses.h>
 #include "wakeup.h"
 #include <vector>

--- a/src/wakeup/waketab.cpp
+++ b/src/wakeup/waketab.cpp
@@ -19,10 +19,10 @@ class wakeup_window *newtab_window;
 
 class wakeup_window: public tab_window {
 public:
-	virtual void repaint(void);
-	virtual void cursor_enter(void);
-	virtual void expose(void);
-	virtual void window_refresh(void);
+	virtual void repaint(void) override;
+	virtual void cursor_enter(void) override;
+	virtual void expose(void) override;
+	virtual void window_refresh(void) override;
 };
 
 static void init_wakeup(void)

--- a/src/wakeup/wakeup.cpp
+++ b/src/wakeup/wakeup.cpp
@@ -34,17 +34,17 @@ std::vector<class wakeup *> wakeup_all;
 wakeup::wakeup(const std::string &str, double _score, const std::string &enable, const std::string &disable)
 {
 	score = _score;
-        desc = str;
-        wakeup_enable = enable;
-        wakeup_disable = disable;
+	desc = str;
+	wakeup_enable = enable;
+	wakeup_disable = disable;
 }
 
 wakeup::wakeup(void)
 {
 	score = 0;
-        desc = "";
-        wakeup_enable = _("Enabled");
-        wakeup_disable = _("Disabled");
+	desc = "";
+	wakeup_enable = _("Enabled");
+	wakeup_disable = _("Disabled");
 	wakeup_idle = _("Unknown");
 }
 

--- a/src/wakeup/wakeup.cpp
+++ b/src/wakeup/wakeup.cpp
@@ -23,7 +23,6 @@
  *      Gayatri Kammela <gayatri.kammela@intel.com>
  */
 
-#include <string.h>
 #include <ncurses.h>
 #include "wakeup.h"
 #include <vector>

--- a/src/wakeup/wakeup_ethernet.cpp
+++ b/src/wakeup/wakeup_ethernet.cpp
@@ -28,7 +28,6 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <utility>
 #include <iostream>
 #include <fstream>

--- a/src/wakeup/wakeup_ethernet.h
+++ b/src/wakeup/wakeup_ethernet.h
@@ -34,11 +34,11 @@ public:
 	std::string interf;
 	ethernet_wakeup(const std::string &eth_path, const std::string &iface);
 
-	virtual int wakeup_value(void);
+	virtual int wakeup_value(void) override;
 
-	virtual void wakeup_toggle(void);
+	virtual void wakeup_toggle(void) override;
 
-	virtual std::string wakeup_toggle_script(void);
+	virtual std::string wakeup_toggle_script(void) override;
 
 };
 

--- a/src/wakeup/wakeup_usb.cpp
+++ b/src/wakeup/wakeup_usb.cpp
@@ -28,7 +28,6 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <utility>
 #include <iostream>
 #include <fstream>

--- a/src/wakeup/wakeup_usb.h
+++ b/src/wakeup/wakeup_usb.h
@@ -34,11 +34,11 @@ public:
 	std::string interf;
 	usb_wakeup(const std::string &usb_path, const std::string &iface);
 
-	virtual int wakeup_value(void);
+	virtual int wakeup_value(void) override;
 
-	virtual void wakeup_toggle(void);
+	virtual void wakeup_toggle(void) override;
 
-	virtual std::string wakeup_toggle_script(void);
+	virtual std::string wakeup_toggle_script(void) override;
 
 };
 


### PR DESCRIPTION
Second round of code review fixes following PR #199.

## Summary of changes

This PR addresses medium severity findings from the deep code review, covering:

### Bug fixes
- `cpu.cpp`: Fix `core_num` never incremented — dead-code branch in `report_display_cpu_cstates`
- `rapl_interface.cpp`: Replace `atof()` with `std::stod()` with error handling for sysfs energy reads
- `rapl_interface.cpp`: Cache `energy_status_units` to avoid repeated MSR reads
- `gpu_rapl_device.cpp`: Guard `start/end_measurement` against invalid RAPL domain
- `runtime_pm.cpp`: Skip devices without runtime PM sysfs files in `do_bus()`
- `report-data-html.cpp`: Initialize `title_mod` in both `init_tune_table_attr` and `init_wakeup_table_attr`
- `cpu_linux.cpp`: Replace implicit dot/dotdot skip with explicit `entry->d_name[0] == '.'` check

### Code quality
- `usb.cpp`: Replace fixed-size `snprintf` buffer with `std::format`
- `ahci.cpp`: Remove dead zero-initializers for `cols` and `rows`
- `report-formatter-csv.h`: Remove undefined `add_quotes()` declaration and unused `text_start` member
- `timer.h`: Remove dead `timer_list` class
- `perf_bundle.cpp`: Fix diagnostic `printf` → `fprintf(stderr, _(...))`
- `persistent.cpp`, `abstract_cpu.cpp`: Redirect `cout` error output to `fprintf(stderr, ...)`
- `wakeup.cpp`: Fix space indentation in constructors
- All files: Replace `string.h` with `<cstring>` or remove where unused

### Include cleanup
- Remove duplicate and incorrectly-quoted includes across multiple files
- Remove unused `<iostream>`, `<fstream>`, `<limits.h>` includes