### PR TITLE
main: fix missing #include

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
  */
 #include <iostream>
 #include <fstream>
+#include <new>
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>


### PR DESCRIPTION
libcxx now provides a `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` flag. When used, `set_new_handler` was no longer implicitly included by the headers here.

(I tried to follow the description of `please post patches to the mailing list instead of using github pull requests`, but https://lists.01.org/hyperkitty/list/powertop@lists.01.org/ was down)