### PR TITLE
src: add missing <unistd.h> in lib.h and test_framework

### DIFF
--- a/src/lib.h
+++ b/src/lib.h
@@ -48,6 +48,7 @@ inline std::string pt_format(std::string_view fmt, Args&&... args)
 #include <libintl.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 /* Include only for Automake builds */
 #ifdef HAVE_CONFIG_H

--- a/src/test_framework.cpp
+++ b/src/test_framework.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <format>
 #include <cstdlib>
+#include <unistd.h>
 #include "test_framework.h"
 
 test_framework_manager& test_framework_manager::get() {
@@ -203,11 +204,11 @@ void test_framework_manager::record_access(const std::string& path, int mode, in
 }
 
 static std::string access_mode_str(int mode) {
-	if (mode == 0) return "F_OK";
+	if (mode == F_OK) return "F_OK";
 	std::string s;
-	if (mode & 4) s += "R_OK|";
-	if (mode & 2) s += "W_OK|";
-	if (mode & 1) s += "X_OK|";
+	if (mode & R_OK) s += "R_OK|";
+	if (mode & W_OK) s += "W_OK|";
+	if (mode & X_OK) s += "X_OK|";
 	if (!s.empty()) s.pop_back();
 	return s;
 }


### PR DESCRIPTION
Adding <unistd.h> to lib.h provides R_OK, W_OK, X_OK, and F_OK
macros globally, fixing build failures reported in issue #208.
Also updated test_framework.cpp to use these macros instead
of hardcoded integers.

Fixes: #208
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
